### PR TITLE
Use marker types for Reset / Enable of peripherals within the crate also

### DIFF
--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -29,13 +29,13 @@ fn main() -> ! {
     // Constrain and Freeze clock
     println!(log, "Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let mut ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
 
     println!(log, "");
     println!(log, "stm32h7xx-hal example - Blinky");
     println!(log, "");
 
-    let gpioe = dp.GPIOE.split(&mut ccdr.ahb4);
+    let gpioe = dp.GPIOE.split(ccdr.peripheral.GPIOE);
 
     // Configure PE1 as output.
     let mut led = gpioe.pe1.into_push_pull_output();

--- a/examples/blinky_random.rs
+++ b/examples/blinky_random.rs
@@ -29,13 +29,13 @@ fn main() -> ! {
     // Constrain and Freeze clock
     println!(log, "Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let mut ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
 
     println!(log, "");
     println!(log, "stm32h7xx-hal example - Random Blinky");
     println!(log, "");
 
-    let gpioe = dp.GPIOE.split(&mut ccdr.ahb4);
+    let gpioe = dp.GPIOE.split(ccdr.peripheral.GPIOE);
 
     // Configure PE1 as output.
     let mut led = gpioe.pe1.into_push_pull_output();
@@ -44,7 +44,7 @@ fn main() -> ! {
     let mut delay = cp.SYST.delay(ccdr.clocks);
 
     // Get true random number generator
-    let mut rng = dp.RNG.constrain(&mut ccdr);
+    let mut rng = dp.RNG.constrain(ccdr.peripheral.RNG, &ccdr.clocks);
     let mut random_bytes = [0u16; 3];
     match rng.fill(&mut random_bytes) {
         Ok(()) => println!(log, "random bytes: {:?}", random_bytes),

--- a/examples/blinky_timer.rs
+++ b/examples/blinky_timer.rs
@@ -32,13 +32,13 @@ fn main() -> ! {
     // Constrain and Freeze clock
     println!(log, "Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let mut ccdr = rcc.freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.freeze(vos, &dp.SYSCFG);
 
     println!(log, "");
     println!(log, "stm32h7xx-hal example - Blinky timer");
     println!(log, "");
 
-    let gpioe = dp.GPIOE.split(&mut ccdr.ahb4);
+    let gpioe = dp.GPIOE.split(ccdr.peripheral.GPIOE);
 
     // Configure PE1 as output.
     let mut led = gpioe.pe1.into_push_pull_output();
@@ -48,7 +48,7 @@ fn main() -> ! {
     let mut delay = cp.SYST.delay(ccdr.clocks);
 
     // Configure the timer.
-    let mut timer = dp.TIM2.timer(1.hz(), &mut ccdr);
+    let mut timer = dp.TIM2.timer(1.hz(), ccdr.peripheral.TIM2, &ccdr.clocks);
 
     loop {
         for _ in 0..5 {

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -26,19 +26,20 @@ fn main() -> ! {
     // Constrain and Freeze clock
     println!(log, "Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let mut ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
-    let gpiob = dp.GPIOB.split(&mut ccdr.ahb4);
+    let ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
+    let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
 
     // Configure the SCL and the SDA pin for our I2C bus
     let scl = gpiob.pb8.into_alternate_af4().set_open_drain();
     let sda = gpiob.pb9.into_alternate_af4().set_open_drain();
 
-    let mut i2c = dp.I2C1.i2c((scl, sda), 100.khz(), &ccdr);
+    // let mut i2c = dp.I2C1.i2c((scl, sda), 100.khz(), &ccdr);
 
-    // Echo what is received on the I2C at register 0x60
-    let mut buf = [0x60];
-    loop {
-        buf[0] = 0x11;
-        i2c.write_read(0x76, &buf.clone(), &mut buf).unwrap();
-    }
+    // // Echo what is received on the I2C at register 0x60
+    // let mut buf = [0x60];
+    // loop {
+    //     buf[0] = 0x11;
+    //     i2c.write_read(0x76, &buf.clone(), &mut buf).unwrap();
+    // }
+    loop {}
 }

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -33,13 +33,14 @@ fn main() -> ! {
     let scl = gpiob.pb8.into_alternate_af4().set_open_drain();
     let sda = gpiob.pb9.into_alternate_af4().set_open_drain();
 
-    // let mut i2c = dp.I2C1.i2c((scl, sda), 100.khz(), &ccdr);
+    let mut i2c =
+        dp.I2C1
+            .i2c((scl, sda), 100.khz(), ccdr.peripheral.I2C1, &ccdr.clocks);
 
-    // // Echo what is received on the I2C at register 0x60
-    // let mut buf = [0x60];
-    // loop {
-    //     buf[0] = 0x11;
-    //     i2c.write_read(0x76, &buf.clone(), &mut buf).unwrap();
-    // }
-    loop {}
+    // Echo what is received on the I2C at register 0x60
+    let mut buf = [0x60];
+    loop {
+        buf[0] = 0x11;
+        i2c.write_read(0x76, &buf.clone(), &mut buf).unwrap();
+    }
 }

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -29,11 +29,11 @@ fn main() -> ! {
     // Constrain and Freeze clock
     println!(log, "Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let mut ccdr = rcc.sys_ck(8.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(8.mhz()).freeze(vos, &dp.SYSCFG);
 
     // Acquire the GPIOE peripheral. This also enables the clock for
     // GPIOE in the RCC register.
-    let gpioa = dp.GPIOA.split(&mut ccdr.ahb4);
+    let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
 
     // Select PWM output pins
     let pins = (
@@ -47,7 +47,9 @@ fn main() -> ! {
     println!(log, "");
 
     // Configure PWM at 10kHz
-    let (mut pwm, ..) = dp.TIM1.pwm(pins, 10.khz(), &mut ccdr);
+    let (mut pwm, ..) =
+        dp.TIM1
+            .pwm(pins, 10.khz(), ccdr.peripheral.TIM1, &ccdr.clocks);
 
     // Output PWM on PA8
     let max = pwm.get_max_duty();

--- a/examples/rtfm.rs
+++ b/examples/rtfm.rs
@@ -28,14 +28,14 @@ const APP: () = {
 
         // RCC
         let rcc = ctx.device.RCC.constrain();
-        let mut ccdr = rcc
+        let ccdr = rcc
             .use_hse(25.mhz())
             .sys_ck(400.mhz())
             .freeze(vos, &ctx.device.SYSCFG);
 
         // GPIO
-        let gpioc = ctx.device.GPIOC.split(&mut ccdr.ahb4);
-        let gpioi = ctx.device.GPIOI.split(&mut ccdr.ahb4);
+        let gpioc = ctx.device.GPIOC.split(ccdr.peripheral.GPIOC);
+        let gpioi = ctx.device.GPIOI.split(ccdr.peripheral.GPIOI);
 
         // Button
         let mut button = gpioc.pc13.into_floating_input();

--- a/examples/rtfm_timers.rs
+++ b/examples/rtfm_timers.rs
@@ -36,26 +36,40 @@ const APP: () = {
 
         // RCC
         let rcc = ctx.device.RCC.constrain();
-        let mut ccdr = rcc
+        let ccdr = rcc
             .use_hse(25.mhz())
             .sys_ck(400.mhz())
             .freeze(vos, &ctx.device.SYSCFG);
 
         // Timers
-        let mut timer1 = ctx.device.TIM1.timer(125.ms(), &mut ccdr);
+        let mut timer1 =
+            ctx.device
+                .TIM1
+                .timer(125.ms(), ccdr.peripheral.TIM1, &ccdr.clocks);
         timer1.listen(Event::TimeOut);
 
-        let mut timer2 = ctx.device.TIM2.timer(250.ms(), &mut ccdr);
+        let mut timer2 =
+            ctx.device
+                .TIM2
+                .timer(250.ms(), ccdr.peripheral.TIM2, &ccdr.clocks);
         timer2.listen(Event::TimeOut);
 
-        let mut timer3 = ctx.device.TIM12.timer(500.ms(), &mut ccdr);
+        let mut timer3 = ctx.device.TIM12.timer(
+            500.ms(),
+            ccdr.peripheral.TIM12,
+            &ccdr.clocks,
+        );
         timer3.listen(Event::TimeOut);
 
-        let mut timer4 = ctx.device.TIM17.timer(1000.ms(), &mut ccdr);
+        let mut timer4 = ctx.device.TIM17.timer(
+            1000.ms(),
+            ccdr.peripheral.TIM17,
+            &ccdr.clocks,
+        );
         timer4.listen(Event::TimeOut);
 
         // GPIO
-        let gpioi = ctx.device.GPIOI.split(&mut ccdr.ahb4);
+        let gpioi = ctx.device.GPIOI.split(ccdr.peripheral.GPIOI);
 
         init::LateResources {
             timer1,

--- a/examples/sai_pdm.rs
+++ b/examples/sai_pdm.rs
@@ -30,15 +30,15 @@ fn main() -> ! {
     // Constrain and Freeze clock
     println!(log, "Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let mut ccdr = rcc
+    let ccdr = rcc
         .sys_ck(100.mhz())
         .pll1_q_ck(20_480.khz()) // SAI1 clock source
         .freeze(vos, &dp.SYSCFG);
 
     // Acquire GPIO peripherals. This also enables the clock for each
     // GPIO in the RCC register.
-    let gpioc = dp.GPIOC.split(&mut ccdr.ahb4);
-    let gpioe = dp.GPIOE.split(&mut ccdr.ahb4);
+    let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
+    let gpioe = dp.GPIOE.split(ccdr.peripheral.GPIOE);
 
     let d1 = gpioc.pc1.into_alternate_af2();
     let ck1 = gpioe.pe2.into_alternate_af2();
@@ -49,7 +49,9 @@ fn main() -> ! {
     println!(log, "");
 
     // Configure SAI for PDM mode
-    let mut sai = dp.SAI1.pdm(pins, 1_024.khz(), &mut ccdr);
+    let mut sai =
+        dp.SAI1
+            .pdm(pins, 1_024.khz(), ccdr.peripheral.SAI1, &ccdr.clocks);
 
     loop {
         println!(log, "0x{:04x}", 0xFFFF & block!(sai.read_data()).unwrap());

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -32,11 +32,11 @@ fn main() -> ! {
     // Constrain and Freeze clock
     println!(log, "Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let mut ccdr = rcc.sys_ck(160.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(160.mhz()).freeze(vos, &dp.SYSCFG);
 
     // Acquire the GPIOC peripheral. This also enables the clock for
     // GPIOC in the RCC register.
-    let gpioc = dp.GPIOC.split(&mut ccdr.ahb4);
+    let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
 
     let tx = gpioc.pc10.into_alternate_af7();
     let rx = gpioc.pc11.into_alternate_af7();
@@ -48,7 +48,12 @@ fn main() -> ! {
     // Configure the serial peripheral.
     let serial = dp
         .USART3
-        .usart((tx, rx), serial::config::Config::default(), &mut ccdr)
+        .usart(
+            (tx, rx),
+            serial::config::Config::default(),
+            ccdr.peripheral.USART3,
+            &ccdr.clocks,
+        )
         .unwrap();
 
     let (mut tx, mut rx) = serial.split();

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -30,14 +30,14 @@ fn main() -> ! {
     // Constrain and Freeze clock
     println!(log, "Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let mut ccdr = rcc
+    let ccdr = rcc
         .sys_ck(96.mhz())
         .pll1_q_ck(48.mhz())
         .freeze(vos, &dp.SYSCFG);
 
     // Acquire the GPIOC peripheral. This also enables the clock for
     // GPIOC in the RCC register.
-    let gpioc = dp.GPIOC.split(&mut ccdr.ahb4);
+    let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
 
     let sck = gpioc.pc10.into_alternate_af6();
     let miso = gpioc.pc11.into_alternate_af6();
@@ -47,18 +47,19 @@ fn main() -> ! {
     println!(log, "stm32h7xx-hal example - SPI");
     println!(log, "");
 
-    // Initialise the SPI peripheral.
-    let mut spi =
-        dp.SPI3
-            .spi((sck, miso, mosi), spi::MODE_0, 3.mhz(), &mut ccdr);
+    // // Initialise the SPI peripheral.
+    // let mut spi =
+    //     dp.SPI3
+    //         .spi((sck, miso, mosi), spi::MODE_0, 3.mhz(), &mut ccdr);
 
-    // Write fixed data
-    spi.write(&[0x11u8, 0x22, 0x33]).unwrap();
+    // // Write fixed data
+    // spi.write(&[0x11u8, 0x22, 0x33]).unwrap();
 
-    // Echo what is received on the SPI
-    let mut received = 0;
-    loop {
-        block!(spi.send(received)).ok();
-        received = block!(spi.read()).unwrap();
-    }
+    // // Echo what is received on the SPI
+    // let mut received = 0;
+    // loop {
+    //     block!(spi.send(received)).ok();
+    //     received = block!(spi.read()).unwrap();
+    // }
+    loop {}
 }

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -47,19 +47,22 @@ fn main() -> ! {
     println!(log, "stm32h7xx-hal example - SPI");
     println!(log, "");
 
-    // // Initialise the SPI peripheral.
-    // let mut spi =
-    //     dp.SPI3
-    //         .spi((sck, miso, mosi), spi::MODE_0, 3.mhz(), &mut ccdr);
+    // Initialise the SPI peripheral.
+    let mut spi = dp.SPI3.spi(
+        (sck, miso, mosi),
+        spi::MODE_0,
+        3.mhz(),
+        ccdr.peripheral.SPI3,
+        &ccdr.clocks,
+    );
 
-    // // Write fixed data
-    // spi.write(&[0x11u8, 0x22, 0x33]).unwrap();
+    // Write fixed data
+    spi.write(&[0x11u8, 0x22, 0x33]).unwrap();
 
-    // // Echo what is received on the SPI
-    // let mut received = 0;
-    // loop {
-    //     block!(spi.send(received)).ok();
-    //     received = block!(spi.read()).unwrap();
-    // }
-    loop {}
+    // Echo what is received on the SPI
+    let mut received = 0;
+    loop {
+        block!(spi.send(received)).ok();
+        received = block!(spi.read()).unwrap();
+    }
 }

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
     println!(log, "Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
 
-    let mut ccdr = rcc
+    let ccdr = rcc
         .sys_ck(100.mhz())
         .per_ck(4.mhz())
         .freeze(vos, &dp.SYSCFG);
@@ -47,7 +47,8 @@ fn main() -> ! {
     let mut delay = Delay::new(cp.SYST, ccdr.clocks);
 
     // Setup ADC
-    let mut adc3 = adc::Adc::adc3(dp.ADC3, &mut delay, &mut ccdr);
+    let mut adc3 =
+        adc::Adc::adc3(dp.ADC3, &mut delay, ccdr.peripheral.ADC3, &ccdr.clocks);
     adc3.set_resolution(adc::Resolution::SIXTEENBIT);
 
     // Setup Temperature Sensor on the disabled ADC

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -3,6 +3,7 @@ use crate::hal::blocking::delay::DelayUs;
 
 use core::marker::PhantomData;
 
+use crate::stm32;
 use crate::stm32::{ADC1, ADC2, ADC3, ADC3_COMMON};
 
 use crate::delay::Delay;
@@ -14,8 +15,7 @@ use crate::gpio::gpiof::{
 };
 use crate::gpio::gpioh::{PH2, PH3, PH4, PH5};
 use crate::gpio::Analog;
-use crate::rcc::Ccdr;
-use crate::rcc::D3CCIPR;
+use crate::rcc::{rec, CoreClocks, ResetEnable};
 
 #[cfg(not(feature = "revision_v"))]
 const ADC_KER_CK_MAX: u32 = 36_000_000;
@@ -271,53 +271,39 @@ adc_internal!(
 );
 
 pub trait AdcExt<ADC>: Sized {
-    fn adc(self, delay: &mut Delay, ccdr: &mut Ccdr) -> Adc<ADC, Disabled>;
+    type Rec: ResetEnable;
+
+    fn adc(
+        self,
+        delay: &mut Delay,
+        prec: Self::Rec,
+        clocks: &CoreClocks,
+    ) -> Adc<ADC, Disabled>;
 }
 
 /// Stored ADC config can be restored using the `Adc::restore_cfg` method
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct StoredConfig(AdcSampleTime, Resolution, AdcLshift);
 
-impl Adc<ADC1, Disabled> {
-    /// Check the ADC periperal can be safely reset
-    fn is_safe_to_reset(ccdr: &mut Ccdr) -> bool {
-        // Not safe if shared enable with ADC2 already enabled
-        !ccdr.ahb1.enr().read().adc12en().bit_is_set()
-    }
-}
-impl Adc<ADC2, Disabled> {
-    /// Check the ADC periperal can be safely reset
-    fn is_safe_to_reset(ccdr: &mut Ccdr) -> bool {
-        // Not safe if shared enable with ADC1 already enabled
-        !ccdr.ahb1.enr().read().adc12en().bit_is_set()
-    }
-}
-impl Adc<ADC3, Disabled> {
-    /// Check the ADC periperal can be safely reset
-    fn is_safe_to_reset(_ccdr: &mut Ccdr) -> bool {
-        true // Always safe for ADC3
-    }
-}
-
 #[allow(unused_macros)]
 macro_rules! adc_hal {
     ($(
         $ADC:ident: (
             $adcX: ident,
-            $adcxen:ident,
-            $adcxrst:ident,
-            $AHB:ident,
-            $ahb:ident,
+            $Rec:ident,
             $COMMON:ident
         )
     ),+ $(,)*) => {
         $(
             impl AdcExt<$ADC> for $ADC {
+                type Rec = rec::$Rec;
+
 	            fn adc(self,
                        delay: &mut Delay,
-                       ccdr: &mut Ccdr) -> Adc<$ADC, Disabled>
+                       prec: rec::$Rec,
+                       clocks: &CoreClocks) -> Adc<$ADC, Disabled>
 	            {
-	                Adc::$adcX(self, delay, ccdr)
+	                Adc::$adcX(self, delay, prec, clocks)
 	            }
 	        }
 
@@ -326,7 +312,9 @@ macro_rules! adc_hal {
                 ///
                 /// Sets all configurable parameters to one-shot defaults,
                 /// performs a boot-time calibration.
-                pub fn $adcX(adc: $ADC, delay: &mut Delay, ccdr: &mut Ccdr) -> Self {
+                pub fn $adcX(adc: $ADC, delay: &mut Delay,
+                             prec: rec::$Rec, clocks: &CoreClocks
+                ) -> Self {
                     let mut s = Self {
                         rb: adc,
                         sample_time: AdcSampleTime::default(),
@@ -335,27 +323,19 @@ macro_rules! adc_hal {
                         _enabled: PhantomData,
                     };
 
-                    // Some ADCs are not safe to reset, as the ADC
-                    // reset line is shared
-                    let is_safe_to_reset = Self::is_safe_to_reset(ccdr);
-
                     // Select Kernel Clock
                     s.enable_clock(
-                        &mut ccdr.d3ccipr,
-                        ccdr.clocks.per_ck().expect("per_ck is not running!").0,
+                        clocks.per_ck().expect("per_ck is not running!").0
                     );
 
                     // Enable AHB clock
-                    ccdr.$ahb.enr().modify(|_, w| w.$adcxen().set_bit());
+                    let prec = prec.enable();
 
                     // Power Down
                     s.power_down();
 
-                    // Reset
-                    if is_safe_to_reset {
-                        ccdr.$ahb.rstr().modify(|_, w| w.$adcxrst().set_bit());
-                        ccdr.$ahb.rstr().modify(|_, w| w.$adcxrst().clear_bit());
-                    }
+                    // Reset periperal
+                    prec.reset();
 
                     // Power Up, Preconfigure and Calibrate
                     s.power_up(delay);
@@ -365,12 +345,14 @@ macro_rules! adc_hal {
                     s
                 }
 
-                fn enable_clock(&mut self, d3ccipr: &mut D3CCIPR, per_ck: u32) {
+                fn enable_clock(&mut self, per_ck: u32) {
                     // Set per_ck as adc clock, TODO: we might want to
                     // change this so we can also use other clocks as
                     // input for this
                     assert!(per_ck <= ADC_KER_CK_MAX, "per_ck is not running or too fast");
-                    d3ccipr.kernel_ccip().modify(|_, w| unsafe { w.adcsel().bits(0b10) });
+                    let d3ccipr = &unsafe { &*stm32::RCC::ptr() }.d3ccipr;
+
+                    d3ccipr.modify(|_, w| unsafe { w.adcsel().bits(0b10) });
                 }
 
                 /// Disables Deeppowerdown-mode and enables voltage regulator
@@ -730,7 +712,7 @@ macro_rules! adc_hal {
 }
 
 adc_hal!(
-    ADC1: (adc1, adc12en, adc12rst, AHB1, ahb1, ADC12_COMMON),
-    ADC2: (adc2, adc12en, adc12rst, AHB1, ahb1, ADC12_COMMON),
-    ADC3: (adc3, adc3en, adc3rst, AHB4, ahb4, ADC3_COMMON),
+    ADC1: (adc1, Adc12, ADC12_COMMON),
+    ADC2: (adc2, Adc12, ADC12_COMMON),
+    ADC3: (adc3, Adc3, ADC3_COMMON),
 );

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -571,8 +571,8 @@ macro_rules! adc_hal {
             impl<ED> Adc<$ADC, ED> {
 
                 /// Releases the ADC peripheral
-                pub fn free(self) -> $ADC {
-                    self.rb
+                pub fn free(self) -> ($ADC, rec::$Rec) {
+                    (self.rb, rec::$Rec { _marker: PhantomData })
                 }
 
                 /// Save current ADC config

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -8,7 +8,7 @@ use crate::gpio::gpiof::{PF0, PF1, PF14, PF15};
 use crate::gpio::gpioh::{PH11, PH12, PH4, PH5, PH7, PH8};
 use crate::gpio::{Alternate, AF4, AF6};
 use crate::hal::blocking::i2c::{Read, Write, WriteRead};
-use crate::rcc::Ccdr;
+use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::stm32::{I2C1, I2C2, I2C3, I2C4};
 use crate::time::Hertz;
 use cast::{u16, u8};
@@ -51,12 +51,25 @@ pub struct I2c<I2C> {
 }
 
 pub trait I2cExt<I2C>: Sized {
-    fn i2c<PINS, F>(self, _pins: PINS, freq: F, ccdr: &Ccdr) -> I2c<I2C>
+    type Rec: ResetEnable;
+
+    fn i2c<PINS, F>(
+        self,
+        _pins: PINS,
+        freq: F,
+        prec: Self::Rec,
+        clocks: &CoreClocks,
+    ) -> I2c<I2C>
     where
         PINS: Pins<I2C>,
         F: Into<Hertz>;
 
-    fn i2c_unchecked<F>(self, freq: F, ccdr: &Ccdr) -> I2c<I2C>
+    fn i2c_unchecked<F>(
+        self,
+        freq: F,
+        prec: Self::Rec,
+        clocks: &CoreClocks,
+    ) -> I2c<I2C>
     where
         F: Into<Hertz>;
 }
@@ -102,26 +115,25 @@ macro_rules! busy_wait {
 }
 
 macro_rules! i2c {
-    ($($I2CX:ident: ($i2cX:ident, $i2cXen:ident, $i2cXrst:ident, $apbXenr:ident, $apbXrstr:ident, $pclkX:ident),)+) => {
+    ($($I2CX:ident: ($i2cX:ident, $Rec:ident, $pclkX:ident),)+) => {
         $(
             impl I2c<$I2CX> {
                 /// Basically a new function for an I2C peripheral
                 pub fn $i2cX<F> (
                     i2c: $I2CX,
                     freq: F,
-                    ccdr: &Ccdr
+                    prec: rec::$Rec,
+                    clocks: &CoreClocks
                 ) -> Self where
                     F: Into<Hertz>,
                 {
-                    ccdr.rb.$apbXenr.modify(|_, w| w.$i2cXen().set_bit());
-                    ccdr.rb.$apbXrstr.modify(|_, w| w.$i2cXrst().set_bit());
-                    ccdr.rb.$apbXrstr.modify(|_, w| w.$i2cXrst().clear_bit());
+                    prec.enable().reset();
 
                     let freq = freq.into().0;
 
                     assert!(freq <= 1_000_000);
 
-                    let i2cclk = ccdr.clocks.$pclkX().0;
+                    let i2cclk = clocks.$pclkX().0;
 
                     // Clear PE bit in I2C_CR1
                     i2c.cr1.modify(|_, w| w.pe().clear_bit());
@@ -213,19 +225,25 @@ macro_rules! i2c {
             }
 
             impl I2cExt<$I2CX> for $I2CX {
-                fn i2c<PINS, F>(self, _pins: PINS, freq: F, ccdr: &Ccdr) -> I2c<$I2CX>
+                type Rec = rec::$Rec;
+
+                fn i2c<PINS, F>(self, _pins: PINS, freq: F,
+                                prec: rec::$Rec,
+                                clocks: &CoreClocks) -> I2c<$I2CX>
                 where
                     PINS: Pins<$I2CX>,
                     F: Into<Hertz>
                 {
-                    I2c::$i2cX(self, freq, ccdr)
+                    I2c::$i2cX(self, freq, prec, clocks)
                 }
 
-                fn i2c_unchecked<F>(self, freq: F, ccdr: &Ccdr) -> I2c<$I2CX>
+                fn i2c_unchecked<F>(self, freq: F,
+                                    prec: rec::$Rec,
+                                    clocks: &CoreClocks) -> I2c<$I2CX>
                 where
                     F: Into<Hertz>
                 {
-                    I2c::$i2cX(self, freq, ccdr)
+                    I2c::$i2cX(self, freq, prec, clocks)
                 }
             }
 
@@ -464,8 +482,8 @@ pins! {
 }
 
 i2c!(
-    I2C1: (i2c1, i2c1en, i2c1rst, apb1lenr, apb1lrstr, pclk1),
-    I2C2: (i2c2, i2c2en, i2c2rst, apb1lenr, apb1lrstr, pclk1),
-    I2C3: (i2c3, i2c3en, i2c3rst, apb1lenr, apb1lrstr, pclk1),
-    I2C4: (i2c4, i2c4en, i2c4rst, apb4enr, apb4rstr, pclk4),
+    I2C1: (i2c1, I2c1, pclk1),
+    I2C2: (i2c2, I2c2, pclk1),
+    I2C3: (i2c3, I2c3, pclk1),
+    I2C4: (i2c4, I2c4, pclk4),
 );

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,5 +1,7 @@
 //! Inter Integrated Circuit implementation
 
+use core::marker::PhantomData;
+
 use crate::gpio::gpioa::PA8;
 use crate::gpio::gpiob::{PB10, PB11, PB6, PB7, PB8, PB9};
 use crate::gpio::gpioc::PC9;
@@ -219,8 +221,8 @@ macro_rules! i2c {
                 }
 
                 /// Releases the I2C peripheral
-                pub fn free(self) -> $I2CX {
-                    self.i2c
+                pub fn free(self) -> ($I2CX, rec::$Rec) {
+                    (self.i2c, rec::$Rec { _marker: PhantomData })
                 }
             }
 

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -107,7 +107,7 @@ macro_rules! peripheral_reset_and_enable_control {
                     /// Owned ability to Reset, Enable and Disable peripheral
                     $( #[ $pmeta ] )*
                     pub struct $p {
-                        _marker: PhantomData<*const ()>,
+                        pub(crate) _marker: PhantomData<*const ()>,
                     }
                     $( #[ $pmeta ] )*
                     unsafe impl Send for $p {}

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -240,6 +240,8 @@ peripheral_reset_and_enable_control! {
         Dac12,
         Cec,
         Lptim1,
+        I2c1, I2c2, I2c3,
+        Spi2, Spi3,
         Tim2, Tim3, Tim4, Tim5, Tim6, Tim7, Tim12, Tim13, Tim14,
         Usart2, Usart3, Uart4, Uart5, Uart7, Uart8
     ];
@@ -255,6 +257,7 @@ peripheral_reset_and_enable_control! {
         Dfsdm1 kernel_clk: Dfsdm1 d2ccip1 "DFSDM1 kernel Clk source selection",
         Sai1 kernel_clk: Sai1(Variant) d2ccip1 "SAI1 kernel clock source selection",
         Sai2, Sai3,
+        Spi1, Spi4, Spi5,
         Tim1, Tim8, Tim15, Tim16, Tim17,
         Usart1, Usart6
     ];
@@ -266,6 +269,8 @@ peripheral_reset_and_enable_control! {
     APB4, "Advanced Peripheral Bus 4 (APB4) peripherals" => [
         Vref, Comp12,
         Lptim2, Lptim3, Lptim4, Lptim5,
+        I2c4,
+        Spi6,
 
         Sai4 kernel_clk_a: Sai4A(Variant) d3ccip
             "Sub-Block A of SAI4 kernel clock source selection"

--- a/src/sai/mod.rs
+++ b/src/sai/mod.rs
@@ -1,5 +1,7 @@
 //! # Serial Audio Interface
 
+use core::marker::PhantomData;
+
 use crate::stm32::sai4::CH;
 use crate::stm32::{SAI1, SAI4};
 
@@ -151,7 +153,7 @@ macro_rules! sai_hal {
                 }
 
                 /// Releases the SAI peripheral
-                pub fn free(self) -> $SAIX {
+                pub fn free(self) -> ($SAIX, rec::$Rec) {
                     // Refer to RM0433 Rev 7 51.4.15 Disabling the SAI
 
                     // Master: Clear SAIEN
@@ -175,7 +177,8 @@ macro_rules! sai_hal {
                         ch.cr1.read().saien().bit_is_set()
                     }).unwrap_or(false) {}
 
-                    self.rb
+
+                    (self.rb, rec::$Rec { _marker: PhantomData })
                 }
             }
         )+

--- a/src/sai/mod.rs
+++ b/src/sai/mod.rs
@@ -1,11 +1,10 @@
 //! # Serial Audio Interface
 
 use crate::stm32::sai4::CH;
-use crate::stm32::{SAI1, SAI2, SAI3, SAI4};
+use crate::stm32::{SAI1, SAI4};
 
 // clocks
-use crate::rcc::Ccdr;
-use crate::stm32::rcc::{d2ccip1r, d3ccipr};
+use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::time::Hertz;
 use stm32h7::Variant::Val;
 
@@ -14,36 +13,40 @@ pub use pdm::SaiPdmExt;
 
 /// Trait for associating clocks with SAI instances
 pub trait GetClkSAI {
-    fn sai_a_ker_ck(ccdr: &Ccdr) -> Option<Hertz>;
-    fn sai_b_ker_ck(ccdr: &Ccdr) -> Option<Hertz>;
+    type Rec: ResetEnable;
+
+    fn sai_a_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Option<Hertz>;
+    fn sai_b_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Option<Hertz>;
 }
 
 // Return kernel clocks for this SAI
 macro_rules! impl_sai_ker_ck {
-    ($ccip:ident,
-       $fieldA:ident, $fieldB:ident, $ACCESS_A:ident, $ACCESS_B:ident:
+    ($Rec:ident,
+       $get_mux_A:ident, $get_mux_B:ident, $AccessA:ident, $AccessB:ident:
      $($SAIX:ident),+) => {
         $(
             impl GetClkSAI for $SAIX {
+                type Rec = rec::$Rec;
+
                 /// Current kernel clock - A
-                fn sai_a_ker_ck(ccdr: &Ccdr) -> Option<Hertz> {
-                    match ccdr.rb.$ccip.read().$fieldA().variant() {
-                        Val($ccip::$ACCESS_A::PLL1_Q) => ccdr.clocks.pll1_q_ck(),
-                        Val($ccip::$ACCESS_A::PLL2_P) => ccdr.clocks.pll2_p_ck(),
-                        Val($ccip::$ACCESS_A::PLL3_P) => ccdr.clocks.pll3_p_ck(),
-                        Val($ccip::$ACCESS_A::I2S_CKIN) => unimplemented!(),
-                        Val($ccip::$ACCESS_A::PER) => ccdr.clocks.per_ck(),
+                fn sai_a_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Option<Hertz> {
+                    match prec.$get_mux_A() {
+                        Val(rec::$AccessA::PLL1_Q) => clocks.pll1_q_ck(),
+                        Val(rec::$AccessA::PLL2_P) => clocks.pll2_p_ck(),
+                        Val(rec::$AccessA::PLL3_P) => clocks.pll3_p_ck(),
+                        Val(rec::$AccessA::I2S_CKIN) => unimplemented!(),
+                        Val(rec::$AccessA::PER) => clocks.per_ck(),
                         _ => unreachable!(),
                     }
                 }
                 /// Current kernel clock - B
-                fn sai_b_ker_ck(ccdr: &Ccdr) -> Option<Hertz> {
-                    match ccdr.rb.$ccip.read().$fieldB().variant() {
-                        Val($ccip::$ACCESS_B::PLL1_Q) => ccdr.clocks.pll1_q_ck(),
-                        Val($ccip::$ACCESS_B::PLL2_P) => ccdr.clocks.pll2_p_ck(),
-                        Val($ccip::$ACCESS_B::PLL3_P) => ccdr.clocks.pll3_p_ck(),
-                        Val($ccip::$ACCESS_B::I2S_CKIN) => unimplemented!(),
-                        Val($ccip::$ACCESS_B::PER) => ccdr.clocks.per_ck(),
+                fn sai_b_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Option<Hertz> {
+                    match prec.$get_mux_B() {
+                        Val(rec::$AccessB::PLL1_Q) => clocks.pll1_q_ck(),
+                        Val(rec::$AccessB::PLL2_P) => clocks.pll2_p_ck(),
+                        Val(rec::$AccessB::PLL3_P) => clocks.pll3_p_ck(),
+                        Val(rec::$AccessB::I2S_CKIN) => unimplemented!(),
+                        Val(rec::$AccessB::PER) => clocks.per_ck(),
                         _ => unreachable!(),
                     }
                 }
@@ -52,13 +55,13 @@ macro_rules! impl_sai_ker_ck {
     };
 }
 impl_sai_ker_ck! {
-    d2ccip1r, sai1sel, sai1sel, SAI1SEL_A, SAI1SEL_A: SAI1
+    Sai1, get_kernel_clk_mux, get_kernel_clk_mux, Sai1ClkSel, Sai1ClkSel: SAI1
 }
+// impl_sai_ker_ck! {
+//     d2ccip1r, get_kernel_clk_mux, get_kernel_clk_mux, SAI23SEL_A, SAI23SEL_A: SAI2, SAI3
+// }
 impl_sai_ker_ck! {
-    d2ccip1r, sai23sel, sai23sel, SAI23SEL_A, SAI23SEL_A: SAI2, SAI3
-}
-impl_sai_ker_ck! {
-    d3ccipr, sai4asel, sai4bsel, SAI4ASEL_A, SAI4BSEL_A: SAI4
+    Sai4, get_kernel_clk_a_mux, get_kernel_clk_b_mux, Sai4AClkSel, Sai4BClkSel: SAI4
 }
 
 pub trait INTERFACE {}
@@ -86,18 +89,14 @@ pub struct Sai<SAI, INTERFACE> {
 }
 
 macro_rules! sai_hal {
-    ($($SAIX:ident: ($saiX:ident,
-                     $apb:ident, $timXen:ident, $timXrst:ident),)+) => {
+    ($($SAIX:ident: ($saiX:ident, $Rec:ident),)+) => {
         $(
             // Common to all interfaces
             impl<INTERFACE> Sai<$SAIX, INTERFACE> {
                 /// Low level RCC initialisation
-                fn sai_rcc_init(&mut self, ccdr: &mut Ccdr)
+                fn sai_rcc_init(&mut self, prec: rec::$Rec)
                 {
-                    ccdr.$apb.enr().modify(|_, w| w.$timXen().set_bit());
-                    ccdr.$apb.rstr().modify(|_, w| w.$timXrst().set_bit());
-                    ccdr.$apb.rstr().modify(|_, w| w.$timXrst().clear_bit());
-
+                    prec.enable().reset();
                 }
 
                 /// Access to the current master channel
@@ -184,9 +183,9 @@ macro_rules! sai_hal {
 }
 
 sai_hal! {
-    SAI1: (sai1, apb2, sai1en, sai1rst),
+    SAI1: (sai1, Sai1),
     // Uncomment when an interface is implemented for these
-    // SAI2: (sai2, apb2, sai2en, sai2rst),
-    // SAI3: (sai3, apb2, sai3en, sai3rst),
-    SAI4: (sai4, apb4, sai4en, sai4rst),
+    // SAI2: (sai2, Sai2),
+    // SAI3: (sai3, Sai3),
+    SAI4: (sai4, Sai4),
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -452,8 +452,8 @@ macro_rules! spi {
                         self.spi.sr.read().ovr().is_overrun()
                     }
 
-                    pub fn free(self) -> $SPIX {
-                        self.spi
+                    pub fn free(self) -> ($SPIX, rec::$Rec) {
+                        (self.spi, rec::$Rec { _marker: PhantomData })
                     }
                 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -14,7 +14,7 @@
 //! let dp = ...;                   // Device peripherals
 //! let (sck, miso, mosi) = ...;    // GPIO pins
 //!
-//! let spi = dp.SPI1.spi((sck, miso, mosi), spi::MODE_0, 1.mhz(), &mut ccdr);
+//! let spi = dp.SPI1.spi((sck, miso, mosi), spi::MODE_0, 1.mhz(), ccdr.peripheral.SPI1, &ccdr.clocks);
 //! ```
 //!
 //! The GPIO pins should be supplied as a
@@ -28,7 +28,7 @@
 //! filler types instead:
 //!
 //! ```
-//! let spi = dp.SPI1.spi((sck, spi::NoMiso, mosi), spi::MODE_0, 1.mhz(), &mut ccdr);
+//! let spi = dp.SPI1.spi((sck, spi::NoMiso, mosi), spi::MODE_0, 1.mhz(), ccdr.peripheral.SPI1, &ccdr.clocks);
 //! ```
 //!
 //! ## Word Sizes
@@ -40,7 +40,7 @@
 //!
 //! For example, an explict type annotation:
 //! ```
-//! let _: spi:Spi<_, _, u8> = dp.SPI1.spi((sck, spi::NoMiso, mosi), spi::MODE_0, 1.mhz(), &mut ccdr);
+//! let _: spi:Spi<_, _, u8> = dp.SPI1.spi((sck, spi::NoMiso, mosi), spi::MODE_0, 1.mhz(), ccdr.peripheral.SPI1, &ccdr.clocks);
 //! ```
 //!
 //! ## Clocks
@@ -58,6 +58,7 @@ use crate::hal;
 pub use crate::hal::spi::{
     Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3,
 };
+use crate::stm32;
 use crate::stm32::rcc::{d2ccip1r, d3ccipr};
 use crate::stm32::spi1::cfg1::MBR_A as MBR;
 use core::marker::PhantomData;
@@ -81,7 +82,7 @@ use crate::gpio::gpiok::PK0;
 
 use crate::gpio::{Alternate, AF5, AF6, AF7, AF8};
 
-use crate::rcc::Ccdr;
+use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::time::Hertz;
 
 /// SPI error
@@ -267,12 +268,15 @@ pub struct Spi<SPI, WORD = u8> {
 }
 
 pub trait SpiExt<SPI, WORD>: Sized {
+    type Rec: ResetEnable;
+
     fn spi<PINS, T>(
         self,
         _pins: PINS,
         mode: Mode,
         freq: T,
-        ccdr: &Ccdr,
+        prec: Self::Rec,
+        clocks: &CoreClocks,
     ) -> Spi<SPI, WORD>
     where
         PINS: Pins<SPI>,
@@ -282,7 +286,8 @@ pub trait SpiExt<SPI, WORD>: Sized {
         self,
         mode: Mode,
         freq: T,
-        ccdr: &Ccdr,
+        prec: Self::Rec,
+        clocks: &CoreClocks,
     ) -> Spi<SPI, WORD>
     where
         T: Into<Hertz>;
@@ -301,8 +306,8 @@ macro_rules! spi {
                 .bits(16 - 1) // 16 bit frames
         });
     };
-	($($SPIX:ident: ($spiX:ident, $apbXenr:ident, $spiXen:ident,
-                     $pclkX:ident) => ($($TY:ident),+),)+) => {
+	($($SPIX:ident: ($spiX:ident, $Rec:ident, $pclkX:ident)
+       => ($($TY:ident),+),)+) => {
 	    $(
             // For each $TY
             $(
@@ -311,19 +316,20 @@ macro_rules! spi {
                         spi: $SPIX,
                         mode: Mode,
                         freq: T,
-                        ccdr: &Ccdr,
+                        prec: rec::$Rec,
+                        clocks: &CoreClocks,
                     ) -> Self
                     where
                         T: Into<Hertz>,
                     {
                         // Enable clock for SPI
-                        ccdr.rb.$apbXenr.modify(|_, w| w.$spiXen().enabled());
+                        prec.enable();
 
                         // Disable SS output
                         spi.cfg2.write(|w| w.ssoe().disabled());
 
                         let spi_freq = freq.into().0;
-	                    let spi_ker_ck = match Self::kernel_clk(ccdr) {
+	                    let spi_ker_ck = match Self::kernel_clk(clocks) {
                             Some(ker_hz) => ker_hz.0,
                             _ => panic!("$SPIX kernel clock not running!")
                         };
@@ -452,26 +458,30 @@ macro_rules! spi {
                 }
 
                 impl SpiExt<$SPIX, $TY> for $SPIX {
+                    type Rec = rec::$Rec;
+
 	                fn spi<PINS, T>(self,
                                     _pins: PINS,
                                     mode: Mode,
                                     freq: T,
-                                    ccdr: &Ccdr) -> Spi<$SPIX, $TY>
+                                    prec: rec::$Rec,
+                                    clocks: &CoreClocks) -> Spi<$SPIX, $TY>
 	                where
 	                    PINS: Pins<$SPIX>,
 	                    T: Into<Hertz>
 	                {
-	                    Spi::<$SPIX, $TY>::$spiX(self, mode, freq, ccdr)
+	                    Spi::<$SPIX, $TY>::$spiX(self, mode, freq, prec, clocks)
 	                }
 
 	                fn spi_unchecked<T>(self,
-                                    mode: Mode,
-                                    freq: T,
-                                    ccdr: &Ccdr) -> Spi<$SPIX, $TY>
+                                        mode: Mode,
+                                        freq: T,
+                                        prec: rec::$Rec,
+                                        clocks: &CoreClocks) -> Spi<$SPIX, $TY>
 	                where
 	                    T: Into<Hertz>
 	                {
-	                    Spi::<$SPIX, $TY>::$spiX(self, mode, freq, ccdr)
+	                    Spi::<$SPIX, $TY>::$spiX(self, mode, freq, prec, clocks)
 	                }
 	            }
 
@@ -545,14 +555,16 @@ macro_rules! spi123sel {
             impl<WORD> Spi<$SPIX, WORD> {
                 /// Returns the frequency of the current kernel clock
                 /// for SPI1, SPI2, SPI3
-                fn kernel_clk(ccdr: &Ccdr) -> Option<Hertz> {
-                    match ccdr.rb.d2ccip1r.read().spi123sel().variant() {
-                        Val(d2ccip1r::SPI123SEL_A::PLL1_Q) => ccdr.clocks.pll1_q_ck(),
-                        Val(d2ccip1r::SPI123SEL_A::PLL2_P) => ccdr.clocks.pll2_p_ck(),
-                        Val(d2ccip1r::SPI123SEL_A::PLL3_P) => ccdr.clocks.pll3_p_ck(),
+                fn kernel_clk(clocks: &CoreClocks) -> Option<Hertz> {
+                    let d2ccip1r = unsafe { (*stm32::RCC::ptr()).d2ccip1r.read() };
+
+                    match d2ccip1r.spi123sel().variant() {
+                        Val(d2ccip1r::SPI123SEL_A::PLL1_Q) => clocks.pll1_q_ck(),
+                        Val(d2ccip1r::SPI123SEL_A::PLL2_P) => clocks.pll2_p_ck(),
+                        Val(d2ccip1r::SPI123SEL_A::PLL3_P) => clocks.pll3_p_ck(),
                         // Need a method of specifying pin clock
                         Val(d2ccip1r::SPI123SEL_A::I2S_CKIN) => unimplemented!(),
-                        Val(d2ccip1r::SPI123SEL_A::PER) => ccdr.clocks.per_ck(),
+                        Val(d2ccip1r::SPI123SEL_A::PER) => clocks.per_ck(),
                         _ => unreachable!(),
                     }
                 }
@@ -566,14 +578,16 @@ macro_rules! spi45sel {
             impl<WORD> Spi<$SPIX, WORD> {
                 /// Returns the frequency of the current kernel clock
                 /// for SPI4, SPI5
-                fn kernel_clk(ccdr: &Ccdr) -> Option<Hertz> {
-                    match ccdr.rb.d2ccip1r.read().spi45sel().variant() {
-                        Val(d2ccip1r::SPI45SEL_A::APB) => Some(ccdr.clocks.pclk2()),
-                        Val(d2ccip1r::SPI45SEL_A::PLL2_Q) => ccdr.clocks.pll2_q_ck(),
-                        Val(d2ccip1r::SPI45SEL_A::PLL3_Q) => ccdr.clocks.pll3_q_ck(),
-                        Val(d2ccip1r::SPI45SEL_A::HSI_KER) => ccdr.clocks.hsi_ck(),
-                        Val(d2ccip1r::SPI45SEL_A::CSI_KER) => ccdr.clocks.csi_ck(),
-                        Val(d2ccip1r::SPI45SEL_A::HSE) => ccdr.clocks.hse_ck(),
+                fn kernel_clk(clocks: &CoreClocks) -> Option<Hertz> {
+                    let d2ccip1r = unsafe { (*stm32::RCC::ptr()).d2ccip1r.read() };
+
+                    match d2ccip1r.spi45sel().variant() {
+                        Val(d2ccip1r::SPI45SEL_A::APB) => Some(clocks.pclk2()),
+                        Val(d2ccip1r::SPI45SEL_A::PLL2_Q) => clocks.pll2_q_ck(),
+                        Val(d2ccip1r::SPI45SEL_A::PLL3_Q) => clocks.pll3_q_ck(),
+                        Val(d2ccip1r::SPI45SEL_A::HSI_KER) => clocks.hsi_ck(),
+                        Val(d2ccip1r::SPI45SEL_A::CSI_KER) => clocks.csi_ck(),
+                        Val(d2ccip1r::SPI45SEL_A::HSE) => clocks.hse_ck(),
                         _ => unreachable!(),
                     }
                 }
@@ -587,14 +601,16 @@ macro_rules! spi6sel {
             impl<WORD> Spi<$SPIX, WORD> {
                 /// Returns the frequency of the current kernel clock
                 /// for SPI6
-                fn kernel_clk(ccdr: &Ccdr) -> Option<Hertz> {
-                    match ccdr.rb.d3ccipr.read().spi6sel().variant() {
-                        Val(d3ccipr::SPI6SEL_A::RCC_PCLK4) => Some(ccdr.clocks.pclk4()),
-                        Val(d3ccipr::SPI6SEL_A::PLL2_Q) => ccdr.clocks.pll2_q_ck(),
-                        Val(d3ccipr::SPI6SEL_A::PLL3_Q) => ccdr.clocks.pll3_q_ck(),
-                        Val(d3ccipr::SPI6SEL_A::HSI_KER) => ccdr.clocks.hsi_ck(),
-                        Val(d3ccipr::SPI6SEL_A::CSI_KER) => ccdr.clocks.csi_ck(),
-                        Val(d3ccipr::SPI6SEL_A::HSE) => ccdr.clocks.hse_ck(),
+                fn kernel_clk(clocks: &CoreClocks) -> Option<Hertz> {
+                    let d3ccipr = unsafe { (*stm32::RCC::ptr()).d3ccipr.read() };
+
+                    match d3ccipr.spi6sel().variant() {
+                        Val(d3ccipr::SPI6SEL_A::RCC_PCLK4) => Some(clocks.pclk4()),
+                        Val(d3ccipr::SPI6SEL_A::PLL2_Q) => clocks.pll2_q_ck(),
+                        Val(d3ccipr::SPI6SEL_A::PLL3_Q) => clocks.pll3_q_ck(),
+                        Val(d3ccipr::SPI6SEL_A::HSI_KER) => clocks.hsi_ck(),
+                        Val(d3ccipr::SPI6SEL_A::CSI_KER) => clocks.csi_ck(),
+                        Val(d3ccipr::SPI6SEL_A::HSE) => clocks.hse_ck(),
                         _ => unreachable!(),
                     }
                 }
@@ -604,12 +620,12 @@ macro_rules! spi6sel {
 }
 
 spi! {
-    SPI1: (spi1, apb2enr,  spi1en, pclk2) => (u8, u16),
-    SPI2: (spi2, apb1lenr, spi2en, pclk1) => (u8, u16),
-    SPI3: (spi3, apb1lenr, spi3en, pclk1) => (u8, u16),
-    SPI4: (spi4, apb2enr,  spi4en, pclk2) => (u8, u16),
-    SPI5: (spi5, apb2enr,  spi5en, pclk2) => (u8, u16),
-    SPI6: (spi6, apb4enr,  spi6en, pclk2) => (u8, u16),
+    SPI1: (spi1, Spi1, pclk2) => (u8, u16),
+    SPI2: (spi2, Spi2, pclk1) => (u8, u16),
+    SPI3: (spi3, Spi3, pclk1) => (u8, u16),
+    SPI4: (spi4, Spi4, pclk2) => (u8, u16),
+    SPI5: (spi5, Spi5, pclk2) => (u8, u16),
+    SPI6: (spi6, Spi6, pclk2) => (u8, u16),
 }
 
 spi123sel! {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -14,14 +14,15 @@ use cast::{u16, u32};
 use nb;
 use void::Void;
 
-use crate::rcc::Ccdr;
+use crate::rcc::{rec, CoreClocks, ResetEnable};
+use crate::stm32;
 use crate::stm32::rcc::{d2ccip2r, d3ccipr};
 use crate::time::Hertz;
 use stm32h7::Variant::Val;
 
 /// Associate clocks with timers
 pub trait GetClk {
-    fn get_clk(ccdr: &Ccdr) -> Option<Hertz>;
+    fn get_clk(clocks: &CoreClocks) -> Option<Hertz>;
 }
 
 /// Timers with CK_INT derived from rcc_tim[xy]_ker_ck
@@ -30,8 +31,8 @@ macro_rules! impl_tim_ker_ck {
         $(
             $(
                 impl GetClk for $TIMX {
-                    fn get_clk(ccdr: &Ccdr) -> Option<Hertz> {
-                        Some(ccdr.clocks.$ckX())
+                    fn get_clk(clocks: &CoreClocks) -> Option<Hertz> {
+                        Some(clocks.$ckX())
                     }
                 }
             )+
@@ -46,14 +47,17 @@ impl_tim_ker_ck! {
 /// LPTIM1 Kernel Clock
 impl GetClk for LPTIM1 {
     /// Current kernel clock
-    fn get_clk(ccdr: &Ccdr) -> Option<Hertz> {
-        match ccdr.rb.d2ccip2r.read().lptim1sel().variant() {
-            Val(d2ccip2r::LPTIM1SEL_A::RCC_PCLK1) => Some(ccdr.clocks.pclk1()),
-            Val(d2ccip2r::LPTIM1SEL_A::PLL2_P) => ccdr.clocks.pll2_p_ck(),
-            Val(d2ccip2r::LPTIM1SEL_A::PLL3_R) => ccdr.clocks.pll3_r_ck(),
+    fn get_clk(clocks: &CoreClocks) -> Option<Hertz> {
+        // unsafe: read only
+        let d2ccip2r = &unsafe { &*stm32::RCC::ptr() }.d2ccip2r;
+
+        match d2ccip2r.read().lptim1sel().variant() {
+            Val(d2ccip2r::LPTIM1SEL_A::RCC_PCLK1) => Some(clocks.pclk1()),
+            Val(d2ccip2r::LPTIM1SEL_A::PLL2_P) => clocks.pll2_p_ck(),
+            Val(d2ccip2r::LPTIM1SEL_A::PLL3_R) => clocks.pll3_r_ck(),
             Val(d2ccip2r::LPTIM1SEL_A::LSE) => unimplemented!(),
             Val(d2ccip2r::LPTIM1SEL_A::LSI) => unimplemented!(),
-            Val(d2ccip2r::LPTIM1SEL_A::PER) => ccdr.clocks.per_ck(),
+            Val(d2ccip2r::LPTIM1SEL_A::PER) => clocks.per_ck(),
             _ => unreachable!(),
         }
     }
@@ -61,14 +65,17 @@ impl GetClk for LPTIM1 {
 /// LPTIM2 Kernel Clock
 impl GetClk for LPTIM2 {
     /// Current kernel clock
-    fn get_clk(ccdr: &Ccdr) -> Option<Hertz> {
-        match ccdr.rb.d3ccipr.read().lptim2sel().variant() {
-            Val(d3ccipr::LPTIM2SEL_A::RCC_PCLK4) => Some(ccdr.clocks.pclk4()),
-            Val(d3ccipr::LPTIM2SEL_A::PLL2_P) => ccdr.clocks.pll2_p_ck(),
-            Val(d3ccipr::LPTIM2SEL_A::PLL3_R) => ccdr.clocks.pll3_r_ck(),
+    fn get_clk(clocks: &CoreClocks) -> Option<Hertz> {
+        // unsafe: read only
+        let d3ccipr = &unsafe { &*stm32::RCC::ptr() }.d3ccipr;
+
+        match d3ccipr.read().lptim2sel().variant() {
+            Val(d3ccipr::LPTIM2SEL_A::RCC_PCLK4) => Some(clocks.pclk4()),
+            Val(d3ccipr::LPTIM2SEL_A::PLL2_P) => clocks.pll2_p_ck(),
+            Val(d3ccipr::LPTIM2SEL_A::PLL3_R) => clocks.pll3_r_ck(),
             Val(d3ccipr::LPTIM2SEL_A::LSE) => unimplemented!(),
             Val(d3ccipr::LPTIM2SEL_A::LSI) => unimplemented!(),
-            Val(d3ccipr::LPTIM2SEL_A::PER) => ccdr.clocks.per_ck(),
+            Val(d3ccipr::LPTIM2SEL_A::PER) => clocks.per_ck(),
             _ => unreachable!(),
         }
     }
@@ -79,14 +86,17 @@ macro_rules! impl_clk_lptim345 {
 	    $(
             impl GetClk for $TIMX {
                 /// Current kernel clock
-                fn get_clk(ccdr: &Ccdr) -> Option<Hertz> {
-                    match ccdr.rb.d3ccipr.read().lptim345sel().variant() {
-                        Val(d3ccipr::LPTIM345SEL_A::RCC_PCLK4) => Some(ccdr.clocks.pclk4()),
-                        Val(d3ccipr::LPTIM345SEL_A::PLL2_P) => ccdr.clocks.pll2_p_ck(),
-                        Val(d3ccipr::LPTIM345SEL_A::PLL3_R) => ccdr.clocks.pll3_r_ck(),
+                fn get_clk(clocks: &CoreClocks) -> Option<Hertz> {
+                    // unsafe: read only
+                    let d3ccipr = &unsafe { &*stm32::RCC::ptr() }.d3ccipr;
+
+                    match d3ccipr.read().lptim345sel().variant() {
+                        Val(d3ccipr::LPTIM345SEL_A::RCC_PCLK4) => Some(clocks.pclk4()),
+                        Val(d3ccipr::LPTIM345SEL_A::PLL2_P) => clocks.pll2_p_ck(),
+                        Val(d3ccipr::LPTIM345SEL_A::PLL3_R) => clocks.pll3_r_ck(),
                         Val(d3ccipr::LPTIM345SEL_A::LSE) => unimplemented!(),
                         Val(d3ccipr::LPTIM345SEL_A::LSI) => unimplemented!(),
-                        Val(d3ccipr::LPTIM345SEL_A::PER) => ccdr.clocks.per_ck(),
+                        Val(d3ccipr::LPTIM345SEL_A::PER) => clocks.per_ck(),
                         _ => unreachable!(),
                     }
                 }
@@ -98,7 +108,14 @@ impl_clk_lptim345! { LPTIM3, LPTIM4, LPTIM5 }
 
 /// External trait for hardware timers
 pub trait TimerExt<TIM> {
-    fn timer<T>(self, timeout: T, ccdr: &mut Ccdr) -> Timer<TIM>
+    type Rec: ResetEnable;
+
+    fn timer<T>(
+        self,
+        timeout: T,
+        prec: Self::Rec,
+        clocks: &CoreClocks,
+    ) -> Timer<TIM>
     where
         T: Into<Hertz>;
 }
@@ -119,7 +136,7 @@ pub enum Event {
 }
 
 macro_rules! hal {
-    ($($TIMX:ident: ($timX:ident, $apb:ident, $timXen:ident, $timXrst:ident),)+) => {
+    ($($TIMX:ident: ($timX:ident, $Rec:ident),)+) => {
         $(
             impl Periodic for Timer<$TIMX> {}
 
@@ -158,26 +175,30 @@ macro_rules! hal {
             }
 
             impl TimerExt<$TIMX> for $TIMX {
-                fn timer<T>(self, timeout: T, ccdr: &mut Ccdr) -> Timer<$TIMX>
+                type Rec = rec::$Rec;
+
+                fn timer<T>(self, timeout: T,
+                            prec: Self::Rec, clocks: &CoreClocks
+                ) -> Timer<$TIMX>
                     where
                         T: Into<Hertz>,
                 {
-                    Timer::$timX(self, timeout, ccdr)
+                    Timer::$timX(self, timeout, prec, clocks)
                 }
             }
 
             impl Timer<$TIMX> {
                 /// Configures a TIM peripheral as a periodic count down timer
-                pub fn $timX<T>(tim: $TIMX, timeout: T, ccdr: &mut Ccdr) -> Self
+                pub fn $timX<T>(tim: $TIMX, timeout: T,
+                                prec: rec::$Rec, clocks: &CoreClocks
+                ) -> Self
                 where
                     T: Into<Hertz>,
                 {
                     // enable and reset peripheral to a clean slate state
-                    ccdr.$apb.enr().modify(|_, w| w.$timXen().set_bit());
-                    ccdr.$apb.rstr().modify(|_, w| w.$timXrst().set_bit());
-                    ccdr.$apb.rstr().modify(|_, w| w.$timXrst().clear_bit());
+                    prec.enable().reset();
 
-                    let clk = $TIMX::get_clk(&ccdr)
+                    let clk = $TIMX::get_clk(clocks)
                         .expect("Timer input clock not running!").0;
 
                     let mut timer = Timer {
@@ -273,26 +294,26 @@ macro_rules! hal {
 
 hal! {
     // Advanced-control
-    TIM1: (tim1, apb2, tim1en, tim1rst),
-    TIM8: (tim8, apb2, tim8en, tim8rst),
+    TIM1: (tim1, Tim1),
+    TIM8: (tim8, Tim8),
 
     // General-purpose
-    TIM2: (tim2, apb1l, tim2en, tim2rst),
-    TIM3: (tim3, apb1l, tim3en, tim3rst),
-    TIM4: (tim4, apb1l, tim4en, tim4rst),
-    TIM5: (tim5, apb1l, tim5en, tim5rst),
+    TIM2: (tim2, Tim2),
+    TIM3: (tim3, Tim3),
+    TIM4: (tim4, Tim4),
+    TIM5: (tim5, Tim5),
 
     // Basic
-    TIM6: (tim6, apb1l, tim6en, tim6rst),
-    TIM7: (tim7, apb1l, tim7en, tim7rst),
+    TIM6: (tim6, Tim6),
+    TIM7: (tim7, Tim7),
 
     // General-purpose
-    TIM12: (tim12, apb1l, tim12en, tim12rst),
-    TIM13: (tim13, apb1l, tim13en, tim13rst),
-    TIM14: (tim14, apb1l, tim14en, tim14rst),
+    TIM12: (tim12, Tim12),
+    TIM13: (tim13, Tim13),
+    TIM14: (tim14, Tim14),
 
     // General-purpose
-    TIM15: (tim15, apb2, tim15en, tim15rst),
-    TIM16: (tim16, apb2, tim16en, tim16rst),
-    TIM17: (tim17, apb2, tim17en, tim17rst),
+    TIM15: (tim15, Tim15),
+    TIM16: (tim16, Tim16),
+    TIM17: (tim17, Tim17),
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -3,6 +3,8 @@
 // TODO: on the h7x3 at least, only TIM2, TIM3, TIM4, TIM5 can support 32 bits.
 // TIM1 is 16 bit.
 
+use core::marker::PhantomData;
+
 use crate::hal::timer::{CountDown, Periodic};
 use crate::stm32::{LPTIM1, LPTIM2, LPTIM3, LPTIM4, LPTIM5};
 use crate::stm32::{
@@ -282,10 +284,11 @@ macro_rules! hal {
                 }
 
                 /// Releases the TIM peripheral
-                pub fn free(mut self) -> $TIMX {
+                pub fn free(mut self) -> ($TIMX, rec::$Rec) {
                     // pause counter
                     self.pause();
-                    self.tim
+
+                    (self.tim, rec::$Rec { _marker: PhantomData })
                 }
             }
         )+


### PR DESCRIPTION
For peripeherals used in this crate.

After this, periperhal initialisations will generally have a function
signature ending `..., ccdr.peripheral.XXX, &ccdr.clocks);`