### PR TITLE
revision_v: Update feature gates from revision v split in PAC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ env:
 - MCU=stm32h743
 - MCU=stm32h753
 - MCU=stm32h750
+- MCU=stm32h742v
+- MCU=stm32h743v
+- MCU=stm32h753v
+- MCU=stm32h750v
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,17 @@ cortex-m-log = { version = "~0.6", features = ["itm"] }
 default = ["unproven"]
 unproven = ["embedded-hal/unproven"]
 device-selected = []
+revision_v = []
 rt = ["stm32h7/rt"]
-stm32h742 = ["stm32h7/stm32h7x3", "device-selected"]
-stm32h743 = ["stm32h7/stm32h7x3", "device-selected"]
-stm32h753 = ["stm32h7/stm32h7x3", "device-selected"]
-stm32h750 = ["stm32h7/stm32h7x3", "device-selected"]
-rev_v = []
+stm32h742 = ["stm32h7/stm32h743", "device-selected"]
+stm32h743 = ["stm32h7/stm32h743", "device-selected"]
+stm32h753 = ["stm32h7/stm32h753", "device-selected"]
+stm32h750 = ["stm32h7/stm32h743", "device-selected"]
+stm32h742v = ["stm32h7/stm32h743v", "device-selected", "revision_v"]
+stm32h743v = ["stm32h7/stm32h743v", "device-selected", "revision_v"]
+stm32h753v = ["stm32h7/stm32h753v", "device-selected", "revision_v"]
+stm32h750v = ["stm32h7/stm32h743v", "device-selected", "revision_v"]
+
 
 [profile.dev]
 codegen-units = 1 # better optimizations

