### PR TITLE
rcc: add options to configure more PLL outputs

### DIFF
--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -30,7 +30,10 @@ fn main() -> ! {
     // Constrain and Freeze clock
     println!(log, "Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let mut ccdr = rcc.sys_ck(96.mhz()).freeze(vos, &dp.SYSCFG);
+    let mut ccdr = rcc
+        .sys_ck(96.mhz())
+        .pll1_q_ck(48.mhz())
+        .freeze(vos, &dp.SYSCFG);
 
     // Acquire the GPIOC peripheral. This also enables the clock for
     // GPIOC in the RCC register.


### PR DESCRIPTION
* All 3 outputs of PLL1 can be configured.
* Moving closer to a generic interface for PLL2/PLL3; just needs macro
  definitions and call to setup.
* An `assert` will occour if pll1_p_ck is set independently when it is
  requried for sys_ck.
* When `pll1_r_ck` is `None` in the configuration struct, it is set if
  required to keep `traceclk` running. Afaict there's no documentation
  on acceptable frequencies for `traceclk`, set p_ck/2 as a sensible
  choice (can be overridden by setting some `pll1_r_ck`).