### PR TITLE
Merging in stm32h7x3-hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "stm32h7xx-hal"
 version = "0.1.0"
 authors = ["Andrew Straw <strawman@astraw.com>",
-           "Richard Meadows <richard@richard.fish>"]
+           "Richard Meadows <richard@richard.fish>",
+           "Henrik Böving <hargonix@gmail.com>"]
 edition = "2018"
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Peripheral access API for STM32H7 series microcontrollers"

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -3,11 +3,7 @@
 
 extern crate panic_itm;
 
-use stm32h7xx_hal::{
-    prelude::*,
-    pac,
-    i2c::I2c,
-};
+use stm32h7xx_hal::{i2c::I2c, pac, prelude::*};
 
 use cortex_m_rt::entry;
 
@@ -37,12 +33,7 @@ fn main() -> ! {
     let scl = gpiob.pb8.into_alternate_af4().set_open_drain();
     let sda = gpiob.pb9.into_alternate_af4().set_open_drain();
 
-    let mut i2c = I2c::i2c1(
-        dp.I2C1,
-        (scl, sda),
-        100.khz(),
-        &ccdr
-    );
+    let mut i2c = I2c::i2c1(dp.I2C1, (scl, sda), 100.khz(), &ccdr);
 
     // Echo what is received on the I2C at register 0x11 and addr 0x10
     // It is expected to get 2 bytes as response here

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -1,0 +1,54 @@
+#![no_main]
+#![no_std]
+
+extern crate panic_itm;
+
+use stm32h7xx_hal::{
+    prelude::*,
+    pac,
+    i2c::I2c,
+};
+
+use cortex_m_rt::entry;
+
+use cortex_m_log::println;
+use cortex_m_log::{
+    destination::Itm, printer::itm::InterruptSync as InterruptSyncItm,
+};
+
+#[entry]
+fn main() -> ! {
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+    let mut log = InterruptSyncItm::new(Itm::new(cp.ITM));
+
+    // Constrain and Freeze power
+    println!(log, "Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let vos = pwr.freeze();
+
+    // Constrain and Freeze clock
+    println!(log, "Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let mut ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
+    let gpiob = dp.GPIOB.split(&mut ccdr.ahb4);
+
+    // Configure the SCL and the SDA pin for our I2C bus
+    let scl = gpiob.pb8.into_alternate_af4().set_open_drain();
+    let sda = gpiob.pb9.into_alternate_af4().set_open_drain();
+
+    let mut i2c = I2c::i2c1(
+        dp.I2C1,
+        (scl, sda),
+        100.khz(),
+        &ccdr
+    );
+
+    // Echo what is received on the I2C at register 0x11 and addr 0x10
+    // It is expected to get 2 bytes as response here
+    let mut buf = [0x11, 0x0];
+    loop {
+        buf[0] = 0x11;
+        i2c.write_read(0x10, &buf.clone(), &mut buf).ok();
+    }
+}

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -3,11 +3,7 @@
 
 extern crate panic_itm;
 
-use stm32h7xx_hal::{
-    prelude::*,
-    pac,
-    watchdog::SystemWindowWatchdog,
-};
+use stm32h7xx_hal::{pac, prelude::*, watchdog::SystemWindowWatchdog};
 
 use cortex_m_rt::entry;
 
@@ -15,7 +11,6 @@ use cortex_m_log::println;
 use cortex_m_log::{
     destination::Itm, printer::itm::InterruptSync as InterruptSyncItm,
 };
-
 
 #[entry]
 fn main() -> ! {
@@ -33,10 +28,7 @@ fn main() -> ! {
     let rcc = dp.RCC.constrain();
     let ccdr = rcc.sys_ck(96.mhz()).freeze(vos, &dp.SYSCFG);
 
-    let mut watchdog = SystemWindowWatchdog::new(
-        dp.WWDG,
-        &ccdr
-    );
+    let mut watchdog = SystemWindowWatchdog::new(dp.WWDG, &ccdr);
 
     println!(log, "");
     println!(log, "stm32h7xx-hal example - Watchdog");
@@ -48,8 +40,7 @@ fn main() -> ! {
 
     // Enable the watchdog with a limit of 100 ms and wait forever
     // -> restart the chip
-    watchdog.start(100u32);
+    watchdog.start(100.ms());
 
     loop {}
-
 }

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -1,0 +1,55 @@
+#![no_main]
+#![no_std]
+
+extern crate panic_itm;
+
+use stm32h7xx_hal::{
+    prelude::*,
+    pac,
+    watchdog::SystemWindowWatchdog,
+};
+
+use cortex_m_rt::entry;
+
+use cortex_m_log::println;
+use cortex_m_log::{
+    destination::Itm, printer::itm::InterruptSync as InterruptSyncItm,
+};
+
+
+#[entry]
+fn main() -> ! {
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+    let mut log = InterruptSyncItm::new(Itm::new(cp.ITM));
+
+    // Constrain and Freeze power
+    println!(log, "Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let vos = pwr.freeze();
+
+    // Constrain and Freeze clock
+    println!(log, "Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(96.mhz()).freeze(vos, &dp.SYSCFG);
+
+    let mut watchdog = SystemWindowWatchdog::new(
+        dp.WWDG,
+        &ccdr
+    );
+
+    println!(log, "");
+    println!(log, "stm32h7xx-hal example - Watchdog");
+    println!(log, "");
+
+    // If the watchdog is working correctly this print should
+    // appear again and again as the chip gets restarted
+    println!(log, "Watchdog restarted!           ");
+
+    // Enable the watchdog with a limit of 100 ms and wait forever
+    // -> restart the chip
+    watchdog.start(100u32);
+
+    loop {}
+
+}

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -226,22 +226,22 @@ macro_rules! gpio {
                 fn make_interrupt_source(&mut self, syscfg: &mut SYSCFG) {
                     let offset = 4 * (self.i % 4);
                     match self.i {
-                        0...3 => {
+                        0..=3 => {
                             syscfg.exticr1.modify(|r, w| unsafe {
                                 w.bits((r.bits() & !(0xf << offset)) | ($extigpionr << offset))
                             });
                         },
-                        4...7 => {
+                        4..=7 => {
                             syscfg.exticr2.modify(|r, w| unsafe {
                                 w.bits((r.bits() & !(0xf << offset)) | ($extigpionr << offset))
                             });
                         },
-                        8...11 => {
+                        8..=11 => {
                             syscfg.exticr3.modify(|r, w| unsafe {
                                 w.bits((r.bits() & !(0xf << offset)) | ($extigpionr << offset))
                             });
                         },
-                        12...15 => {
+                        12..=15 => {
                             syscfg.exticr4.modify(|r, w| unsafe {
                                 w.bits((r.bits() & !(0xf << offset)) | ($extigpionr << offset))
                             });

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,0 +1,398 @@
+//! Inter Integrated Circuit implementation
+
+use crate::gpio::gpioa::PA8;
+use crate::gpio::gpiob::{PB10, PB11, PB6, PB7, PB8, PB9};
+use crate::gpio::gpioc::PC9;
+use crate::gpio::gpiod::{PD12, PD13};
+use crate::gpio::gpiof::{PF0, PF1, PF14, PF15};
+use crate::gpio::gpioh::{PH11, PH12, PH4, PH5, PH7, PH8};
+use crate::gpio::{Alternate, AF4};
+use crate::rcc::Ccdr;
+use crate::time::Hertz;
+use crate::hal::blocking::i2c::{Write, WriteRead, Read};
+use crate::stm32::{I2C1, I2C2, I2C3, I2C4};
+use cast::{u8, u16};
+
+
+/// I2C error
+#[derive(Debug)]
+pub enum Error {
+    /// Bus error
+    Bus,
+    /// Arbitration loss
+    Arbitration,
+    // Overrun, // slave mode only
+    // Pec, // SMBUS mode only
+    // Timeout, // SMBUS mode only
+    // Alert, // SMBUS mode only
+    #[doc(hidden)]
+    _Extensible,
+}
+
+/// A trait to represent the SCL Pin of an I2C Port
+pub unsafe trait PinScl<I2C> {}
+
+/// A trait to represent the SDL Pin of an I2C Port
+pub unsafe trait PinSda<I2C> {}
+
+pub struct I2c<I2C, PINS> {
+    i2c: I2C,
+    pins: PINS,
+}
+
+macro_rules! busy_wait {
+    ($i2c:expr, $flag:ident) => {
+        loop {
+            let isr = $i2c.isr.read();
+
+            if isr.berr().bit_is_set() {
+                return Err(Error::Bus);
+            } else if isr.arlo().bit_is_set() {
+                return Err(Error::Arbitration);
+            } else if isr.$flag().bit_is_set() {
+                break;
+            } else {
+                // try again
+            }
+        }
+    };
+}
+
+macro_rules! i2c {
+    ($($I2CX:ident: ($i2cX:ident, $i2cXen:ident, $i2cXrst:ident, $apbXenr:ident, $apbXrstr:ident, $pclkX:ident),)+) => {
+        $(
+            impl<SCL, SDA> I2c<$I2CX, (SCL, SDA)> {
+                /// Basically a new function for an I2C peripheral
+                pub fn $i2cX<F> (
+                    i2c: $I2CX,
+                    pins: (SCL, SDA),
+                    freq: F,
+                    ccdr: &Ccdr
+                ) -> Self where
+                    F: Into<Hertz>,
+                    SCL: PinScl<$I2CX>,
+                    SDA: PinSda<$I2CX>,
+                {
+                    ccdr.rb.$apbXenr.modify(|_, w| w.$i2cXen().set_bit());
+                    ccdr.rb.$apbXrstr.modify(|_, w| w.$i2cXrst().clear_bit());
+                    ccdr.rb.$apbXrstr.modify(|_, w| w.$i2cXrst().set_bit());
+
+                    let freq = freq.into().0;
+
+                    assert!(freq <= 1_000_000);
+
+                    let i2cclk = ccdr.clocks.$pclkX().0;    
+
+                    // Refer to figure 539 for this:
+                    // Clear PE bit in I2C_CR1
+                    unsafe { &(*I2C1::ptr()).cr1.modify(|_, w| w.pe().clear_bit())};
+
+                    // Enable the Analog Noise Filter by setting ANFOFF (Analog Noise Filter OFF) to 0
+                    // This is usually enabled by default but you never know
+                    unsafe { &(*I2C1::ptr()).cr1.modify(|_, w| w.anfoff().clear_bit())};
+
+                    // TODO review compliance with the timing requirements of I2C
+                    // t_I2CCLK = 1 / PCLK1
+                    // t_PRESC  = (PRESC + 1) * t_I2CCLK
+                    // t_SCLL   = (SCLL + 1) * t_PRESC
+                    // t_SCLH   = (SCLH + 1) * t_PRESC
+                    //
+                    // t_SYNC1 + t_SYNC2 > 4 * t_I2CCLK
+                    // t_SCL ~= t_SYNC1 + t_SYNC2 + t_SCLL + t_SCLH
+                    let ratio = i2cclk / freq - 4;
+                    let (presc, scll, sclh, sdadel, scldel) = if freq > 100_000 {
+                        // fast-mode or fast-mode plus
+                        // here we pick SCLL + 1 = 2 * (SCLH + 1)
+                        let presc = ratio / 387;
+
+                        let sclh = ((ratio / (presc + 1)) - 3) / 3;
+                        let scll = 2 * (sclh + 1) - 1;
+
+                        let (sdadel, scldel) = if freq > 400_000 {
+                            // fast-mode plus
+                            let sdadel = 0;
+                            let scldel = i2cclk / 4_000_000 / (presc + 1) - 1;
+
+                            (sdadel, scldel)
+                        } else {
+                            // fast-mode
+                            let sdadel = i2cclk / 8_000_000 / (presc + 1);
+                            let scldel = i2cclk / 2_000_000 / (presc + 1) - 1;
+
+                            (sdadel, scldel)
+                        };
+
+                        (presc, scll, sclh, sdadel, scldel)
+                    } else {
+                        // standard-mode
+                        // here we pick SCLL = SCLH
+                        let presc = ratio / 514;
+                        let sclh = ((ratio / (presc + 1)) - 2) / 2;
+                        let scll = sclh;
+
+                        let sdadel = i2cclk / 2_000_000 / (presc + 1);
+                        let scldel = i2cclk / 800_000 / (presc + 1) - 1;
+
+                        (presc, scll, sclh, sdadel, scldel)
+                    };
+
+                    let presc = u8(presc).unwrap();
+                    //assert!(presc < 16);
+                    let scldel = u8(scldel).unwrap();
+                    //assert!(scldel < 16);
+                    let sdadel = u8(sdadel).unwrap();
+                    //assert!(sdadel < 16);
+                    let sclh = u8(sclh).unwrap();
+                    let scll = u8(scll).unwrap();
+
+                    // Configure for "fast mode" (400 KHz)
+                    i2c.timingr.write(|w| 
+                        w.presc()
+                            .bits(presc)
+                            .scll()
+                            .bits(scll)
+                            .sclh()
+                            .bits(sclh)
+                            .sdadel()
+                            .bits(sdadel)
+                            .scldel()
+                            .bits(scldel)
+                    );
+
+                    // Enable the peripheral
+                    i2c.cr1.write(|w| w.pe().set_bit());
+
+                    I2c { i2c, pins}
+
+                }
+                
+                /// Releases the I2C peripheral and associated pins
+                pub fn free(self) -> ($I2CX, (SCL, SDA)) {
+                    (self.i2c, self.pins)
+                }
+            }
+            impl<PINS> Write for I2c<$I2CX, PINS> {
+                type Error = Error;
+
+                fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
+                    // TODO support transfers of more than 255 bytes
+                    assert!(bytes.len() < 256 && bytes.len() > 0);
+
+                    // START and prepare to send `bytes`
+                    self.i2c.cr2.write(|w| {
+                        w.start()
+                            .set_bit()
+                            .sadd()
+                            .bits(u16(addr << 1 | 0))
+                            .add10().clear_bit()
+                            .rd_wrn()
+                            .clear_bit()
+                            .nbytes()
+                            .bits(bytes.len() as u8)
+                            .autoend()
+                            .set_bit()
+                    });
+
+                    for byte in bytes {
+                        // Wait until we are allowed to send data (START has been ACKed or last byte
+                        // when through)
+                        busy_wait!(self.i2c, txis);
+
+                        // put byte on the wire
+                        self.i2c.txdr.write(|w| w.txdata().bits(*byte));
+                    }
+                    // automatic STOP
+
+                    Ok(())
+                }
+            }
+
+            impl<PINS> WriteRead for I2c<$I2CX, PINS> {
+                type Error = Error;
+
+                fn write_read(
+                    &mut self,
+                    addr: u8,
+                    bytes: &[u8],
+                    buffer: &mut [u8],
+                ) -> Result<(), Error> {
+                    // TODO support transfers of more than 255 bytes
+                    assert!(bytes.len() < 256 && bytes.len() > 0);
+                    assert!(buffer.len() < 256 && buffer.len() > 0);
+
+                    // TODO do we have to explicitly wait here if the bus is busy (e.g. another
+                    // master is communicating)?
+
+                    // START and prepare to send `bytes`
+                    self.i2c.cr2.write(|w| {
+                        w.start()
+                            .set_bit()
+                            .sadd()
+                            .bits(u16(addr << 1 | 0))
+                            .add10().clear_bit()
+                            .rd_wrn()
+                            .clear_bit()
+                            .nbytes()
+                            .bits(bytes.len() as u8)
+                            .autoend()
+                            .clear_bit()
+
+                    });
+                    //busy_wait!(self.i2c, addr);
+                    for byte in bytes {
+                        // Wait until we are allowed to send data (START has been ACKed or last byte
+                        // when through)
+                        // put byte on the wire
+                        busy_wait!(self.i2c, txis);
+                        self.i2c.txdr.write(|w| w.txdata().bits(*byte));
+                        
+                    }
+
+                    // Wait until the last transmission is finished
+                    busy_wait!(self.i2c, tc);
+
+                    // reSTART and prepare to receive bytes into `buffer`
+                    self.i2c.cr2.write(|w| {
+                        w.sadd()
+                            .bits(u16(addr << 1 | 1))
+                            .add10().clear_bit()
+                            .rd_wrn()
+                            .set_bit()
+                            .nbytes()
+                            .bits(buffer.len() as u8)
+                            .start()
+                            .set_bit()
+                            .autoend()
+                            .set_bit()
+                    });
+
+                    for byte in buffer {
+                        // Wait until we have received something
+                        busy_wait!(self.i2c, rxne);
+
+                        *byte = self.i2c.rxdr.read().rxdata().bits();
+                    }
+
+                    // automatic STOP
+
+                    Ok(())
+                }
+            }
+
+            impl<PINS> Read for I2c<$I2CX, PINS> {
+            type Error = Error;
+
+            fn read(
+                &mut self,
+                addr: u8,
+                buffer: &mut [u8],
+            ) -> Result<(), Error> {
+                // TODO support transfers of more than 255 bytes
+                assert!(buffer.len() < 256 && buffer.len() > 0);
+
+                // TODO do we have to explicitly wait here if the bus is busy (e.g. another
+                // master is communicating)?
+
+                // reSTART and prepare to receive bytes into `buffer`
+                self.i2c.cr2.write(|w| {
+                    w.sadd()
+                        .bits((addr << 1 | 0) as u16)
+                        .rd_wrn()
+                        .set_bit()
+                        .nbytes()
+                        .bits(buffer.len() as u8)
+                        .start()
+                        .set_bit()
+                        .autoend()
+                        .set_bit()
+                });
+
+                for byte in buffer {
+                    // Wait until we have received something
+                    busy_wait!(self.i2c, rxne);
+
+                    *byte = self.i2c.rxdr.read().rxdata().bits();
+                }
+
+                // automatic STOP
+
+                Ok(())
+            }
+            }
+        )+
+    };
+}
+
+macro_rules! pins {
+    ($($I2CX:ty: SCL: [$($SCL:ty),*] SDA: [$($SDA:ty),*])+) => {
+        $(
+            $(
+                unsafe impl PinScl<$I2CX> for $SCL {}
+            )*
+            $(
+                unsafe impl PinSda<$I2CX> for $SDA {}
+            )*
+        )+
+    }
+}
+
+pins! {
+    I2C1: 
+        SCL: [
+            PB6<Alternate<AF4>>,
+            PB8<Alternate<AF4>>
+        ]
+
+        SDA: [
+            PB7<Alternate<AF4>>,
+            PB9<Alternate<AF4>>
+        ]
+    
+    I2C2:
+        SCL: [
+            PB10<Alternate<AF4>>,
+            PF1<Alternate<AF4>>,
+            PH4<Alternate<AF4>>
+        ]
+
+        SDA: [
+            PB11<Alternate<AF4>>,
+            PF0<Alternate<AF4>>,
+            PH5<Alternate<AF4>>
+        ]
+
+    I2C3:
+        SCL: [
+            PA8<Alternate<AF4>>,
+            PH7<Alternate<AF4>>
+        ]
+
+        SDA: [
+            PC9<Alternate<AF4>>,
+            PH8<Alternate<AF4>>
+        ]
+    
+    I2C4:
+        SCL: [
+            PD12<Alternate<AF4>>,
+            PF14<Alternate<AF4>>,
+            PH11<Alternate<AF4>>,
+            PB6<Alternate<AF4>>,
+            PB8<Alternate<AF4>>
+        ]
+
+        SDA: [
+            PB7<Alternate<AF4>>,
+            PB9<Alternate<AF4>>,
+            PD13<Alternate<AF4>>,
+            PF15<Alternate<AF4>>,
+            PH12<Alternate<AF4>>
+        ]
+}
+
+i2c!(
+    I2C1: (i2c1, i2c1en, i2c1rst, apb1lenr, apb1lrstr, pclk1),
+    I2C2: (i2c2, i2c2en, i2c2rst, apb1lenr, apb1lrstr, pclk1),
+    I2C3: (i2c3, i2c3en, i2c3rst, apb1lenr, apb1lrstr, pclk1),
+    I2C4: (i2c4, i2c4en, i2c4rst, apb4enr, apb4rstr, pclk4),
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ pub mod flash;
 #[cfg(feature = "device-selected")]
 pub mod gpio;
 #[cfg(feature = "device-selected")]
+pub mod i2c;
+#[cfg(feature = "device-selected")]
 pub mod prelude;
 #[cfg(feature = "device-selected")]
 pub mod pwr;
@@ -59,7 +61,5 @@ pub mod spi;
 pub mod time;
 #[cfg(feature = "device-selected")]
 pub mod timer;
-#[cfg(feature = "device-selected")]
-pub mod i2c;
 #[cfg(feature = "device-selected")]
 pub mod watchdog;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,3 +59,7 @@ pub mod spi;
 pub mod time;
 #[cfg(feature = "device-selected")]
 pub mod timer;
+#[cfg(feature = "device-selected")]
+pub mod i2c;
+#[cfg(feature = "device-selected")]
+pub mod watchdog;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,8 +1,8 @@
 //! Prelude
 pub use embedded_hal::prelude::*;
 
-pub use crate::flash::FlashExt as _stm32h7xx_hal_flash_FlashExt;
 pub use crate::delay::DelayExt as _stm32h7xx_hal_delay_DelayExt;
+pub use crate::flash::FlashExt as _stm32h7xx_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32h7xx_hal_gpio_GpioExt;
 pub use crate::pwr::PwrExt as _stm32h7xx_hal_pwr_PwrExt;
 pub use crate::rcc::RccExt as _stm32h7xx_hal_rcc_RccExt;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -492,14 +492,12 @@ impl Rcc {
         let csi = CSI;
 
         // per_ck from HSI by default
-        let (per_ck, ckpersel) = match (
-            self.config.per_ck == self.config.hse,
-            self.config.per_ck,
-        ) {
-            (true, Some(hse)) => (hse, CKPERSELW::HSE), // HSE
-            (_, Some(CSI)) => (csi, CKPERSELW::CSI),    // CSI
-            _ => (hsi, CKPERSELW::HSI),                 // HSI
-        };
+        let (per_ck, ckpersel) =
+            match (self.config.per_ck == self.config.hse, self.config.per_ck) {
+                (true, Some(hse)) => (hse, CKPERSELW::HSE), // HSE
+                (_, Some(CSI)) => (csi, CKPERSELW::CSI),    // CSI
+                _ => (hsi, CKPERSELW::HSI),                 // HSI
+            };
 
         // D1 Core Prescaler
         // Set to 1
@@ -568,9 +566,7 @@ impl Rcc {
         let hse_ck = match self.config.hse {
             Some(hse) => {
                 // Ensure HSE is on and stable
-                rcc.cr.modify(|_, w| {
-                    w.hseon().on().hsebyp().not_bypassed()
-                });
+                rcc.cr.modify(|_, w| w.hseon().on().hsebyp().not_bypassed());
                 while rcc.cr.read().hserdy().is_not_ready() {}
 
                 Some(Hertz(hse))
@@ -616,12 +612,11 @@ impl Rcc {
         rcc.d1ccipr.modify(|_, w| w.ckpersel().variant(ckpersel));
 
         // Select system clock source
-        let swbits =
-            match (pll1_p_ck.is_some(), self.config.hse.is_some()) {
-                (true, _) => SWW::PLL1 as u8,
-                (false, true) => SWW::HSE as u8,
-                _ => SWW::HSI as u8,
-            };
+        let swbits = match (pll1_p_ck.is_some(), self.config.hse.is_some()) {
+            (true, _) => SWW::PLL1 as u8,
+            (false, true) => SWW::HSE as u8,
+            _ => SWW::HSI as u8,
+        };
         rcc.cfgr.modify(|_, w| unsafe { w.sw().bits(swbits) });
         while rcc.cfgr.read().sws().bits() != swbits {}
 

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -77,6 +77,8 @@ pub struct Ccdr {
     pub apb1: APB1,
     /// Advanced Peripheral Bus 2 (APB2) registers
     pub apb2: APB2,
+    /// Advanced Peripheral Bus 3 (APB3) registers
+    pub apb3: APB3,
     /// Advanced Peripheral Bus 4 (APB4) registers
     pub apb4: APB4,
     // Yes, it lives (locally)! We retain the right to switch most
@@ -161,6 +163,25 @@ impl APB2 {
     pub(crate) fn rstr(&mut self) -> &rcc::APB2RSTR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).apb2rstr }
+    }
+}
+
+/// Advanced Peripheral Bus 3 (APB3) peripheral registers
+pub struct APB3 {
+    _0: (),
+}
+
+impl APB3 {
+    #[allow(unused)]
+    pub(crate) fn enr(&mut self) -> &rcc::APB3ENR {
+        // NOTE(unsafe) this proxy grants exclusive access to this register
+        unsafe { &(*RCC::ptr()).apb3enr }
+    }
+
+    #[allow(unused)]
+    pub(crate) fn rstr(&mut self) -> &rcc::APB3RSTR {
+        // NOTE(unsafe) this proxy grants exclusive access to this register
+        unsafe { &(*RCC::ptr()).apb3rstr }
     }
 }
 
@@ -289,8 +310,8 @@ macro_rules! ppre_calculate {
                 0 => unreachable!(),
                 1 => (0b000, 1 as u8),
                 2 => (0b100, 2),
-                3...5 => (0b101, 4),
-                6...11 => (0b110, 8),
+                3..=5 => (0b101, 4),
+                6..=11 => (0b110, 8),
                 _ => (0b111, 16),
             };
 
@@ -412,29 +433,29 @@ impl Rcc {
         let (wait_states, progr_delay) = match vos {
             // VOS 1 range VCORE 1.15V - 1.26V
             Voltage::Scale0 | Voltage::Scale1 => match rcc_aclk_mhz {
-                0...69 => (0, 0),
-                70...139 => (1, 1),
-                140...184 => (2, 1),
-                185...209 => (2, 2),
-                210...224 => (3, 2),
+                0..=69 => (0, 0),
+                70..=139 => (1, 1),
+                140..=184 => (2, 1),
+                185..=209 => (2, 2),
+                210..=224 => (3, 2),
                 _ => (7, 3),
             },
             // VOS 2 range VCORE 1.05V - 1.15V
             Voltage::Scale2 => match rcc_aclk_mhz {
-                0...54 => (0, 0),
-                55...109 => (1, 1),
-                110...164 => (2, 1),
-                165...224 => (3, 2),
+                0..=54 => (0, 0),
+                55..=109 => (1, 1),
+                110..=164 => (2, 1),
+                165..=224 => (3, 2),
                 225 => (4, 2),
                 _ => (7, 3),
             },
             // VOS 3 range VCORE 0.95V - 1.05V
             Voltage::Scale3 => match rcc_aclk_mhz {
-                0...44 => (0, 0),
-                45...89 => (1, 1),
-                90...134 => (2, 1),
-                135...179 => (3, 2),
-                180...224 => (4, 2),
+                0..=44 => (0, 0),
+                45..=89 => (1, 1),
+                90..=134 => (2, 1),
+                135..=179 => (3, 2),
+                180..=224 => (4, 2),
                 _ => (7, 3),
             },
             _ => (7, 3),
@@ -515,12 +536,12 @@ impl Rcc {
                 0 => unreachable!(),
                 1 => (HPREW::DIV1, 1),
                 2 => (HPREW::DIV2, 2),
-                3...5 => (HPREW::DIV4, 4),
-                6...11 => (HPREW::DIV8, 8),
-                12...39 => (HPREW::DIV16, 16),
-                40...95 => (HPREW::DIV64, 64),
-                96...191 => (HPREW::DIV128, 128),
-                192...383 => (HPREW::DIV256, 256),
+                3..=5 => (HPREW::DIV4, 4),
+                6..=11 => (HPREW::DIV8, 8),
+                12..=39 => (HPREW::DIV16, 16),
+                40..=95 => (HPREW::DIV64, 64),
+                96..=191 => (HPREW::DIV128, 128),
+                192..=383 => (HPREW::DIV256, 256),
                 _ => (HPREW::DIV512, 512),
             };
 
@@ -621,6 +642,7 @@ impl Rcc {
             ahb4: AHB4 { _0: () },
             apb1: APB1 { _0: () },
             apb2: APB2 { _0: () },
+            apb3: APB3 { _0: () },
             apb4: APB4 { _0: () },
             clocks: CoreClocks {
                 hclk: Hertz(rcc_hclk),

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -726,8 +726,7 @@ where
     Tx<USART>: serial::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        let _ =
-            s.as_bytes().iter().map(|c| block!(self.write(*c))).last();
+        let _ = s.as_bytes().iter().map(|c| block!(self.write(*c))).last();
         Ok(())
     }
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -276,13 +276,13 @@ macro_rules! spi {
                     };
                     let mbr = match spi_ker_ck / spi_freq {
                         0 => unreachable!(),
-                        1...2 => MBRW::DIV2,
-                        3...5 => MBRW::DIV4,
-                        6...11 => MBRW::DIV8,
-                        12...23 => MBRW::DIV16,
-                        24...47 => MBRW::DIV32,
-                        48...95 => MBRW::DIV64,
-                        96...191 => MBRW::DIV128,
+                        1..=2 => MBRW::DIV2,
+                        3..=5 => MBRW::DIV4,
+                        6..=11 => MBRW::DIV8,
+                        12..=23 => MBRW::DIV16,
+                        24..=47 => MBRW::DIV32,
+                        48..=95 => MBRW::DIV64,
+                        96..=191 => MBRW::DIV128,
                         _ => MBRW::DIV256,
                     };
                     spi.cfg1.modify(|_, w| {

--- a/src/time.rs
+++ b/src/time.rs
@@ -2,8 +2,6 @@
 
 use cortex_m::peripheral::DWT;
 
-// use crate::rcc::Clocks;
-
 /// Bits per second
 #[derive(Clone, Copy)]
 pub struct Bps(pub u32);

--- a/src/time.rs
+++ b/src/time.rs
@@ -18,6 +18,10 @@ pub struct KiloHertz(pub u32);
 #[derive(Clone, Copy)]
 pub struct MegaHertz(pub u32);
 
+/// MilliSeconds
+#[derive(PartialEq, PartialOrd, Clone, Copy)]
+pub struct MilliSeconds(pub u32);
+
 /// Extension trait that adds convenience methods to the `u32` type
 pub trait U32Ext {
     /// Wrap in `Bps`
@@ -31,6 +35,9 @@ pub trait U32Ext {
 
     /// Wrap in `MegaHertz`
     fn mhz(self) -> MegaHertz;
+
+    /// Wrap in "MilliSeconds"
+    fn ms(self) -> MilliSeconds;
 }
 
 impl U32Ext for u32 {
@@ -48,6 +55,10 @@ impl U32Ext for u32 {
 
     fn mhz(self) -> MegaHertz {
         MegaHertz(self)
+    }
+
+    fn ms(self) -> MilliSeconds {
+        MilliSeconds(self)
     }
 }
 

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,0 +1,82 @@
+//! System Window Watchdog implementation
+
+use crate::rcc::Ccdr;
+use crate::time::Hertz;
+use cast::u8;
+use crate::hal::watchdog::{Watchdog, WatchdogEnable};
+use stm32h7::stm32h7x3::WWDG;
+
+/// Implements the System Window Watchdog
+pub struct SystemWindowWatchdog {
+    wwdg: WWDG,
+    down_counter: u8,
+    pclk3_frequency: Hertz,
+}
+
+impl SystemWindowWatchdog {
+    /// Returns a System Window Watchdog object with down_counter intialized to zero
+    /// to indicate the clock has not been used yet
+    pub fn new(wwdg: WWDG, ccdr: &Ccdr) -> Self {
+        // enable the peripheral inside the APB3
+        ccdr.rb.apb3enr.modify(|_, w| w.wwdg1en().set_bit());
+        SystemWindowWatchdog {
+            wwdg,
+            down_counter: 0,
+            pclk3_frequency: ccdr.clocks.pclk3(),
+        }
+    }
+}
+
+impl Watchdog for SystemWindowWatchdog {
+    /// Feeds the watchdog in order to avoid a reset, only executes properly if the watchdog
+    /// has already been started aka. the down_counter is not 0 anymore
+    fn feed(&mut self) {
+        // if this value is 0 it is assumed that the watchdog has not yet been started
+        assert!(self.down_counter != 0);
+        self.wwdg.cr.modify(|_, w| w.t().bits(self.down_counter));
+    }
+}
+
+impl WatchdogEnable for SystemWindowWatchdog {
+    type Time = u32;
+    /// Starts the watchdog with a given timeout period, if this period is out of bounds the function
+    /// is going to panic
+    fn start<T>(&mut self, period: T)
+    where
+        T: Into<Self::Time>,
+    {
+        let period = period.into();
+        let maximum =
+            (4096 * 2u32.pow(7) * 64) / (self.pclk3_frequency.0 / 1000);
+        assert!(period <= maximum);
+
+        // cant approximate this at compile time as the apb clock frequency is not known at compile time
+        // TODO: find a better way for this
+        let mut best_config: (u32, u32) = (0, 0);
+        let mut closest: u32 = 33334;
+        for wdgtb in 0..8 {
+            for t in 1..64 {
+                // timeout = pclk * 4096 * 2^WDGTB[2:0] * (t[5:0] +1)
+                let current_timeout = (4096 * (1 << wdgtb) * (t + 1))
+                    / (self.pclk3_frequency.0 / 1000);
+                if period > current_timeout {
+                    let difference = period - current_timeout;
+                    if difference < closest {
+                        closest = difference;
+                        best_config = (wdgtb, t);
+                    }
+                }
+            }
+        }
+
+        let wdgtb = u8(best_config.0).unwrap();
+        self.down_counter = u8(best_config.1).unwrap() | (1 << 6);
+
+        // write the config values, matching the set timeout the most
+        self.wwdg.cfr.modify(|_, w| w.wdgtb().bits(wdgtb));
+        self.wwdg.cfr.modify(|_, w| w.w().bits(self.down_counter));
+        self.wwdg.cr.modify(|_, w| w.t().bits(self.down_counter));
+        // enable the watchdog
+        self.wwdg.cr.modify(|_, w| w.wdga().set_bit());
+    }
+}


### PR DESCRIPTION
This PR merges in the stm32h7x3-hal project, bringing:
* An I2C implementation
* A Watchdog implementation
* Examples for both of them

Furthermore it adds myself as an author and replaces all the `...` inclusive range syntax with `..=` syntax instead as the first one has been deprecated.

Me and a friend of mine are currently also working on an ADC implementation, still for our version of the HAL so maybe it would be better to wait until we are done with it, ported it over and continue our work over at this version of the HAL.