### PR TITLE
Updated pwr to handle vos0

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,11 +2,11 @@ block_labels = ["wip"]
 delete_merged_branches = true
 status = [
     "Rustfmt",
-    "ci (1.41.0, stm32h743)",
-    "ci (1.41.0, stm32h753)",
-    "ci (1.41.0, stm32h743v)",
-    "ci (1.41.0, stm32h753v)",
-    "ci (1.41.0, stm32h747cm7)",
+    "ci (1.43.0, stm32h743)",
+    "ci (1.43.0, stm32h753)",
+    "ci (1.43.0, stm32h743v)",
+    "ci (1.43.0, stm32h753v)",
+    "ci (1.43.0, stm32h747cm7)",
     "ci (stable, stm32h743)",
     "ci (stable, stm32h753)",
     "ci (stable, stm32h743v)",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:                   # All permutations of {rust, mcu}
         rust:
-          - 1.41.0  # MSRV
+          - 1.43.0  # MSRV
           - stable
         mcu:
           - stm32h743

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,7 @@ required-features = ["rt"]
 [[example]]
 name = "rtic_timers"
 required-features = ["rt"]
+
+[[example]]
+name = "vos0"
+required-features = ["revision_v"]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ programming interfaces are only available on the high density connectors.
 Minimum supported Rust version
 ------------------------------
 
-The Minimum Supported Rust Version (MSRV) at the moment is **1.41.0**. Older
+The Minimum Supported Rust Version (MSRV) at the moment is **1.43.0**. Older
 versions **may** compile, especially when some features are not used
 in your application.
 

--- a/examples/vos0.rs
+++ b/examples/vos0.rs
@@ -36,7 +36,7 @@ fn main() -> ! {
         .freeze(vos, &dp.SYSCFG);
 
     println!(log, "");
-    println!(log, "stm32h7xx-hal example - RCC");
+    println!(log, "stm32h7xx-hal example - VOS0");
     println!(log, "");
 
     // HCLK

--- a/examples/vos0.rs
+++ b/examples/vos0.rs
@@ -1,0 +1,49 @@
+#![deny(warnings)]
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+extern crate panic_itm;
+
+use cortex_m;
+use cortex_m_rt::entry;
+use stm32h7xx_hal::{pac, rcc, prelude::*};
+
+use cortex_m_log::println;
+use cortex_m_log::{
+    destination::Itm, printer::itm::InterruptSync as InterruptSyncItm,
+};
+
+#[entry]
+fn main() -> ! {
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().expect("Cannot take peripherals");
+    let mut log = InterruptSyncItm::new(Itm::new(cp.ITM));
+
+    // Constrain and Freeze power
+    println!(log, "Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let rcc = dp.RCC.constrain();
+    let vos = pwr.freeze_vos0(&rcc, &dp.SYSCFG);
+
+    // Constrain and Freeze clock
+    println!(log, "Setup RCC...                  ");
+    let ccdr = rcc
+        .sys_ck(480.mhz())
+        .pll1_strategy(rcc::PllConfigStrategy::Iterative)
+        .freeze(vos, &dp.SYSCFG);
+
+    println!(log, "");
+    println!(log, "stm32h7xx-hal example - RCC");
+    println!(log, "");
+
+    // HCLK
+    println!(log, "hclk = {} MHz", ccdr.clocks.hclk().0 as f32 / 1e6);
+    // assert_eq!(ccdr.clocks.hclk().0, 50_000_000);
+
+    // SYS_CK
+    println!(log, "sys_ck = {} MHz", ccdr.clocks.sys_ck().0 as f32 / 1e6);
+    assert_eq!(ccdr.clocks.sys_ck().0, 480_000_000);
+
+    loop {}
+}

--- a/examples/vos0.rs
+++ b/examples/vos0.rs
@@ -23,19 +23,7 @@ fn main() -> ! {
     // Constrain and Freeze power
     println!(log, "Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos;
-
-    // Enable VOS0 for revision v parts
-    #[cfg(feature = "revision_v")]
-    {
-        vos = pwr.vos0(&dp.SYSCFG).freeze()
-    };
-
-    // VOS0 is only support by revision v parts
-    #[cfg(not(feature = "revision_v"))]
-    {
-        vos = pwr.freeze()
-    };
+    let vos = pwr.vos0(&dp.SYSCFG).freeze();
 
     // Constrain and Freeze clock
     // The PllConfigStrategy::Normal strategy uses the medium range VCO which has a maximum of 420 Mhz

--- a/examples/vos0.rs
+++ b/examples/vos0.rs
@@ -27,11 +27,15 @@ fn main() -> ! {
 
     // Enable VOS0 for revision v parts
     #[cfg(feature = "revision_v")]
-    { vos = pwr.vos0(&dp.SYSCFG).freeze() };
+    {
+        vos = pwr.vos0(&dp.SYSCFG).freeze()
+    };
 
     // VOS0 is only support by revision v parts
     #[cfg(not(feature = "revision_v"))]
-    { vos = pwr.freeze() };
+    {
+        vos = pwr.freeze()
+    };
 
     // Constrain and Freeze clock
     // The PllConfigStrategy::Normal strategy uses the medium range VCO which has a maximum of 420 Mhz

--- a/examples/vos0.rs
+++ b/examples/vos0.rs
@@ -23,7 +23,15 @@ fn main() -> ! {
     // Constrain and Freeze power
     println!(log, "Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.vos0(&dp.SYSCFG).freeze();
+    let vos;
+
+    // Enable VOS0 for revision v parts
+    #[cfg(feature = "revision_v")]
+    { vos = pwr.vos0(&dp.SYSCFG).freeze() };
+
+    // VOS0 is only support by revision v parts
+    #[cfg(not(feature = "revision_v"))]
+    { vos = pwr.freeze() };
 
     // Constrain and Freeze clock
     // The PllConfigStrategy::Normal strategy uses the medium range VCO which has a maximum of 420 Mhz

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -49,8 +49,9 @@
 //! power supply method, `freeze` will panic until you power on reset
 //! your board.
 
-use crate::stm32::{PWR, SYSCFG};
-use crate::rcc::Rcc;
+use crate::stm32::PWR;
+#[cfg(feature = "revision_v")]
+use crate::stm32::{RCC, SYSCFG};
 
 /// Extension trait that constrains the `PWR` peripheral
 pub trait PwrExt {
@@ -63,6 +64,8 @@ impl PwrExt for PWR {
             rb: self,
             #[cfg(any(feature = "dualcore"))]
             supply_configuration: SupplyConfiguration::Default,
+            #[cfg(feature = "revision_v")]
+            enable_vos0: false,
         }
     }
 }
@@ -74,6 +77,8 @@ pub struct Pwr {
     pub(crate) rb: PWR,
     #[cfg(any(feature = "dualcore"))]
     supply_configuration: SupplyConfiguration,
+    #[cfg(feature = "revision_v")]
+    enable_vos0: bool,
 }
 
 /// Voltage Scale
@@ -181,66 +186,13 @@ impl Pwr {
         }
     }
 
-    pub fn freeze(self) -> VoltageScale {
-         // NB. The lower bytes of CR3 can only be written once after
-        // POR, and must be written with a valid combination. Refer to
-        // RM0433 Rev 7 6.8.4. This is partially enforced by dropping
-        // `self` at the end of this method, but of course we cannot
-        // know what happened between the previous POR and here.
-
-        #[cfg(any(feature = "singlecore"))]
-        self.rb.cr3.modify(|_, w| {
-            w.scuen().set_bit().ldoen().set_bit().bypass().clear_bit()
-        });
-
-        #[cfg(any(feature = "dualcore"))]
-        self.rb.cr3.modify(|_, w| {
-            use SupplyConfiguration::*;
-
-            match self.supply_configuration {
-                LDOSupply => w.sden().clear_bit().ldoen().set_bit(),
-                DirectSMPS => w.sden().set_bit().ldoen().clear_bit(),
-                SMPSFeedsIntoLDO1V8 => unsafe {
-                    w.sden().set_bit().ldoen().set_bit().sdlevel().bits(1)
-                },
-                SMPSFeedsIntoLDO2V5 => unsafe {
-                    w.sden().set_bit().ldoen().set_bit().sdlevel().bits(2)
-                },
-                Bypass => {
-                    w.sden().clear_bit().ldoen().clear_bit().bypass().set_bit()
-                }
-                Default => {
-                    // Default configuration. The actual reset value of
-                    // CR3 varies between packages (See RM0399 Section
-                    // 7.8.4 Footnote 2). Therefore we do not modify
-                    // anything here.
-                    w
-                }
-            }
-        });
-        // Verify supply configuration, panics if these values read
-        // from CR3 do not match those written.
-        #[cfg(any(feature = "dualcore"))]
-        self.verify_supply_configuration();
-
-        // Validate the supply configuration. If you are stuck here, it is
-        // because the voltages on your board do not match those specified
-        // in the D3CR.VOS and CR3.SDLEVEL fields.  By default after reset
-        // VOS = Scale 3, so check that the voltage on the VCAP pins =
-        // 1.0V.
-        while self.rb.csr1.read().actvosrdy().bit_is_clear() {}
-
-        // We have now entered Run mode. See RM0433 Rev 7 Section 6.6.1
-
-        // go to VOS1 voltage scale for high performance
-        self.rb.d3cr.write(|w| unsafe { w.vos().bits(0b11) });
-        while self.rb.d3cr.read().vosrdy().bit_is_clear() {}
-
-        VoltageScale::Scale1
+    #[cfg(feature = "revision_v")]
+    pub fn vos0(mut self, _: &SYSCFG) -> Self {
+        self.enable_vos0 = true;
+        self
     }
 
-    #[cfg(feature = "revision_v")]
-    pub fn freeze_vos0(self, rcc: &Rcc, syscfg: &SYSCFG) -> VoltageScale {
+    pub fn freeze(self) -> VoltageScale {
         // NB. The lower bytes of CR3 can only be written once after
         // POR, and must be written with a valid combination. Refer to
         // RM0433 Rev 7 6.8.4. This is partially enforced by dropping
@@ -297,10 +249,23 @@ impl Pwr {
 
         // Enable overdrive for maximum clock
         // Syscfgen required to set enable overdrive
-        rcc.rb.apb4enr.modify(|_, w| w.syscfgen().enabled());
-        unsafe { syscfg.pwrcr.modify(|_, w| w.oden().bits(1)) };
-        while self.rb.d3cr.read().vosrdy().bit_is_clear() {}
-        VoltageScale::Scale0
+        #[cfg(feature = "revision_v")]
+        if self.enable_vos0 {
+            unsafe {
+                &(*RCC::ptr()).apb4enr.modify(|_, w| w.syscfgen().enabled())
+            };
+            #[cfg(any(feature = "dualcore"))]
+            unsafe {
+                &(*SYSCFG::ptr()).pwrcr.modify(|_, w| w.oden().set_bit())
+            };
+            #[cfg(not(any(feature = "dualcore")))]
+            unsafe {
+                &(*SYSCFG::ptr()).pwrcr.modify(|_, w| w.oden().bits(1))
+            };
+            while self.rb.d3cr.read().vosrdy().bit_is_clear() {}
+            return VoltageScale::Scale0;
+        }
 
+        VoltageScale::Scale1
     }
 }


### PR DESCRIPTION
Looking at how VOS0 scaling needs to be implemented the current structure is going to need to be broken a bit I opted to create a new freeze_vos0 function to not break all the existing code.

> Setup PWR...
> Setup RCC...
> 
> stm32h7xx-hal example - RCC
> 
> hclk = 240 MHz
> sys_ck = 480 MHz

RM0433 rev 7
> VOS0 activation/deactivation sequence
> The system maximum frequency can be reached by boosting the voltage scaling level to
> VOS0. This is done through the ODEN bit in the SYSCFG_PWRCR register.
> The sequence to activate the VOS0 is the following:
> 
> 1. Ensure that the system voltage scaling is set to VOS1 by checking the VOS bits in
> PWR D3 domain control register (PWR D3 domain control register (PWR_D3CR))
> 
> 2. Enable the SYSCFG clock in the RCC by setting the SYSCFGEN bit in the
> RCC_APB4ENR register.
> 
> 3. Enable the ODEN bit in the SYSCFG_PWRCR register.
>   
> 4. Wait for VOSRDY to be set.
> Once the VCORE supply has reached the required level, the system frequency can be
> increased. Figure 31 shows the recommended sequence for switching VCORE from VOS1 to
> VOS0 sequence.