--- a/README.md
+++ b/README.md
@@ -10,14 +10,28 @@ are pull requests!**
 
 📂 *[Local dependancy required](#Hacking)*
 
-`stm32h7xx-hal` contains a hardware abstraction on top of the peripheral access
-API for the STMicro STM32H7 series microcontrollers. The selection of the MCU
-is done by feature gates, typically specified by board support crates.
-Currently supported configurations are:
+`stm32h7xx-hal` contains a hardware abstraction on top of the
+peripheral access API for the STMicro STM32H7 series
+microcontrollers. The selection of the MCU is done by feature gates,
+typically specified by board support crates.
 
-*   stm32h743 ✔️ YES!
+The currently supported parts are:
 
-While stm32h742, stm32h750, and stm32h753 remain unsupported.
+*   stm32h743 ✔️
+*   stm32h753 ✔️
+
+Feature gates for the stm32h742, stm32h750 also exist but may not be
+complete.
+
+In 2019 ST released hardware Revision V of the stm32h742, stm32h743,
+stm32h750 and stm32h753 ([eevblog][]). This hardware revision makes
+breaking hardware changes, documented in [AN5312][]. These parts are
+supported with the following feature gates:
+
+*   stm32h743v ✔️
+*   stm32h753v ✔️
+
+Again, feature gates stm32h742v, stm32h750v also exist.
 
 The idea behind this crate is to gloss over the slight differences in the
 various peripherals available on those MCUs so a HAL can be written for all
@@ -77,3 +91,5 @@ License
 [`stm32h7`]: https://crates.io/crates/stm32h7
 [`stm32f30x-hal`]: https://github.com/japaric/stm32f30x-hal
 [`embedded-hal`]: https://github.com/japaric/embedded-hal
+[AN5312]: https://www.st.com/resource/en/application_note/dm00609692.pdf
+[eevblog]: https://www.eevblog.com/forum/microcontrollers/stm32h7-series-revision-beware-of-the-changes!/

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -712,12 +712,6 @@ macro_rules! gpio {
     }
 }
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 gpio!(GPIOA, gpioa, gpioaen, gpioarst, PA, 0, [
     PA0: (pa0, 0, Input<Floating>, exticr1),
     PA1: (pa1, 1, Input<Floating>, exticr1),
@@ -737,12 +731,6 @@ gpio!(GPIOA, gpioa, gpioaen, gpioarst, PA, 0, [
     PA15: (pa15, 15, Input<Floating>, exticr4),
 ]);
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 gpio!(GPIOB, gpiob, gpioben, gpiobrst, PB, 1, [
     PB0: (pb0, 0, Input<Floating>, exticr1),
     PB1: (pb1, 1, Input<Floating>, exticr1),
@@ -762,12 +750,6 @@ gpio!(GPIOB, gpiob, gpioben, gpiobrst, PB, 1, [
     PB15: (pb15, 15, Input<Floating>, exticr4),
 ]);
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 gpio!(GPIOC, gpioc, gpiocen, gpiocrst, PC, 2, [
     PC0: (pc0, 0, Input<Floating>, exticr1),
     PC1: (pc1, 1, Input<Floating>, exticr1),
@@ -787,12 +769,6 @@ gpio!(GPIOC, gpioc, gpiocen, gpiocrst, PC, 2, [
     PC15: (pc15, 15, Input<Floating>, exticr4),
 ]);
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 gpio!(GPIOD, gpiod, gpioden, gpiodrst, PD, 3, [
     PD0: (pd0, 0, Input<Floating>, exticr1),
     PD1: (pd1, 1, Input<Floating>, exticr1),
@@ -812,12 +788,6 @@ gpio!(GPIOD, gpiod, gpioden, gpiodrst, PD, 3, [
     PD15: (pd15, 15, Input<Floating>, exticr4),
 ]);
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 gpio!(GPIOE, gpioe, gpioeen, gpioerst, PE, 4, [
     PE0: (pe0, 0, Input<Floating>, exticr1),
     PE1: (pe1, 1, Input<Floating>, exticr1),
@@ -837,12 +807,6 @@ gpio!(GPIOE, gpioe, gpioeen, gpioerst, PE, 4, [
     PE15: (pe15, 15, Input<Floating>, exticr4),
 ]);
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 gpio!(GPIOF, gpiof, gpiofen, gpiofrst, PF, 5, [
     PF0: (pf0, 0, Input<Floating>, exticr1),
     PF1: (pf1, 1, Input<Floating>, exticr1),
@@ -862,12 +826,6 @@ gpio!(GPIOF, gpiof, gpiofen, gpiofrst, PF, 5, [
     PF15: (pf15, 15, Input<Floating>, exticr4),
 ]);
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 gpio!(GPIOG, gpiog, gpiogen, gpiogrst, PG, 6, [
     PG0: (pg0, 0, Input<Floating>, exticr1),
     PG1: (pg1, 1, Input<Floating>, exticr1),
@@ -887,12 +845,6 @@ gpio!(GPIOG, gpiog, gpiogen, gpiogrst, PG, 6, [
     PG15: (pg15, 15, Input<Floating>, exticr4),
 ]);
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 gpio!(GPIOH, gpioh, gpiohen, gpiohrst, PH, 7, [
     PH0: (ph0, 0, Input<Floating>, exticr1),
     PH1: (ph1, 1, Input<Floating>, exticr1),
@@ -912,12 +864,6 @@ gpio!(GPIOH, gpioh, gpiohen, gpiohrst, PH, 7, [
     PH15: (ph15, 15, Input<Floating>, exticr4),
 ]);
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 gpio!(GPIOI, gpioi, gpioien, gpioirst, PI, 8, [
     PI0: (pi0, 0, Input<Floating>, exticr1),
     PI1: (pi1, 1, Input<Floating>, exticr1),
@@ -937,12 +883,6 @@ gpio!(GPIOI, gpioi, gpioien, gpioirst, PI, 8, [
     PI15: (pi15, 15, Input<Floating>, exticr4),
 ]);
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 gpio!(GPIOJ, gpioj, gpiojen, gpiojrst, PJ, 9, [
     PJ0: (pj0, 0, Input<Floating>, exticr1),
     PJ1: (pj1, 1, Input<Floating>, exticr1),
@@ -962,12 +902,6 @@ gpio!(GPIOJ, gpioj, gpiojen, gpiojrst, PJ, 9, [
     PJ15: (pj15, 15, Input<Floating>, exticr4),
 ]);
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 gpio!(GPIOK, gpiok, gpioken, gpiokrst, PK, 10, [
     PK0: (pk0, 0, Input<Floating>, exticr1),
     PK1: (pk1, 1, Input<Floating>, exticr1),

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -389,12 +389,6 @@ pins! {
         ]
 }
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 i2c!(
     I2C1: (i2c1, i2c1en, i2c1rst, apb1lenr, apb1lrstr, pclk1),
     I2C2: (i2c2, i2c2en, i2c2rst, apb1lenr, apb1lrstr, pclk1),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,10 @@ compile_error!(
         stm32h743
         stm32h753
         stm32h750
+        stm32h742v
+        stm32h743v
+        stm32h753v
+        stm32h750v
 "
 );
 
@@ -22,10 +26,24 @@ pub use nb::block;
 #[cfg(any(
     feature = "stm32h742",
     feature = "stm32h743",
-    feature = "stm32h753",
     feature = "stm32h750",
 ))]
-pub use stm32h7::stm32h7x3 as stm32;
+pub use stm32h7::stm32h743 as stm32;
+#[cfg(any(
+    feature = "stm32h753",
+))]
+pub use stm32h7::stm32h753 as stm32;
+#[cfg(any(
+    feature = "stm32h742v",
+    feature = "stm32h743v",
+    feature = "stm32h750v",
+))]
+pub use stm32h7::stm32h743v as stm32;
+#[cfg(any(
+    feature = "stm32h753v",
+))]
+pub use stm32h7::stm32h753v as stm32;
+
 
 #[cfg(feature = "device-selected")]
 pub use crate::stm32 as pac;

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -2,12 +2,6 @@
 use crate::hal::{self, Direction};
 use crate::rcc::Ccdr;
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 use crate::gpio::gpioa::{PA0, PA1, PA15, PA5, PA6, PA7, PA8, PA9};
 use crate::gpio::gpiob::{PB0, PB13, PB14, PB3, PB4, PB5, PB6, PB7};
 use crate::gpio::gpioc::{PC6, PC7};
@@ -20,30 +14,12 @@ use crate::gpio::gpiok::{PK0, PK1};
 
 use crate::gpio::Alternate;
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 use crate::gpio::AF1;
 use crate::gpio::AF2;
 use crate::gpio::AF3;
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 use crate::stm32::{TIM1, TIM8};
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 use crate::stm32::{TIM2, TIM3, TIM4, TIM5};
 
 pub trait Pins<TIM> {}
@@ -70,12 +46,6 @@ macro_rules! pins {
     }
 }
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750",
-))]
 pins! {
     TIM1:
         CH1: [
@@ -245,12 +215,6 @@ macro_rules! tim_hal {
     }
 }
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 tim_hal! {
     TIM1: (tim1, apb2, enr, rstr, tim1en, tim1rst, u16),
     TIM8: (tim8, apb2, enr, rstr, tim8en, tim8rst, u16),

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -582,12 +582,6 @@ impl Rcc {
         // Refer to part datasheet "General operating conditions"
         // table for (rev V). We do not assert checks for earlier
         // revisions which may have lower limits.
-        #[cfg(any(
-            feature = "stm32h742",
-            feature = "stm32h743",
-            feature = "stm32h753",
-            feature = "stm32h750"
-        ))]
         let (sys_d1cpre_ck_max, rcc_hclk_max, pclk_max) = match vos {
             Voltage::Scale0 => (480_000_000, 240_000_000, 120_000_000),
             Voltage::Scale1 => (400_000_000, 200_000_000, 100_000_000),

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -11,20 +11,7 @@ use nb::block;
 use crate::stm32::rcc::d2ccip2r;
 use crate::stm32::usart1::cr1::{M0W, PCEW, PSW};
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 use crate::stm32::{USART1, USART2, USART3, USART6};
-
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 use crate::stm32::{UART4, UART5, UART7, UART8};
 
 use crate::gpio::gpioa::{
@@ -206,12 +193,6 @@ macro_rules! uart_pins {
     }
 }
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 usart_pins! {
     USART1:
         TX: [
@@ -282,12 +263,6 @@ usart_pins! {
             PG7<Alternate<AF7>>
         ]
 }
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 uart_pins! {
     UART4:
         TX: [
@@ -702,21 +677,9 @@ usart! {
     UART8: (uart8, apb1, uart8en, uart8rst, pclk1, lenr, lrstr),
 }
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 usart16sel! {
     USART1, USART6,
 }
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 usart234578sel! {
     USART2, USART3, UART4, UART5, UART7, UART8,
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -9,20 +9,8 @@ use crate::stm32::spi1::cfg1::MBRW;
 use core::ptr;
 use nb;
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750",
-))]
 use crate::stm32::{SPI1, SPI2, SPI3, SPI4, SPI5, SPI6};
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 use crate::gpio::gpioa::{PA12, PA5, PA6, PA7, PA9};
 use crate::gpio::gpiob::{PB10, PB13, PB14, PB15, PB2, PB3, PB4, PB5};
 use crate::gpio::gpioc::{PC1, PC10, PC11, PC12, PC2, PC3};
@@ -35,12 +23,6 @@ use crate::gpio::gpioi::{PI1, PI2, PI3};
 use crate::gpio::gpioj::{PJ10, PJ11};
 use crate::gpio::gpiok::PK0;
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 use crate::gpio::{Alternate, AF5, AF6, AF7, AF8};
 
 use crate::rcc::Ccdr;
@@ -95,12 +77,6 @@ macro_rules! pins {
     }
 }
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 pins! {
     SPI1:
         SCK: [
@@ -541,12 +517,6 @@ macro_rules! spi6sel {
     }
 }
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 spi! {
     SPI1: (spi1, apb2enr,  spi1en, pclk2),
     SPI2: (spi2, apb1lenr, spi2en, pclk1),
@@ -556,12 +526,6 @@ spi! {
     SPI6: (spi6, apb4enr,  spi6en, pclk2),
 }
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 spi123sel! {
     SPI1, SPI2, SPI3,
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -38,12 +38,6 @@ macro_rules! impl_tim_ker_ck {
         )+
     }
 }
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750"
-))]
 impl_tim_ker_ck! {
     timx_ker_ck: TIM2, TIM3, TIM4, TIM5, TIM6, TIM7, TIM12, TIM13, TIM14
     timy_ker_ck: TIM1, TIM8, TIM15, TIM16, TIM17
@@ -249,12 +243,6 @@ macro_rules! hal {
     }
 }
 
-#[cfg(any(
-    feature = "stm32h742",
-    feature = "stm32h743",
-    feature = "stm32h753",
-    feature = "stm32h750",
-))]
 hal! {
     TIM1: (tim1, APB2, tim1en, tim1rst, enr, rstr),
     TIM2: (tim2, APB1, tim2en, tim2rst, lenr, lrstr),


### PR DESCRIPTION
Upstream change in stm32-rs
https://github.com/stm32-rs/stm32-rs/pull/247

Remove feature gates where they are not required.

Add new v feature targets to travis.

ADC is currently the only area where this crate differs between v and
non-v.

Revision v tracking issue
https://github.com/stm32-rs/stm32h7xx-hal/issues/9