### PR TITLE
Fixes #72: Timer first cycle invalid

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -162,6 +162,10 @@ macro_rules! hal {
                     // Set PSC and ARR
                     self.set_freq(timeout);
 
+                    // Generate an update event to force an update of the ARR register. This ensures
+                    // the first timer cycle is of the specified duration.
+                    self.tim.egr.write(|w| w.ug.set_bit());
+
                     // Start counter
                     self.resume()
                 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -164,7 +164,7 @@ macro_rules! hal {
 
                     // Generate an update event to force an update of the ARR register. This ensures
                     // the first timer cycle is of the specified duration.
-                    self.tim.egr.write(|w| w.ug.set_bit());
+                    self.tim.egr.write(|w| w.ug().set_bit());
 
                     // Start counter
                     self.resume()


### PR DESCRIPTION
This PR fixes #72 by triggering a timer update event to ensure the ARR register is updated.