### PR TITLE
Fix clear_interrupt_pending_bit()

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -97,7 +97,7 @@ pub trait ExtiPin {
     fn trigger_on_edge(&mut self, exti: &mut EXTI, level: Edge);
     fn enable_interrupt(&mut self, exti: &mut EXTI);
     fn disable_interrupt(&mut self, exti: &mut EXTI);
-    fn clear_interrupt_pending_bit(&mut self, exti: &mut EXTI);
+    fn clear_interrupt_pending_bit(&mut self);
 }
 
 macro_rules! gpio {
@@ -279,8 +279,8 @@ macro_rules! gpio {
                 }
 
                 /// Clear the interrupt pending bit for this pin
-                fn clear_interrupt_pending_bit(&mut self, exti: &mut EXTI) {
-                    exti.cpupr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
+                fn clear_interrupt_pending_bit(&mut self) {
+                    unsafe { (*EXTI::ptr()).cpupr1.write(|w| w.bits(1 << self.i) ) };
                 }
             }
 
@@ -702,8 +702,8 @@ macro_rules! gpio {
                     }
 
                     /// Clear the interrupt pending bit for this pin
-                    fn clear_interrupt_pending_bit(&mut self, exti: &mut EXTI) {
-                        exti.cpupr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
+                    fn clear_interrupt_pending_bit(&mut self) {
+                        unsafe { (*EXTI::ptr()).cpupr1.write(|w| w.bits(1 << $i) ) };
                     }
                 }
 


### PR DESCRIPTION
According to RM0433, sec. 19.6.24, a "bit is cleared by writing a 1 into the bit or by changing the sensitivity of the edge detector."

I have not tested nor compiled this on stm32h7xx. However, I found this issue while porting the ExtiPin trait to stm32f1xx. I have tested this change on my stm32f1xx-hal working copy.

See also stm32-rs/stm32f4xx-hal#114