### PR TITLE
Fix invalid docs.rs `targets` syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [".gitignore"]
 
 [package.metadata.docs.rs]
 features = ["stm32h743", "rt"]
-target = "thumbv7em-none-eabihf"
+targets = ["thumbv7em-none-eabihf"]
 
 [dependencies]
 embedded-hal = "0.2.3"


### PR DESCRIPTION
The `target` field does nothing. There are two options you could have been trying to set:

- `default-target`, the target built for the main page (docs.rs/stm32h7xx-hal)
- `targets`, which controls all targets built.

This changes it to the second since I assume `stm32h7xx-hal` is the only target you want to build, but I can change it to the first if you want to build all tier one platforms instead.