### PR TITLE
timers, bugfix: fix periodic CountDown timer

### DIFF
--- a/examples/blinky_timer.rs
+++ b/examples/blinky_timer.rs
@@ -1,0 +1,66 @@
+#![deny(warnings)]
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+extern crate panic_itm;
+
+#[macro_use(block)]
+extern crate nb;
+
+use cortex_m;
+use cortex_m_rt::entry;
+use stm32h7xx_hal::hal::digital::v2::{OutputPin, ToggleableOutputPin};
+use stm32h7xx_hal::{pac, prelude::*};
+
+use cortex_m_log::println;
+use cortex_m_log::{
+    destination::Itm, printer::itm::InterruptSync as InterruptSyncItm,
+};
+
+#[entry]
+fn main() -> ! {
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+    let mut log = InterruptSyncItm::new(Itm::new(cp.ITM));
+
+    // Constrain and Freeze power
+    println!(log, "Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let vos = pwr.freeze();
+
+    // Constrain and Freeze clock
+    println!(log, "Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let mut ccdr = rcc.freeze(vos, &dp.SYSCFG);
+
+    println!(log, "");
+    println!(log, "stm32h7xx-hal example - Blinky timer");
+    println!(log, "");
+
+    let gpioe = dp.GPIOE.split(&mut ccdr.ahb4);
+
+    // Configure PE1 as output.
+    let mut led = gpioe.pe1.into_push_pull_output();
+    led.set_low().unwrap();
+
+    // Get the delay provider.
+    let mut delay = cp.SYST.delay(ccdr.clocks);
+
+    // Configure the timer.
+    let mut timer = dp.TIM2.timer(1.hz(), &mut ccdr);
+
+    loop {
+        for _ in 0..5 {
+            // 20ms wait with timer
+            led.toggle().unwrap();
+            timer.start(20.ms());
+            block!(timer.wait()).ok();
+
+            // Delay for 500ms. Timer must operate correctly on next
+            // use.
+            led.toggle().unwrap();
+            delay.delay_ms(500_u16);
+        }
+    }
+}

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -39,14 +39,20 @@ macro_rules! hal {
                 where
                     T: Into<Hertz>,
                 {
-                    // pause
+                    // Pause
                     self.pause();
-                    // restart counter
+
+                    // Reset counter
                     self.tim.cnt.reset();
 
+                    // UEV event occours on next overflow
+                    self.tim.cr1.modify(|_, w| w.urs().counter_only());
+                    self.clear_uif_bit();
+
+                    // Set PSC and ARR
                     self.set_freq(timeout);
 
-                    // start counter
+                    // Start counter
                     self.resume()
                 }
 


### PR DESCRIPTION
Previously the `CountDown` timer failed to start a new countdown if the periodic timer was running and no `wait()` call was made in the previous period. This was as the UIF bit was already set.

See embedded-hal docs for the contract:
https://docs.rs/embedded-hal/0.2.3/embedded_hal/timer/trait.CountDown.html#tymethod.start

Add  example to demonstrate correct behaviour.