### PR TITLE
 rcc: write accessors for AHB and APB busses in a macro

### DIFF
--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -463,7 +463,7 @@ macro_rules! pwm_ext_hal {
 
 // Implement PWM configuration for timer
 macro_rules! tim_hal {
-    ($($TIMX:ident: ($timX:ident, $apb:ident, $enr:ident, $rstr:ident,
+    ($($TIMX:ident: ($timX:ident, $apb:ident,
                      $timXen:ident, $timXrst:ident,
                      $typ:ty, $bits:expr $(,$bdtr:ident)*),)+) => {
         $(
@@ -479,9 +479,9 @@ macro_rules! tim_hal {
             where
                 PINS: Pins<$TIMX>,
             {
-                ccdr.$apb.$enr().modify(|_, w| w.$timXen().set_bit());
-                ccdr.$apb.$rstr().modify(|_, w| w.$timXrst().set_bit());
-                ccdr.$apb.$rstr().modify(|_, w| w.$timXrst().clear_bit());
+                ccdr.$apb.enr().modify(|_, w| w.$timXen().set_bit());
+                ccdr.$apb.rstr().modify(|_, w| w.$timXrst().set_bit());
+                ccdr.$apb.rstr().modify(|_, w| w.$timXrst().clear_bit());
 
                 let clk = $TIMX::get_clk(&ccdr)
                     .expect("Timer input clock not running!").0;
@@ -524,22 +524,22 @@ macro_rules! tim_hal {
     }
 }
 tim_hal! {
-    TIM1: (tim1, apb2, enr, rstr, tim1en, tim1rst, u16, 16, bdtr),
-    TIM2: (tim2, apb1, lenr, lrstr, tim2en, tim2rst, u32, 32),
-    TIM3: (tim3, apb1, lenr, lrstr, tim3en, tim3rst, u16, 16),
-    TIM4: (tim4, apb1, lenr, lrstr, tim4en, tim4rst, u16, 16),
-    TIM5: (tim5, apb1, lenr, lrstr, tim5en, tim5rst, u32, 32),
-    TIM8: (tim8, apb2, enr, rstr, tim8en, tim8rst, u16, 16, bdtr),
+    TIM1: (tim1, apb2, tim1en, tim1rst, u16, 16, bdtr),
+    TIM2: (tim2, apb1l, tim2en, tim2rst, u32, 32),
+    TIM3: (tim3, apb1l, tim3en, tim3rst, u16, 16),
+    TIM4: (tim4, apb1l, tim4en, tim4rst, u16, 16),
+    TIM5: (tim5, apb1l, tim5en, tim5rst, u32, 32),
+    TIM8: (tim8, apb2, tim8en, tim8rst, u16, 16, bdtr),
 }
 tim_hal! {
-    TIM12: (tim12, apb1, lenr, lrstr, tim12en, tim12rst, u16, 16),
-    TIM13: (tim13, apb1, lenr, lrstr, tim13en, tim13rst, u16, 16),
-    TIM14: (tim14, apb1, lenr, lrstr, tim14en, tim14rst, u16, 16),
+    TIM12: (tim12, apb1l, tim12en, tim12rst, u16, 16),
+    TIM13: (tim13, apb1l, tim13en, tim13rst, u16, 16),
+    TIM14: (tim14, apb1l, tim14en, tim14rst, u16, 16),
 }
 tim_hal! {
-    TIM15: (tim15, apb2, enr, rstr, tim15en, tim15rst, u16, 16),
-    TIM16: (tim16, apb2, enr, rstr, tim16en, tim16rst, u16, 16),
-    TIM17: (tim17, apb2, enr, rstr, tim17en, tim17rst, u16, 16),
+    TIM15: (tim15, apb2, tim15en, tim15rst, u16, 16),
+    TIM16: (tim16, apb2, tim16en, tim16rst, u16, 16),
+    TIM17: (tim17, apb2, tim17en, tim17rst, u16, 16),
 }
 
 // Implement PwmPin for timer
@@ -633,8 +633,7 @@ tim_pin_hal! {
 
 // Low-power timers
 macro_rules! lptim_hal {
-    ($($TIMX:ident: ($timX:ident, $apb:ident, $enr:ident, $rstr:ident,
-                     $timXen:ident, $timXrst:ident, $timXpac:ident),)+) => {
+    ($($TIMX:ident: ($timX:ident, $apb:ident, $timXen:ident, $timXrst:ident, $timXpac:ident),)+) => {
         $(
             pwm_ext_hal!($TIMX: $timX);
 
@@ -648,9 +647,9 @@ macro_rules! lptim_hal {
             where
                 PINS: Pins<$TIMX>,
             {
-                ccdr.$apb.$enr().modify(|_, w| w.$timXen().set_bit());
-                ccdr.$apb.$rstr().modify(|_, w| w.$timXrst().set_bit());
-                ccdr.$apb.$rstr().modify(|_, w| w.$timXrst().clear_bit());
+                ccdr.$apb.enr().modify(|_, w| w.$timXen().set_bit());
+                ccdr.$apb.rstr().modify(|_, w| w.$timXrst().set_bit());
+                ccdr.$apb.rstr().modify(|_, w| w.$timXrst().clear_bit());
 
                 let clk = $TIMX::get_clk(&ccdr).unwrap().0;
                 let freq = freq.0;
@@ -737,9 +736,9 @@ macro_rules! lptim_hal {
 }
 
 lptim_hal! {
-    LPTIM1: (lptim1, apb1, lenr, lrstr, lptim1en, lptim1rst, lptim1),
-    LPTIM2: (lptim2, apb4, enr, rstr, lptim2en, lptim2rst, lptim1),
-    LPTIM3: (lptim3, apb4, enr, rstr, lptim3en, lptim3rst, lptim3),
-    LPTIM4: (lptim4, apb4, enr, rstr, lptim4en, lptim4rst, lptim3),
-    LPTIM5: (lptim5, apb4, enr, rstr, lptim5en, lptim5rst, lptim3),
+    LPTIM1: (lptim1, apb1l, lptim1en, lptim1rst, lptim1),
+    LPTIM2: (lptim2, apb4, lptim2en, lptim2rst, lptim1),
+    LPTIM3: (lptim3, apb4, lptim3en, lptim3rst, lptim3),
+    LPTIM4: (lptim4, apb4, lptim4en, lptim4rst, lptim3),
+    LPTIM5: (lptim5, apb4, lptim5en, lptim5rst, lptim3),
 }

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -171,7 +171,7 @@ pub struct Qei<TIM, PINS> {
 }
 
 macro_rules! tim_hal {
-    ($($TIM:ident: ($tim:ident, $apb:ident, $enr:ident, $rstr:ident, $timXen:ident, $timXrst:ident, $bits:ident),)+) => {
+    ($($TIM:ident: ($tim:ident, $apb:ident, $timXen:ident, $timXrst:ident, $bits:ident),)+) => {
         $(
             impl<PINS> Qei<$TIM, PINS> {
                 /// Configures a TIM peripheral as a quadrature
@@ -185,9 +185,9 @@ macro_rules! tim_hal {
                 {
                     // enable and reset peripheral to a clean slate
                     // state
-                    ccdr.$apb.$enr().modify(|_, w| w.$timXen().set_bit());
-                    ccdr.$apb.$rstr().modify(|_, w| w.$timXrst().set_bit());
-                    ccdr.$apb.$rstr().modify(|_, w| w.$timXrst().clear_bit());
+                    ccdr.$apb.enr().modify(|_, w| w.$timXen().set_bit());
+                    ccdr.$apb.rstr().modify(|_, w| w.$timXrst().set_bit());
+                    ccdr.$apb.rstr().modify(|_, w| w.$timXrst().clear_bit());
 
 
                     // Configure TxC1 and TxC2 as captures
@@ -252,10 +252,10 @@ macro_rules! tim_hal {
     feature = "stm32h750"
 ))]
 tim_hal! {
-    TIM1: (tim1, apb2, enr, rstr, tim1en, tim1rst, u16),
-    TIM8: (tim8, apb2, enr, rstr, tim8en, tim8rst, u16),
-    TIM2: (tim2, apb1, lenr, lrstr, tim2en, tim2rst, u32),
-    TIM3: (tim3, apb1, lenr, lrstr, tim3en, tim3rst, u16),
-    TIM4: (tim4, apb1, lenr, lrstr, tim4en, tim4rst, u16),
-    TIM5: (tim5, apb1, lenr, lrstr, tim5en, tim5rst, u32),
+    TIM1: (tim1, apb2, tim1en, tim1rst, u16),
+    TIM8: (tim8, apb2, tim8en, tim8rst, u16),
+    TIM2: (tim2, apb1l, tim2en, tim2rst, u32),
+    TIM3: (tim3, apb1l, tim3en, tim3rst, u16),
+    TIM4: (tim4, apb1l, tim4en, tim4rst, u16),
+    TIM5: (tim5, apb1l, tim5en, tim5rst, u32),
 }

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -100,9 +100,9 @@ pub struct Ccdr {
 }
 
 macro_rules! ahb_apb_generation {
-    ($(($AXBn:ident, $AXBnENR:ident, $axbnenr:ident, $AXBnRSTR:ident, $axbnrstr:ident)),+) => {
+    ($(($AXBn:ident, $AXBnENR:ident, $axbnenr:ident, $AXBnRSTR:ident, $axbnrstr:ident, $doc:expr)),+) => {
         $(
-            #[allow(missing_docs)]
+            #[doc=$doc]
             pub struct $AXBn {
                 _0: (),
             }
@@ -125,15 +125,15 @@ macro_rules! ahb_apb_generation {
 }
 
 ahb_apb_generation!(
-    (AHB1, AHB1ENR, ahb1enr, AHB1RSTR, ahb1rstr),
-    (AHB2, AHB2ENR, ahb2enr, AHB2RSTR, ahb2rstr),
-    (AHB3, AHB3ENR, ahb3enr, AHB3RSTR, ahb3rstr),
-    (AHB4, AHB4ENR, ahb4enr, AHB4RSTR, ahb4rstr),
-    (APB1L, APB1LENR, apb1lenr, APB1LRSTR, apb1lrstr),
-    (APB1H, APB1HENR, apb1henr, APB1HRSTR, apb1hrstr),
-    (APB2, APB2ENR, apb2enr, APB2RSTR, apb2rstr),
-    (APB3, APB3ENR, apb3enr, APB3RSTR, apb3rstr),
-    (APB4, APB4ENR, apb4enr, APB4RSTR, apb4rstr)
+    (AHB1, AHB1ENR, ahb1enr, AHB1RSTR, ahb1rstr, "AMBA High-performance Bus (AHB1) registers"),
+    (AHB2, AHB2ENR, ahb2enr, AHB2RSTR, ahb2rstr, "AMBA High-performance Bus (AHB2) registers"),
+    (AHB3, AHB3ENR, ahb3enr, AHB3RSTR, ahb3rstr, "AMBA High-performance Bus (AHB3) registers"),
+    (AHB4, AHB4ENR, ahb4enr, AHB4RSTR, ahb4rstr, "AMBA High-performance Bus (AHB4) registers"),
+    (APB1L, APB1LENR, apb1lenr, APB1LRSTR, apb1lrstr, "Advanced Peripheral Bus 1L (APB1L) registers"),
+    (APB1H, APB1HENR, apb1henr, APB1HRSTR, apb1hrstr, "Advanced Peripheral Bus 1H (APB1H) registers"),
+    (APB2, APB2ENR, apb2enr, APB2RSTR, apb2rstr, "Advanced Peripheral Bus 2 (APB2) registers"),
+    (APB3, APB3ENR, apb3enr, APB3RSTR, apb3rstr, "Advanced Peripheral Bus 3 (APB3) registers"),
+    (APB4, APB4ENR, apb4enr, APB4RSTR, apb4rstr, "Advanced Peripheral Bus 4 (APB4) registers")
 );
 
 /// RCC Domain 3 Kernel Clock Configuration Register

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -77,8 +77,10 @@ pub struct Ccdr {
     pub ahb3: AHB3,
     /// AMBA High-performance Bus (AHB4) registers
     pub ahb4: AHB4,
-    /// Advanced Peripheral Bus 1 (APB1) registers
-    pub apb1: APB1,
+    /// Advanced Peripheral Bus 1L (APB1L) registers
+    pub apb1l: APB1L,
+    /// Advanced Peripheral Bus 1H (APB1H) registers
+    pub apb1h: APB1H,
     /// Advanced Peripheral Bus 2 (APB2) registers
     pub apb2: APB2,
     /// Advanced Peripheral Bus 3 (APB3) registers
@@ -96,157 +98,42 @@ pub struct Ccdr {
     pub(crate) rb: RCC,
 }
 
-/// AMBA High-performance Bus (AHB) peripheral registers
-pub struct AHB1 {
-    _0: (),
-}
+macro_rules! ahb_apb_generation {
+    ($(($AXBn:ident, $AXBnENR:ident, $axbnenr:ident, $AXBnRSTR:ident, $axbnrstr:ident)),+) => {
+        $(
+            #[allow(missing_docs)]
+            pub struct $AXBn {
+                _0: (),
+            }
 
-impl AHB1 {
-    #[allow(unused)]
-    pub(crate) fn enr(&mut self) -> &rcc::AHB1ENR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).ahb1enr }
-    }
+            impl $AXBn {
+                #[allow(unused)]
+                pub (crate) fn enr(&mut self) -> &rcc::$AXBnENR {
+                    // NOTE(unsafe) this proxy grants exclusive access to this register
+                    unsafe { &(*RCC::ptr()).$axbnenr }
+                }
 
-    #[allow(unused)]
-    pub(crate) fn rstr(&mut self) -> &rcc::AHB1RSTR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).ahb1rstr }
-    }
-}
-
-/// AMBA High-performance Bus (AHB) peripheral registers
-pub struct AHB2 {
-    _0: (),
-}
-
-impl AHB2 {
-    #[allow(unused)]
-    pub(crate) fn enr(&mut self) -> &rcc::AHB2ENR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).ahb2enr }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn rstr(&mut self) -> &rcc::AHB2RSTR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).ahb2rstr }
+                #[allow(unused)]
+                pub (crate) fn rstr(&mut self) -> &rcc::$AXBnRSTR {
+                    // NOTE(unsafe) this proxy grants exclusive access to this register
+                    unsafe { &(*RCC::ptr()).$axbnrstr }
+                }
+            }
+        )+ 
     }
 }
 
-/// AMBA High-performance Bus (AHB) peripheral registers
-pub struct AHB3 {
-    _0: (),
-}
-
-impl AHB3 {
-    #[allow(unused)]
-    pub(crate) fn enr(&mut self) -> &rcc::AHB3ENR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).ahb3enr }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn rstr(&mut self) -> &rcc::AHB3RSTR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).ahb3rstr }
-    }
-}
-
-/// AMBA High-performance Bus (AHB) peripheral registers
-pub struct AHB4 {
-    _0: (),
-}
-
-impl AHB4 {
-    #[allow(unused)]
-    pub(crate) fn enr(&mut self) -> &rcc::AHB4ENR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).ahb4enr }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn rstr(&mut self) -> &rcc::AHB4RSTR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).ahb4rstr }
-    }
-}
-
-/// Advanced Peripheral Bus 1 (APB1) peripheral registers
-pub struct APB1 {
-    _0: (),
-}
-
-impl APB1 {
-    #[allow(unused)]
-    pub(crate) fn lenr(&mut self) -> &rcc::APB1LENR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).apb1lenr }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn lrstr(&mut self) -> &rcc::APB1LRSTR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).apb1lrstr }
-    }
-}
-
-/// Advanced Peripheral Bus 2 (APB2) peripheral registers
-pub struct APB2 {
-    _0: (),
-}
-
-impl APB2 {
-    #[allow(unused)]
-    pub(crate) fn enr(&mut self) -> &rcc::APB2ENR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).apb2enr }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn rstr(&mut self) -> &rcc::APB2RSTR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).apb2rstr }
-    }
-}
-
-/// Advanced Peripheral Bus 3 (APB3) peripheral registers
-pub struct APB3 {
-    _0: (),
-}
-
-impl APB3 {
-    #[allow(unused)]
-    pub(crate) fn enr(&mut self) -> &rcc::APB3ENR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).apb3enr }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn rstr(&mut self) -> &rcc::APB3RSTR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).apb3rstr }
-    }
-}
-
-/// Advanced Peripheral Bus 4 (APB4) peripheral registers
-pub struct APB4 {
-    _0: (),
-}
-
-impl APB4 {
-    #[allow(unused)]
-    pub(crate) fn enr(&mut self) -> &rcc::APB4ENR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).apb4enr }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn rstr(&mut self) -> &rcc::APB4RSTR {
-        // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*RCC::ptr()).apb4rstr }
-    }
-}
+ahb_apb_generation!(
+    (AHB1, AHB1ENR, ahb1enr, AHB1RSTR, ahb1rstr),
+    (AHB2, AHB2ENR, ahb2enr, AHB2RSTR, ahb2rstr),
+    (AHB3, AHB3ENR, ahb3enr, AHB3RSTR, ahb3rstr),
+    (AHB4, AHB4ENR, ahb4enr, AHB4RSTR, ahb4rstr),
+    (APB1L, APB1LENR, apb1lenr, APB1LRSTR, apb1lrstr),
+    (APB1H, APB1HENR, apb1henr, APB1HRSTR, apb1hrstr),
+    (APB2, APB2ENR, apb2enr, APB2RSTR, apb2rstr),
+    (APB3, APB3ENR, apb3enr, APB3RSTR, apb3rstr),
+    (APB4, APB4ENR, apb4enr, APB4RSTR, apb4rstr)
+);
 
 /// RCC Domain 3 Kernel Clock Configuration Register
 pub struct D3CCIPR {
@@ -696,7 +583,8 @@ impl Rcc {
             ahb2: AHB2 { _0: () },
             ahb3: AHB3 { _0: () },
             ahb4: AHB4 { _0: () },
-            apb1: APB1 { _0: () },
+            apb1l: APB1L { _0: () },
+            apb1h: APB1H { _0: () },
             apb2: APB2 { _0: () },
             apb3: APB3 { _0: () },
             apb4: APB4 { _0: () },

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -380,7 +380,7 @@ pub trait SerialExt<USART> {
 macro_rules! usart {
     ($(
         $USARTX:ident: ($usartX:ident, $apb:ident, $usartXen:ident, $usartXrst:ident,
-                        $pclkX:ident, $enr:ident, $rstr:ident),
+                        $pclkX:ident),
     )+) => {
         $(
             /// Configures a USART peripheral to provide serial
@@ -399,9 +399,9 @@ macro_rules! usart {
                     use self::config::*;
 
                     // Enable clock for USART and reset
-                    ccdr.$apb.$enr().modify(|_, w| w.$usartXen().enabled());
-                    ccdr.$apb.$rstr().modify(|_, w| w.$usartXrst().set_bit());
-                    ccdr.$apb.$rstr().modify(|_, w| w.$usartXrst().clear_bit());
+                    ccdr.$apb.enr().modify(|_, w| w.$usartXen().enabled());
+                    ccdr.$apb.rstr().modify(|_, w| w.$usartXrst().set_bit());
+                    ccdr.$apb.rstr().modify(|_, w| w.$usartXrst().clear_bit());
 
                     // Get kernel clock
 	                let usart_ker_ck = match Self::kernel_clk(ccdr) {
@@ -691,15 +691,15 @@ macro_rules! usart234578sel {
 }
 
 usart! {
-    USART1: (usart1, apb2, usart1en, usart1rst, pclk2, enr, rstr),
-    USART2: (usart2, apb1, usart2en, usart2rst, pclk1, lenr, lrstr),
-    USART3: (usart3, apb1, usart3en, usart3rst, pclk1, lenr, lrstr),
-    USART6: (usart6, apb2, usart6en, usart6rst, pclk2, enr, rstr),
+    USART1: (usart1, apb2, usart1en, usart1rst, pclk2),
+    USART2: (usart2, apb1l, usart2en, usart2rst, pclk1),
+    USART3: (usart3, apb1l, usart3en, usart3rst, pclk1),
+    USART6: (usart6, apb2, usart6en, usart6rst, pclk2),
 
-    UART4: (uart4, apb1, uart4en, uart4rst, pclk1, lenr, lrstr),
-    UART5: (uart5, apb1, uart5en, uart5rst, pclk1, lenr, lrstr),
-    UART7: (uart7, apb1, uart7en, uart7rst, pclk1, lenr, lrstr),
-    UART8: (uart8, apb1, uart8en, uart8rst, pclk1, lenr, lrstr),
+    UART4: (uart4, apb1l, uart4en, uart4rst, pclk1),
+    UART5: (uart5, apb1l, uart5en, uart5rst, pclk1),
+    UART7: (uart7, apb1l, uart7en, uart7rst, pclk1),
+    UART8: (uart8, apb1l, uart8en, uart8rst, pclk1),
 }
 
 #[cfg(any(

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -10,7 +10,7 @@ use cast::{u16, u32};
 use nb;
 use void::Void;
 
-use crate::rcc::{CoreClocks, APB1, APB2};
+use crate::rcc::{CoreClocks, APB1L, APB2};
 use crate::time::Hertz;
 
 /// Hardware timers
@@ -27,7 +27,7 @@ pub enum Event {
 }
 
 macro_rules! hal {
-    ($($TIM:ident: ($tim:ident, $APB:ident, $timXen:ident, $timXrst:ident, $enr:ident, $rstr:ident),)+) => {
+    ($($TIM:ident: ($tim:ident, $APB:ident, $timXen:ident, $timXrst:ident),)+) => {
         $(
             impl Periodic for Timer<$TIM> {}
 
@@ -70,9 +70,9 @@ macro_rules! hal {
                     T: Into<Hertz>,
                 {
                     // enable and reset peripheral to a clean slate state
-                    apb.$enr().modify(|_, w| w.$timXen().set_bit());
-                    apb.$rstr().modify(|_, w| w.$timXrst().set_bit());
-                    apb.$rstr().modify(|_, w| w.$timXrst().clear_bit());
+                    apb.enr().modify(|_, w| w.$timXen().set_bit());
+                    apb.rstr().modify(|_, w| w.$timXrst().set_bit());
+                    apb.rstr().modify(|_, w| w.$timXrst().clear_bit());
 
                     let mut timer = Timer {
                         clocks,
@@ -164,8 +164,8 @@ macro_rules! hal {
     feature = "stm32h750",
 ))]
 hal! {
-    TIM1: (tim1, APB2, tim1en, tim1rst, enr, rstr),
-    TIM2: (tim2, APB1, tim2en, tim2rst, lenr, lrstr),
+    TIM1: (tim1, APB2, tim1en, tim1rst),
+    TIM2: (tim2, APB1L, tim2en, tim2rst),
     // TIM3: (tim3, APB1, tim3en, tim3rst),
     // TIM4: (tim4, APB1, tim4en, tim4rst),
     // TIM5: (tim5, APB1, tim7en, tim7rst),

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -118,7 +118,7 @@ pub enum Event {
 }
 
 macro_rules! hal {
-    ($($TIM:ident: ($tim:ident, $APB:ident, $timXen:ident, $timXrst:ident),)+) => {
+    ($($TIMX:ident: ($timX:ident, $APB:ident, $timXen:ident, $timXrst:ident),)+) => {
         $(
             impl Periodic for Timer<$TIMX> {}
 


### PR DESCRIPTION
Closes #21 