### PR TITLE
Note about programming Arduino H7 board

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,13 @@ Board | Manufacturer | BSP / Examples?
 [STM32H743I-EVAL](https://www.st.com/en/evaluation-tools/stm32h743i-eval.html) | ST |
 [STM32H747I-EVAL](https://www.st.com/en/evaluation-tools/stm32h747i-eval.html) | ST |
 [STM32H747I-DISCO](https://www.st.com/en/evaluation-tools/stm32h747i-disco.html) | ST |
-[Portenta H7](https://store.arduino.cc/portenta-h7) | Arduino |
+[Portenta H7](https://store.arduino.cc/portenta-h7) ⚠️ | Arduino |
 [OpenH743I-C](https://www.waveshare.com/openh743i-c-standard.htm) | Waveshare |
 
+⚠️: Programming this board via its USB connector requires interacting with
+an unknown proprietary(?) bootloader. This bootloader may make it difficult
+or impossible for you to load binaries not approved by Arduino. Alternative
+programming interfaces are only available on the high density connectors.
 
 Minimum supported Rust version
 ------------------------------


### PR DESCRIPTION
This looks like a nice H7 board (if a bit expensive?), but a quick scan of the [schematic](https://content.arduino.cc/assets/Arduino-PortentaH7-schematic-V1.0.pdf) shows that the usual programming interfaces are only on difficult-to-solder high density connectors. The stm32 bootloader is only on the *other* USB port (USB_FS).

I think a little expectations management is therefore appropriate, especially to warn new users. If someone has a board to test, we can then update with more details.