### PR TITLE
svd2rust: breaking changes from update to v0.15.0

### DIFF
--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -564,7 +564,7 @@ macro_rules! tim_pin_hal {
                 fn enable(&mut self) {
                     let tim = unsafe { &*$TIMX::ptr() };
 
-                    tim.$ccmrx_output.modify(|_, w|
+                    tim.$ccmrx_output().modify(|_, w|
                         w.$ocxpe()
                             .enabled() // Enable preload
                             .$ocxm()

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -161,7 +161,7 @@ macro_rules! tim_hal {
 
 
                     // Configure TxC1 and TxC2 as captures
-                    tim.ccmr1_output.write(|w| unsafe {
+                    tim.ccmr1_output().write(|w| unsafe {
                         w.cc1s()
                             .bits(0b01)
                             .cc2s()


### PR DESCRIPTION
svd2rust v0.15.0 makes the following breaking change ([changelog](https://github.com/rust-embedded/svd2rust/blob/master/CHANGELOG.md#v0150---2019-07-25))

> [breaking-change] for access to alternate registers functions now
  used instead of untagged_unions (no more nightly features)

Fix by making function calls for `cmrrX_output`.

Fixing this will be a breaking change for anyone building `stm32-rs`
locally. To bring your build enviroment up-to-date:

```
cargo install svd2rust --force
```

Closes #29

Unblocks #28 and others