### PR TITLE
A safe interface for the user and other crates to access the RCC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - 1.39.0
+  - 1.40.0
   - stable
   - nightly
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ stm32h7 = "0.10.0"
 void = { version = "1.0.2", default-features = false }
 cast = { version = "0.2.2", default-features = false }
 nb = "0.1.2"
+paste = "0.1.10"
+
 [dependencies.bare-metal]
 version = "0.2.4"
 features = ["const-fn"]

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Board | Manufacturer | BSP / Examples?
 Minimum supported Rust version
 ------------------------------
 
-The minimum supported Rust version at the moment is **1.39.0**. Older
+The minimum supported Rust version at the moment is **1.40.0**. Older
 versions **may** compile, especially when some features are not used
 in your application.
 

--- a/examples/safe_enable_fdcan.rs
+++ b/examples/safe_enable_fdcan.rs
@@ -1,0 +1,36 @@
+#![deny(warnings)]
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+extern crate panic_itm;
+
+use cortex_m_rt::entry;
+use stm32h7xx_hal::rcc::{rec, ResetEnable};
+use stm32h7xx_hal::{pac, prelude::*};
+
+fn enable_fdcan(rec: rec::Fdcan) {
+    rec.enable();
+
+    // rec is dropped here, and can never be changed again
+}
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    let pwr = dp.PWR.constrain();
+    let vos = pwr.freeze();
+
+    // Constrain and Freeze clock
+    let rcc = dp.RCC.constrain();
+    let prec = rcc.take_peripherals().unwrap();
+    let _ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
+
+    enable_fdcan(prec.FDCAN);
+
+    //prec.FDCAN.disable(); // Compile error
+
+    loop {}
+}

--- a/examples/safe_enable_fdcan.rs
+++ b/examples/safe_enable_fdcan.rs
@@ -25,12 +25,11 @@ fn main() -> ! {
 
     // Constrain and Freeze clock
     let rcc = dp.RCC.constrain();
-    let prec = rcc.take_peripherals().unwrap();
-    let _ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
 
-    enable_fdcan(prec.FDCAN);
+    enable_fdcan(ccdr.peripheral.FDCAN);
 
-    //prec.FDCAN.disable(); // Compile error
+    //ccdr.peripheral.FDCAN.disable(); // Compile error
 
     loop {}
 }

--- a/examples/safe_enable_fdcan.rs
+++ b/examples/safe_enable_fdcan.rs
@@ -10,7 +10,7 @@ use stm32h7xx_hal::rcc::{rec, ResetEnable};
 use stm32h7xx_hal::{pac, prelude::*};
 
 fn enable_fdcan(rec: rec::Fdcan) {
-    rec.enable();
+    rec.enable().kernel_clk_mux(rec::FdcanClkSel::PLL1_Q);
 
     // rec is dropped here, and can never be changed again
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(not(test), no_std)]
 #![allow(non_camel_case_types)]
 
+extern crate paste;
+
 #[derive(Debug)]
 pub enum Never {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub use stm32h7::stm32h753v as stm32;
 pub use stm32h7::stm32h747cm7 as stm32;
 #[cfg(any(feature = "stm32h757cm7",))]
 pub use stm32h7::stm32h757cm7 as stm32;
+// TODO(dualcore): soundness of PeripheralREC macro in rcc/rec.rs
 
 #[cfg(all(feature = "singlecore", feature = "dualcore"))]
 compile_error!("Cannot not select both singlecore and dualcore");

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -182,6 +182,8 @@ pub struct Ccdr {
     pub apb4: APB4,
     /// RCC Domain 3 Kernel Clock Configuration Register
     pub d3ccipr: D3CCIPR,
+    /// Peripheral reset / enable / kernel clock control
+    pub peripheral: rec::PeripheralREC,
     // Yes, it lives (locally)! We retain the right to switch most
     // PKSUs on the fly, to fine-tune PLL frequencies, and to enable /
     // reset peripherals.
@@ -845,6 +847,11 @@ impl Rcc {
                 c_ck: Hertz(sys_d1cpre_ck),
             },
             d3ccipr: D3CCIPR { _0: () },
+            peripheral: unsafe {
+                // unsafe: we consume self which was a singleton, hence
+                // we can safely create a singleton here
+                rec::PeripheralREC::new_singleton()
+            },
             rb: self.rb,
         }
     }

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -14,8 +14,9 @@
 //!
 //! # Usage
 //!
