### PR TITLE
Init traits prelude

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -270,6 +270,10 @@ adc_internal!(
           Vrefint => (19, vrefen)
 );
 
+pub trait AdcExt<ADC>: Sized {
+    fn adc(self, delay: &mut Delay, ccdr: &mut Ccdr) -> Adc<ADC, Disabled>;
+}
+
 /// Stored ADC config can be restored using the `Adc::restore_cfg` method
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct StoredConfig(AdcSampleTime, Resolution, AdcLshift);
@@ -308,6 +312,15 @@ macro_rules! adc_hal {
         )
     ),+ $(,)*) => {
         $(
+            impl AdcExt<$ADC> for $ADC {
+	            fn adc(self,
+                       delay: &mut Delay,
+                       ccdr: &mut Ccdr) -> Adc<$ADC, Disabled>
+	            {
+	                Adc::$adcX(self, delay, ccdr)
+	            }
+	        }
+
             impl Adc<$ADC, Disabled> {
                 /// Initialise ADC
                 ///

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,3 +13,4 @@ pub use crate::rng::RngExt as _stm32h7xx_hal_rng_RngExt;
 pub use crate::serial::SerialExt as _stm32h7xx_hal_serial_SerialExt;
 pub use crate::spi::SpiExt as _stm32h7xx_hal_spi_SpiExt;
 pub use crate::time::U32Ext as _stm32h7xx_hal_time_U32Ext;
+pub use crate::timer::TimerExt as _stm32h7xx_hal_timer_TimerExt;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,7 @@
 //! Prelude
 pub use embedded_hal::prelude::*;
 
+pub use crate::adc::AdcExt as _stm32h7xx_hal_adc_AdcExt;
 pub use crate::delay::DelayExt as _stm32h7xx_hal_delay_DelayExt;
 pub use crate::flash::FlashExt as _stm32h7xx_hal_flash_FlashExt;
 pub use crate::gpio::GpioExt as _stm32h7xx_hal_gpio_GpioExt;

--- a/src/time.rs
+++ b/src/time.rs
@@ -62,6 +62,7 @@ impl U32Ext for u32 {
     }
 }
 
+// Unit conversions
 impl Into<Hertz> for KiloHertz {
     fn into(self) -> Hertz {
         Hertz(self.0 * 1_000)
@@ -77,6 +78,22 @@ impl Into<Hertz> for MegaHertz {
 impl Into<KiloHertz> for MegaHertz {
     fn into(self) -> KiloHertz {
         KiloHertz(self.0 * 1_000)
+    }
+}
+
+// MilliSeconds <-> Hertz
+impl Into<MilliSeconds> for Hertz {
+    fn into(self) -> MilliSeconds {
+        let freq = self.0;
+        assert!(freq != 0 && freq <= 1_000);
+        MilliSeconds(1_000 / freq)
+    }
+}
+impl Into<Hertz> for MilliSeconds {
+    fn into(self) -> Hertz {
+        let period = self.0;
+        assert!(period != 0 && period <= 1_000);
+        Hertz(1_000 / period)
     }
 }
 


### PR DESCRIPTION
adc: Add initialisation trait

Simplifies usage:

```rust
let _ = adc::Adc::adc3(dp.ADC3, &mut delay, &mut ccdr);
```
to
```rust
let _ = dp.ADC3.adc(&mut delay, &mut ccdr);
```

Previous method still works.

Re-work arguments for timer, doesn't break anything as there aren't any examples yet.

Closes #20 