### PR TITLE
Minimal requirements for targeting the Cortex-M4 core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
 - MCU=stm32h743v
 - MCU=stm32h753v
 - MCU=stm32h747cm7
+- MCU=stm32h747cm4
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ stm32h743v = ["stm32h7/stm32h743v", "device-selected", "revision_v", "singlecore
 stm32h753v = ["stm32h7/stm32h753v", "device-selected", "revision_v", "singlecore"]
 stm32h750v = ["stm32h7/stm32h743v", "device-selected", "revision_v", "singlecore"]
 stm32h747cm7 = ["stm32h7/stm32h747cm7", "device-selected", "revision_v", "dualcore", "cm7"]
+stm32h747cm4 = ["stm32h7/stm32h747cm4", "device-selected", "revision_v", "dualcore", "cm4"]
 
 
 [profile.dev]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Tell Cargo that if the given file changes, to rerun this build script.
+    println!("cargo:rerun-if-changed=memory.x");
+}

--- a/core1.x
+++ b/core1.x
@@ -1,0 +1,27 @@
+MEMORY
+{
+  /* FLASH and RAM are mandatory memory regions */
+  FLASH0  : ORIGIN = 0x08000000, LENGTH = 1024K
+  FLASH : ORIGIN = 0x08100000, LENGTH = 1024K
+  RAM    : ORIGIN = 0x30020000, LENGTH = 128K /* SRAM2 */
+
+  /* AXISRAM */
+  AXISRAM : ORIGIN = 0x24000000, LENGTH = 512K
+
+  /* SRAM */
+  SRAM1 : ORIGIN = 0x30000000, LENGTH = 128K
+  /* SRAM2: See RAM */
+  SRAM3 : ORIGIN = 0x30040000, LENGTH = 32K
+  SRAM4 : ORIGIN = 0x38000000, LENGTH = 64K
+
+  /* Backup SRAM */
+  BSRAM : ORIGIN = 0x38800000, LENGTH = 4K
+}
+
+/* The location of the stack can be overridden using the
+   `_stack_start` symbol.  Place the stack at the end of RAM */
+_stack_start = ORIGIN(RAM) + LENGTH(RAM);
+
+/* The location of the .text section can be overridden using the
+   `_stext` symbol.  By default it will place after .vector_table */
+/* _stext = ORIGIN(FLASH) + 0x40c; */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,10 @@ pub use stm32h7::stm32h753 as stm32;
 pub use stm32h7::stm32h753v as stm32;
 
 // Dual core
+#[cfg(any(feature = "stm32h747cm4",))]
+pub use stm32h7::stm32h747cm4 as stm32;
 #[cfg(any(feature = "stm32h747cm7",))]
 pub use stm32h7::stm32h747cm7 as stm32;
-#[cfg(any(feature = "stm32h757cm7",))]
-pub use stm32h7::stm32h757cm7 as stm32;
 
 #[cfg(all(feature = "singlecore", feature = "dualcore"))]
 compile_error!("Cannot not select both singlecore and dualcore");


### PR DESCRIPTION
Replace memory.x with core1.x, then build for stm32h747cm4 target