-//! This peripheral is must be used alongside the `PWR` peripheral to
-//! freeze voltage scaling of the device.
+//! This peripheral is must be used alongside the
+//! [`PWR`](../pwr/index.html) peripheral to freeze voltage scaling of the
+//! device.
 //!
 //! A builder pattern is used to specify the state and frequency of
 //! possible clocks. The `freeze` method configures the RCC peripheral
@@ -33,16 +34,17 @@
 //!
 //! * `use_hse(a)` implies `sys_ck(a)`
 //!
-//! * `sys_ck(b)` implies `pll1_p_ck(b)` unless `b` equals HSI or `a`
+//! * `sys_ck(b)` implies `pll1_p_ck(b)` unless `b` equals HSI or
+//! `use_hse(b)` was specified
 //!
 //! * `pll1_p_ck(c)` implies `pll1_r_ck(c/2)`, including when
 //! `pll1_p_ck` was implied by `sys_ck(c)`.
 //!
 //! Implied clock specifications can always be overridden by explicitly
-//! specifying that clock. If this results in a configuration that
-//! cannot be achieved by hardware, `freeze` will panic.
+//! specifying that clock. If this results in a configuration that cannot
+//! be achieved by hardware, `freeze` will panic.
 //!
-//! # Example
+//! # Configuration Example
 //!
 //! A simple example:
 //!
@@ -76,6 +78,65 @@
 //!         .freeze(vos, &dp.SYSCFG);
 //! ```
 //!
+//! A much more complex example, indicative of real usage with a
+//! significant fraction of the STM32H7's capabilities.
+//!
+//! ```rust
+//!     let dp = pac::Peripherals::take().unwrap();
+//!
+//!     let pwr = dp.PWR.constrain();
+//!     let vos = pwr.freeze();
+//!
+//!     let rcc = dp.RCC.constrain();
+//!     let mut ccdr = rcc
+//!         .use_hse(25.mhz()) // XTAL X1
+//!         .sys_ck(400.mhz())
+//!         .pll1_r_ck(100.mhz()) // for TRACECK
+//!         .pll1_q_ck(200.mhz())
+//!         .hclk(200.mhz())
+//!         .pll3_strategy(PllConfigStrategy::Iterative)
+//!         .pll3_p_ck(240.mhz()) // for LTDC
+//!         .pll3_q_ck(48.mhz()) // for LTDC
+//!         .pll3_r_ck(26_666_667.hz()) // Pixel clock for LTDC
+//!         .freeze(vos, &dp.SYSCFG);
+//!```
+//!
+//! # Peripherals
+//!
+//! The `freeze()` method returns a [Core Clocks Distribution and Reset
+//! (CCDR)](struct.Ccdr.html) object. This singleton tells you how the core
+//! clocks were actually configured (in
+//! [CoreClocks](struct.CoreClocks.html)) and allows you to configure the
+//! remaining peripherals (see [PeripheralREC](struct.PeripheralREC.html)).
+//!
+//!```rust
+//! let ccdr = ...; // Returned by `freeze()`, see examples above
+//!
+//! // Runtime confirmation that hclk really is 200MHz
+//! assert_eq!(ccdr.clocks.hclk().0, 200_000_000);
+//!
+//! // Panics if pll1_q_ck is not running
+//! let _ = ccdr.clocks.pll1_q_ck().unwrap();
+//!
+//! // Enable the clock to a peripheral and reset it
+//! ccdr.peripheral.FDCAN.enable().reset();
+//!```
+//!
+//! The [PeripheralREC](struct.PeripheralREC.html) members implement move
+//! semantics, so once you have passed them to a constructor they cannot be
+//! modified again in safe Rust.
+//!
+//!```rust
+//! // Constructor for custom FDCAN driver
+//! my_fdcan(dp.FDCAN,
+//!          &ccdr.clocks,         // Immutable reference to core clock state
+//!          ccdr.peripheral.FDCAN // Ownership of reset + enable control
+//! );
+//!
+//! // Compile error, value was moved ^^
+//! ccdr.peripheral.FDCAN.disable();
+//!```
+//!
 #![deny(missing_docs)]
 
 use crate::pwr::VoltageScale as Voltage;
