### PR TITLE
[rust] Rust 1.37.0 stable was released on 15th August 2019

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: rust
 rust:
   - nightly
   - beta
-#  - stable
+  - stable
 
 cache: cargo
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ are pull requests!**
 
 🚧 *Work in progress*
 
-❗ *Beta or nightly required*
-
 `stm32h7xx-hal` contains a hardware abstraction on top of the
 peripheral access API for the STMicro STM32H7 series
 microcontrollers. The selection of the MCU is done by feature gates,


### PR DESCRIPTION
https://blog.rust-lang.org/2019/08/15/Rust-1.37.0.html

Closes #6