@@ -93,7 +154,7 @@ pub mod rec;
 
 pub use core_clocks::CoreClocks;
 pub use pll::{PllConfig, PllConfigStrategy};
-pub use rec::ResetEnable;
+pub use rec::{PeripheralREC, ResetEnable};
 
 /// Configuration of the core clocks
 pub struct Config {
@@ -183,7 +244,7 @@ pub struct Ccdr {
     /// RCC Domain 3 Kernel Clock Configuration Register
     pub d3ccipr: D3CCIPR,
     /// Peripheral reset / enable / kernel clock control
-    pub peripheral: rec::PeripheralREC,
+    pub peripheral: PeripheralREC,
     // Yes, it lives (locally)! We retain the right to switch most
     // PKSUs on the fly, to fine-tune PLL frequencies, and to enable /
     // reset peripherals.
@@ -850,7 +911,7 @@ impl Rcc {
             peripheral: unsafe {
                 // unsafe: we consume self which was a singleton, hence
                 // we can safely create a singleton here
-                rec::PeripheralREC::new_singleton()
+                PeripheralREC::new_singleton()
             },
             rb: self.rb,
         }

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -89,9 +89,11 @@ use crate::time::Hertz;
 
 mod core_clocks;
 mod pll;
+pub mod rec;
 
 pub use core_clocks::CoreClocks;
 pub use pll::{PllConfig, PllConfigStrategy};
+pub use rec::ResetEnable;
 
 /// Configuration of the core clocks
 pub struct Config {

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -40,7 +40,11 @@ impl Rcc {
 
 macro_rules! peripheral_reset_and_enable_control {
     ($($AXBn:ident, $axb_doc:expr => [
-        $( $p:ident $(kernel$(($Variant:ident))* $ccip:ident $clk_doc:expr)* ),*
+        $(
+            $( #[ $pmeta:meta ] )*
+                $p:ident
+            $( kernel$(($Variant:ident))* $ccip:ident $clk_doc:expr )*
+        ),*
     ];)+) => {
         paste::item! {
             /// Peripheral Reset and Enable Control
@@ -49,6 +53,7 @@ macro_rules! peripheral_reset_and_enable_control {
                 $(
                     $(
                         #[allow(missing_docs)]
+                        $( #[ $pmeta ] )*
                         pub [< $p:upper >]: $p,
                     )*
                 )+
@@ -70,6 +75,7 @@ macro_rules! peripheral_reset_and_enable_control {
                     PeripheralREC {
                         $(
                             $(
+                                $( #[ $pmeta ] )*
                                 [< $p:upper >]: $p {
                                     _marker: PhantomData,
                                 },
@@ -82,10 +88,13 @@ macro_rules! peripheral_reset_and_enable_control {
             $(
                 $(
                     /// Owned ability to Reset, Enable and Disable peripheral
+                    $( #[ $pmeta ] )*
                     pub struct $p {
                         _marker: PhantomData<*const ()>,
                     }
+                    $( #[ $pmeta ] )*
                     unsafe impl Send for $p {}
+                    $( #[ $pmeta ] )*
                     impl ResetEnable for $p {
                         #[inline(always)]
                         fn enable(self) -> Self {
@@ -126,6 +135,7 @@ macro_rules! peripheral_reset_and_enable_control {
                             self
                         }
                     }
+                    $( #[ $pmeta ] )*
                     impl $p {
                         $(
                             #[inline(always)]
@@ -186,10 +196,10 @@ macro_rules! variant_return_type {
 }
 
 // Must only contain peripherals that are not used anywhere in this HAL
-#[cfg(any(feature = "singlecore"))]
 peripheral_reset_and_enable_control! {
     AHB1, "AMBA High-performance Bus (AHB1) peripherals" => [
-        Eth1Mac, Dma2, Dma1
+        Eth1Mac, Dma2, Dma1,
+        #[cfg(any(feature = "dualcore"))] Art
     ];
     AHB2, "AMBA High-performance Bus (AHB2) peripherals" => [
         Sdmmc2, Hash, Crypt
@@ -204,49 +214,11 @@ peripheral_reset_and_enable_control! {
         Hsem, Bdma, Crc
     ];
     APB1L, "Advanced Peripheral Bus 1L (APB1L) peripherals" => [
-        Dac12, Cec
+        Dac12,
+        #[cfg(any(feature = "singlecore"))] Cec // TODO remove gate
     ];
     APB1H, "Advanced Peripheral Bus 1H (APB1H) peripherals" => [
         Fdcan kernel(Variant) d2ccip1 "FDCAN kernel clock source selection",
-        Swp kernel d2ccip1 "SWPMI kernel clock source selection",
-        Crs, Mdios, Opamp
-    ];
-    APB2, "Advanced Peripheral Bus 2 (APB2) peripherals" => [
-        Hrtim,
-        Dfsdm1 kernel d2ccip1 "DFSDM1 kernel Clk source selection"
-    ];
-    APB3, "Advanced Peripheral Bus 3 (APB3) peripherals" => [
-        Ltdc
-    ];
-    APB4, "Advanced Peripheral Bus 4 (APB4) peripherals" => [
-        Vref, Comp12
-    ];
-}
-
-// Must only contain peripherals that are not used anywhere in this HAL
-#[cfg(any(feature = "dualcore"))]
-peripheral_reset_and_enable_control! {
-    AHB1, "AMBA High-performance Bus (AHB1) peripherals" => [
-        Eth1Mac, Dma2, Dma1, Art
-    ];
-    AHB2, "AMBA High-performance Bus (AHB2) peripherals" => [
-        Sdmmc2, Hash, Crypt
-    ];
-    AHB3, "AMBA High-performance Bus (AHB3) peripherals" => [
-        Sdmmc1,
-        Qspi kernel d1ccip "QUADSPI kernel clock source selection",
-        Fmc kernel d1ccip "FMC kernel clock source selection",
-        Jpgdec, Dma2d, Mdma
-    ];
-    AHB4, "AMBA High-performance Bus (AHB4) peripherals" => [
-        Hsem, Bdma, Crc
-    ];
-    APB1L, "Advanced Peripheral Bus 1L (APB1L) peripherals" => [
-        Dac12
-        // HdmiCec TODO
-    ];
-    APB1H, "Advanced Peripheral Bus 1H (APB1H) peripherals" => [
-        Fdcan kernel d2ccip1 "FDCAN kernel clock source selection",
         Swp kernel d2ccip1 "SWPMI kernel clock source selection",
         Crs, Mdios, Opamp
     ];

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -80,37 +80,44 @@ macro_rules! peripheral_reset_and_enable_control {
                     pub struct $p {
                         _marker: PhantomData<*const ()>,
                     }
+                    unsafe impl Send for $p {}
                     impl ResetEnable for $p {
                         #[inline(always)]
                         fn enable(self) -> Self {
                             // unsafe: Owned exclusive access to this bitfield
-                            let enr = unsafe {
-                                &(*RCC::ptr()).[< $AXBn:lower enr >]
-                            };
-                            enr.modify(|_, w| w.
-                                       [< $p:lower en >]().set_bit());
+                            interrupt::free(|_| {
+                                let enr = unsafe {
+                                    &(*RCC::ptr()).[< $AXBn:lower enr >]
+                                };
+                                enr.modify(|_, w| w.
+                                           [< $p:lower en >]().set_bit());
+                            });
                             self
                         }
                         #[inline(always)]
                         fn disable(self) -> Self {
                             // unsafe: Owned exclusive access to this bitfield
-                            let enr = unsafe {
-                                &(*RCC::ptr()).[< $AXBn:lower enr >]
-                            };
-                            enr.modify(|_, w| w.
-                                       [< $p:lower en >]().clear_bit());
+                            interrupt::free(|_| {
+                                let enr = unsafe {
+                                    &(*RCC::ptr()).[< $AXBn:lower enr >]
+                                };
+                                enr.modify(|_, w| w.
+                                           [< $p:lower en >]().clear_bit());
+                            });
                             self
                         }
                         #[inline(always)]
                         fn reset(self) -> Self {
                             // unsafe: Owned exclusive access to this bitfield
-                            let rstr = unsafe {
-                                &(*RCC::ptr()).[< $AXBn:lower rstr >]
-                            };
-                            rstr.modify(|_, w| w.
-                                        [< $p:lower rst >]().set_bit());
-                            rstr.modify(|_, w| w.
-                                        [< $p:lower rst >]().clear_bit());
+                            interrupt::free(|_| {
+                                let rstr = unsafe {
+                                    &(*RCC::ptr()).[< $AXBn:lower rstr >]
+                                };
+                                rstr.modify(|_, w| w.
+                                            [< $p:lower rst >]().set_bit());
+                                rstr.modify(|_, w| w.
+                                            [< $p:lower rst >]().clear_bit());
+                            });
                             self
                         }
                     }
@@ -128,11 +135,13 @@ macro_rules! peripheral_reset_and_enable_control {
                             /// RM0433 Section 8.5.10
                             pub fn kernel_clk_mux(self, sel: [< $p ClkSel >]) -> Self {
                                 // unsafe: Owned exclusive access to this bitfield
-                                let ccip = unsafe {
-                                    &(*RCC::ptr()).[< $ccip r >]
-                                };
-                                ccip.modify(|_, w| w.
-                                            [< $p:lower sel >]().variant(sel));
+                                interrupt::free(|_| {
+                                    let ccip = unsafe {
+                                        &(*RCC::ptr()).[< $ccip r >]
+                                    };
+                                    ccip.modify(|_, w| w.
+                                                [< $p:lower sel >]().variant(sel));
+                                });
                                 self
                             }
                         )*

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -64,7 +64,7 @@ macro_rules! peripheral_reset_and_enable_control {
         $(
             $( #[ $pmeta:meta ] )*
                 $p:ident
-            $( kernel$(($Variant:ident))* $ccip:ident $clk_doc:expr )*
+            $( kernel_clk: $(($Variant:ident))* $ccip:ident $clk_doc:expr )*
         ),*
     ];)+) => {
         paste::item! {
@@ -227,8 +227,8 @@ peripheral_reset_and_enable_control! {
     ];
     AHB3, "AMBA High-performance Bus (AHB3) peripherals" => [
         Sdmmc1,
-        Qspi kernel d1ccip "QUADSPI kernel clock source selection",
-        Fmc kernel d1ccip "FMC kernel clock source selection",
+        Qspi kernel_clk: d1ccip "QUADSPI kernel clock source selection",
+        Fmc kernel_clk: d1ccip "FMC kernel clock source selection",
         Jpgdec, Dma2d, Mdma
     ];
     AHB4, "AMBA High-performance Bus (AHB4) peripherals" => [
@@ -239,13 +239,13 @@ peripheral_reset_and_enable_control! {
         #[cfg(any(feature = "singlecore"))] Cec // TODO remove gate
     ];
     APB1H, "Advanced Peripheral Bus 1H (APB1H) peripherals" => [
-        Fdcan kernel(Variant) d2ccip1 "FDCAN kernel clock source selection",
-        Swp kernel d2ccip1 "SWPMI kernel clock source selection",
+        Fdcan kernel_clk: (Variant) d2ccip1 "FDCAN kernel clock source selection",
+        Swp kernel_clk: d2ccip1 "SWPMI kernel clock source selection",
         Crs, Mdios, Opamp
     ];
     APB2, "Advanced Peripheral Bus 2 (APB2) peripherals" => [
         Hrtim,
-        Dfsdm1 kernel d2ccip1 "DFSDM1 kernel Clk source selection"
+        Dfsdm1 kernel_clk: d2ccip1 "DFSDM1 kernel Clk source selection"
     ];
     APB3, "Advanced Peripheral Bus 3 (APB3) peripherals" => [
         Ltdc

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -163,10 +163,11 @@ macro_rules! peripheral_reset_and_enable_control {
     }
 }
 
-// Must only contain periperhals that are not used anywhere in this HAL
+// Must only contain peripherals that are not used anywhere in this HAL
+#[cfg(any(feature = "singlecore"))]
 peripheral_reset_and_enable_control! {
     AHB1, "AMBA High-performance Bus (AHB1) peripherals" => [
-        Eth1Mac, Art, Dma2, Dma1
+        Eth1Mac, Dma2, Dma1
     ];
     AHB2, "AMBA High-performance Bus (AHB2) peripherals" => [
         Sdmmc2, Hash, Crypt
@@ -181,7 +182,46 @@ peripheral_reset_and_enable_control! {
         Hsem, Bdma, Crc
     ];
     APB1L, "Advanced Peripheral Bus 1L (APB1L) peripherals" => [
-        Dac12, HdmiCec
+        Dac12, Cec
+    ];
+    APB1H, "Advanced Peripheral Bus 1H (APB1H) peripherals" => [
+        Fdcan kernel d2ccip1 "FDCAN kernel clock source selection",
+        Swp kernel d2ccip1 "SWPMI kernel clock source selection",
+        Crs, Mdios, Opamp
+    ];
+    APB2, "Advanced Peripheral Bus 2 (APB2) peripherals" => [
+        Hrtim,
+        Dfsdm1 kernel d2ccip1 "DFSDM1 kernel Clk source selection"
+    ];
+    APB3, "Advanced Peripheral Bus 3 (APB3) peripherals" => [
+        Ltdc
+    ];
+    APB4, "Advanced Peripheral Bus 4 (APB4) peripherals" => [
+        Vref, Comp12
+    ];
+}
+
+// Must only contain peripherals that are not used anywhere in this HAL
+#[cfg(any(feature = "dualcore"))]
+peripheral_reset_and_enable_control! {
+    AHB1, "AMBA High-performance Bus (AHB1) peripherals" => [
+        Eth1Mac, Dma2, Dma1, Art
+    ];
+    AHB2, "AMBA High-performance Bus (AHB2) peripherals" => [
+        Sdmmc2, Hash, Crypt
+    ];
+    AHB3, "AMBA High-performance Bus (AHB3) peripherals" => [
+        Sdmmc1,
+        Qspi kernel d1ccip "QUADSPI kernel clock source selection",
+        Fmc kernel d1ccip "FMC kernel clock source selection",
+        Jpgdec, Dma2d, Mdma
+    ];
+    AHB4, "AMBA High-performance Bus (AHB4) peripherals" => [
+        Hsem, Bdma, Crc
+    ];
+    APB1L, "Advanced Peripheral Bus 1L (APB1L) peripherals" => [
+        Dac12
+        // HdmiCec TODO
     ];
     APB1H, "Advanced Peripheral Bus 1H (APB1H) peripherals" => [
         Fdcan kernel d2ccip1 "FDCAN kernel clock source selection",

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -42,7 +42,6 @@ macro_rules! peripheral_reset_and_enable_control {
     ];)+) => {
         paste::item! {
             /// Peripheral Reset and Enable Control
-            #[non_exhaustive]
             #[allow(non_snake_case)]
             pub struct PeripheralsREC {
                 $(
@@ -51,6 +50,11 @@ macro_rules! peripheral_reset_and_enable_control {
                         pub [< $p:upper >]: $p,
                     )*
                 )+
+
+                // Private field making `Peripherals` non-exhaustive. We
+                // don't use `#[non_exhaustive]` so we can support older
+                // Rust versions.
+                _priv: (),
             }
             impl Rcc {
                 /// Unchecked version of `PeripheralsREC::take`
@@ -66,6 +70,7 @@ macro_rules! peripheral_reset_and_enable_control {
                                 },
                             )*
                         )+
+                            _priv: (),
                     }
                 }
             }

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -1,4 +1,25 @@
-//! Peripheral Reset and Enable Control
+//! Peripheral Reset and Enable Control (REC)
+//!
+//! This module contains safe accessors to the RCC functionality for each
+//! periperal.
+//!
+//! At a minimum each peripheral implements
+//! [ResetEnable](trait.ResetEnable.html). Additionally those peripherals
+//! that have a multiplexer in the PKSU may also have methods
+//! `kernel_clk_mux` and `get_kernel_clk_mux`. These set and get the state
+//! of the kernel clock multiplexer respectively.
+//!
+//! # Example
+//!
+//! ```
+//! // Constrain and Freeze power
+//! ...
+//! let rcc = dp.RCC.constrain();
+//! let ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
+//!
+//! // Enable the clock to a peripheral and reset it
+//! ccdr.peripheral.FDCAN.enable().reset();
+//! ```
 #![deny(missing_docs)]
 
 use core::marker::PhantomData;

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -70,6 +70,7 @@ macro_rules! peripheral_reset_and_enable_control {
         paste::item! {
             /// Peripheral Reset and Enable Control
             #[allow(non_snake_case)]
+            #[non_exhaustive]
             pub struct PeripheralREC {
                 $(
                     $(
@@ -78,11 +79,6 @@ macro_rules! peripheral_reset_and_enable_control {
                         pub [< $p:upper >]: $p,
                     )*
                 )+
-
-                // Private field making `Peripherals` non-exhaustive. We
-                // don't use `#[non_exhaustive]` so we can support older
-                // Rust versions.
-                _priv: (),
             }
             impl PeripheralREC {
                 /// Return a new instance of the peripheral resets /
@@ -102,7 +98,6 @@ macro_rules! peripheral_reset_and_enable_control {
                                 },
                             )*
                         )+
-                            _priv: (),
                     }
                 }
             }

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -46,7 +46,7 @@ macro_rules! peripheral_reset_and_enable_control {
                 $(
                     $(
                         #[allow(missing_docs)]
-                        pub [<$p:upper>]: $p,
+                        pub [< $p:upper >]: $p,
                     )*
                 )+
             }
@@ -59,7 +59,7 @@ macro_rules! peripheral_reset_and_enable_control {
                     PeripheralsREC {
                         $(
                             $(
-                                [<$p:upper>]: $p {
+                                [< $p:upper >]: $p {
                                     _marker: PhantomData,
                                 },
                             )*
@@ -78,32 +78,32 @@ macro_rules! peripheral_reset_and_enable_control {
                         fn enable(self) -> Self {
                             // unsafe: Owned exclusive access to this bitfield
                             let enr = unsafe {
-                                &(*RCC::ptr()).[<$AXBn:lower enr>]
+                                &(*RCC::ptr()).[< $AXBn:lower enr >]
                             };
                             enr.modify(|_, w| w.
-                                       [<$p:lower en>]().set_bit());
+                                       [< $p:lower en >]().set_bit());
                             self
                         }
                         #[inline(always)]
                         fn disable(self) -> Self {
                             // unsafe: Owned exclusive access to this bitfield
                             let enr = unsafe {
-                                &(*RCC::ptr()).[<$AXBn:lower enr>]
+                                &(*RCC::ptr()).[< $AXBn:lower enr >]
                             };
                             enr.modify(|_, w| w.
-                                       [<$p:lower en>]().clear_bit());
+                                       [< $p:lower en >]().clear_bit());
                             self
                         }
                         #[inline(always)]
                         fn reset(self) -> Self {
                             // unsafe: Owned exclusive access to this bitfield
                             let rstr = unsafe {
-                                &(*RCC::ptr()).[<$AXBn:lower rstr>]
+                                &(*RCC::ptr()).[< $AXBn:lower rstr >]
                             };
                             rstr.modify(|_, w| w.
-                                        [<$p:lower rst>]().set_bit());
+                                        [< $p:lower rst >]().set_bit());
                             rstr.modify(|_, w| w.
-                                        [<$p:lower rst>]().clear_bit());
+                                        [< $p:lower rst >]().clear_bit());
                             self
                         }
                     }


### PR DESCRIPTION
Safe access to enable, disable and reset peripherals that are not used in this hal.

Uses a macro with https://github.com/dtolnay/paste for brevity.

From discussion on #66 