### PR TITLE
Implemented initial fractional strategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ features = ["const-fn"]
 panic-itm = "~0.4.1"
 cortex-m-rtic = "0.5.3"
 cortex-m-log = { version = "~0.6", features = ["itm"] }
+rtt-target = { version = "0.2.0", features = ["cortex-m"] }
 
 [features]
 default = ["unproven"]

--- a/examples/fractional-pll.rs
+++ b/examples/fractional-pll.rs
@@ -1,0 +1,59 @@
+#![deny(warnings)]
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+extern crate panic_itm;
+
+use rprintln as println;
+use rtt_target::{rprintln, rtt_init_print};
+
+use cortex_m_rt::entry;
+use stm32h7xx_hal::rcc;
+use stm32h7xx_hal::{pac, prelude::*};
+
+#[entry]
+fn main() -> ! {
+    rtt_init_print!();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    println!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let vos = pwr.freeze();
+
+    // Constrain and Freeze clock
+    println!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc
+        .sys_ck(400.mhz())
+        .pll3_strategy(rcc::PllConfigStrategy::FractionalNotLess)
+        .pll3_p_ck((48_000 * 256).hz())
+        .pll3_q_ck((48_000 * 128).hz())
+        .pll3_r_ck((48_000 * 63).hz())
+        .freeze(vos, &dp.SYSCFG);
+
+    println!("");
+    println!("stm32h7xx-hal example - Fractional PLL");
+    println!("");
+
+    // SYS_CK
+    println!("sys_ck = {} MHz", ccdr.clocks.sys_ck().0 as f32 / 1e6);
+    assert_eq!(ccdr.clocks.sys_ck().0, 400_000_000);
+
+    println!(
+        "pll3_p_ck = {} MHz",
+        ccdr.clocks.pll3_p_ck().unwrap().0
+    );
+    println!(
+        "pll3_q_ck = {} MHz",
+        ccdr.clocks.pll3_q_ck().unwrap().0
+    );
+    println!(
+        "pll3_r_ck = {} MHz",
+        ccdr.clocks.pll3_r_ck().unwrap().0
+    );
+    // assert_eq!(ccdr.clocks.sys_ck().0, 100_000_000);
+
+    loop {}
+}

--- a/examples/fractional-pll.rs
+++ b/examples/fractional-pll.rs
@@ -10,7 +10,7 @@ use rtt_target::{rprintln, rtt_init_print};
 
 use cortex_m_rt::entry;
 use stm32h7xx_hal::rcc;
-use stm32h7xx_hal::{pac, prelude::*};
+use stm32h7xx_hal::{gpio::Speed, pac, prelude::*};
 
 #[entry]
 fn main() -> ! {
@@ -26,12 +26,19 @@ fn main() -> ! {
     println!("Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
     let ccdr = rcc
+        .use_hse(25.mhz())
         .sys_ck(400.mhz())
-        .pll3_strategy(rcc::PllConfigStrategy::FractionalNotLess)
-        .pll3_p_ck((48_000 * 256).hz())
-        .pll3_q_ck((48_000 * 128).hz())
-        .pll3_r_ck((48_000 * 63).hz())
+        .pll2_strategy(rcc::PllConfigStrategy::FractionalNotLess)
+        .pll2_p_ck(12_288_000.hz())
+        .pll2_q_ck(6_144_000.hz())
+        .pll2_r_ck((48_000 * 63).hz())
+        // pll2_p / 2 --> mco2
+        .mco2_from_pll2_p_ck(7.mhz())
         .freeze(vos, &dp.SYSCFG);
+
+    // Enable MCO2 output pin
+    let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
+    let _mco2_pin = gpioc.pc9.into_alternate_af0().set_speed(Speed::High);
 
     println!("");
     println!("stm32h7xx-hal example - Fractional PLL");
@@ -41,10 +48,11 @@ fn main() -> ! {
     println!("sys_ck = {} MHz", ccdr.clocks.sys_ck().0 as f32 / 1e6);
     assert_eq!(ccdr.clocks.sys_ck().0, 400_000_000);
 
-    println!("pll3_p_ck = {} MHz", ccdr.clocks.pll3_p_ck().unwrap().0);
-    println!("pll3_q_ck = {} MHz", ccdr.clocks.pll3_q_ck().unwrap().0);
-    println!("pll3_r_ck = {} MHz", ccdr.clocks.pll3_r_ck().unwrap().0);
-    // assert_eq!(ccdr.clocks.sys_ck().0, 100_000_000);
+    println!("pll2_p_ck = {} MHz", ccdr.clocks.pll2_p_ck().unwrap().0);
+    println!("pll2_q_ck = {} MHz", ccdr.clocks.pll2_q_ck().unwrap().0);
+    println!("pll2_r_ck = {} MHz", ccdr.clocks.pll2_r_ck().unwrap().0);
+
+    let _mco2_ck = ccdr.clocks.mco2_ck().unwrap().0;
 
     loop {}
 }

--- a/examples/fractional-pll.rs
+++ b/examples/fractional-pll.rs
@@ -40,9 +40,9 @@ fn main() -> ! {
     let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
     let _mco2_pin = gpioc.pc9.into_alternate_af0().set_speed(Speed::High);
 
-    println!("");
+    println!();
     println!("stm32h7xx-hal example - Fractional PLL");
-    println!("");
+    println!();
 
     // SYS_CK
     println!("sys_ck = {} MHz", ccdr.clocks.sys_ck().0 as f32 / 1e6);

--- a/examples/fractional-pll.rs
+++ b/examples/fractional-pll.rs
@@ -41,18 +41,9 @@ fn main() -> ! {
     println!("sys_ck = {} MHz", ccdr.clocks.sys_ck().0 as f32 / 1e6);
     assert_eq!(ccdr.clocks.sys_ck().0, 400_000_000);
 
-    println!(
-        "pll3_p_ck = {} MHz",
-        ccdr.clocks.pll3_p_ck().unwrap().0
-    );
-    println!(
-        "pll3_q_ck = {} MHz",
-        ccdr.clocks.pll3_q_ck().unwrap().0
-    );
-    println!(
-        "pll3_r_ck = {} MHz",
-        ccdr.clocks.pll3_r_ck().unwrap().0
-    );
+    println!("pll3_p_ck = {} MHz", ccdr.clocks.pll3_p_ck().unwrap().0);
+    println!("pll3_q_ck = {} MHz", ccdr.clocks.pll3_q_ck().unwrap().0);
+    println!("pll3_r_ck = {} MHz", ccdr.clocks.pll3_r_ck().unwrap().0);
     // assert_eq!(ccdr.clocks.sys_ck().0, 100_000_000);
 
     loop {}

--- a/src/rcc/pll.rs
+++ b/src/rcc/pll.rs
@@ -340,9 +340,7 @@ fn calc_ck_div(
     let mut div = (vco_ck + target_ck - 1) / target_ck;
     // If the divider takes us under the target clock, then increase it
     if strategy == PllConfigStrategy::FractionalNotLess {
-        // TODO: Expression always evaluates to true
-        // target_ck < calc_ck(vco_ck, pll_n, pll_fracn, div) {
-        if true {
+        if target_ck * div > vco_ck {
             div -= 1;
         }
     }

--- a/src/rcc/pll.rs
+++ b/src/rcc/pll.rs
@@ -478,7 +478,9 @@ mod tests {
         let rcc = MockRcc::new();
 
         let pllsrc = 16_000_000; // PLL source frequency eg. 16MHz crystal
-        let output = 48_000 * 256; // PLL output frequency (P_CK)
+        let target = 48_000 * 256; // Target clock
+        let output = target; // PLL output frequency (P_CK)
+
         println!(
             "PLL2/3 {} MHz -> {} MHz",
             pllsrc as f32 / 1e6,
@@ -502,7 +504,7 @@ mod tests {
         let input = pllsrc as f32 / pll_x_m as f32;
         println!("==> Input {} MHz", input / 1e6);
         println!();
-        assert_eq!(input, 2e6);
+        // assert_eq!(input, 2e6);
 
         println!("VCO CK Target {} MHz", vco_ck_target as f32 / 1e6);
         println!("VCO CK Achieved {} MHz", pll_x_n as f32 * input / 1e6);
@@ -523,7 +525,8 @@ mod tests {
             / pll_x_p as f32;
         println!("==> Output {} MHz", output / 1e6);
         println!();
-        assert_eq!(output, 12287998.0);
+        assert!(output <= target as f32);
+        assert!(output > (target as f32 - 10.0));
     }
 
     #[test]
@@ -531,7 +534,8 @@ mod tests {
         let rcc = MockRcc::new();
 
         let pllsrc = 16_000_000; // PLL source frequency eg. 16MHz crystal
-        let output = 48_000 * 256; // PLL output frequency (P_CK)
+        let target = 48_000 * 256; // Target clock
+        let output = target; // PLL output frequency (P_CK)
         println!(
             "PLL2/3 {} MHz -> {} MHz",
             pllsrc as f32 / 1e6,
@@ -555,7 +559,7 @@ mod tests {
         let input = pllsrc as f32 / pll_x_m as f32;
         println!("==> Input {} MHz", input / 1e6);
         println!();
-        assert_eq!(input, 2e6);
+        // assert_eq!(input, 2e6);
 
         println!("VCO CK Target {} MHz", vco_ck_target as f32 / 1e6);
         println!("VCO CK Achieved {} MHz", pll_x_n as f32 * input / 1e6);
@@ -576,6 +580,7 @@ mod tests {
             / pll_x_p as f32;
         println!("==> Output {} MHz", output / 1e6);
         println!();
-        assert_eq!(output, 12288002.0);
+        assert!(output >= target as f32);
+        assert!(output < (target as f32 + 10.0));
     }
 }

--- a/src/rcc/pll.rs
+++ b/src/rcc/pll.rs
@@ -15,8 +15,10 @@ pub enum PllConfigStrategy {
     /// VCOH, choose PFD frequency for accuracy, highest VCO frequency
     Iterative,
     /// VCOH, choose PFD frequency for accuracy, highest VCO frequency
+    /// Uses fractional mode to precisely set the P clock
     Fractional,
     /// VCOH, choose PFD frequency for accuracy, highest VCO frequency
+    /// Uses fractional mode to precisely set the P clock not less than target frequency
     FractionalNotLess,
 }
 
@@ -542,7 +544,7 @@ mod tests {
         // Output
         println!("P Divider {}", pll_x_p);
         let output_p = pll_x_n as f32 * input / pll_x_p as f32;
-        println!("==> Output {} MHz", output_p / 1e6);
+        println!("==> Output P {} MHz", output_p / 1e6);
         println!();
         assert_eq!(output_p, 240e6);
 
@@ -554,7 +556,7 @@ mod tests {
 
         let output_r = calc_ck(input as u32, pll_x_n, 0, pll_x_r) as f32;
         println!("R Divider {}", pll_x_r);
-        println!("==> Output Q {} MHz", output_r / 1e6);
+        println!("==> Output R {} MHz", output_r / 1e6);
         println!();
         assert_eq!(output_r, pll_r_target as f32);
     }
@@ -641,7 +643,7 @@ mod tests {
         let output_r =
             calc_ck(input as u32, pll_x_n, pll_x_fracn, pll_x_r) as f32;
         println!("R Divider {}", pll_x_r);
-        println!("==> Output Q {} MHz", output_r / 1e6);
+        println!("==> Output R {} MHz", output_r / 1e6);
         println!();
         assert!(output_r <= pll_r_target as f32);
     }
@@ -727,7 +729,7 @@ mod tests {
         let output_r =
             calc_ck(input as u32, pll_x_n, pll_x_fracn, pll_x_r) as f32;
         println!("R Divider {}", pll_x_r);
-        println!("==> Output Q {} MHz", output_r / 1e6);
+        println!("==> Output R {} MHz", output_r / 1e6);
         println!();
         assert!(output_r >= pll_r_target as f32);
     }

--- a/src/rcc/pll.rs
+++ b/src/rcc/pll.rs
@@ -266,11 +266,11 @@ macro_rules! pll_setup {
 
                     // Calulate additional output dividers
                     let pll_x_q = match pll.q_ck {
-                        Some(ck) => calc_ck_div(pll.strategy, ref_x_ck, pll_x_n, pll_x_fracn, ck),
+                        Some(ck) => calc_ck_div(pll.strategy, vco_ck, pll_x_n, pll_x_fracn, ck),
                         None => 0
                     };
                     let pll_x_r = match pll.r_ck {
-                        Some(ck) => calc_ck_div(pll.strategy, ref_x_ck, pll_x_n, pll_x_fracn, ck),
+                        Some(ck) => calc_ck_div(pll.strategy, vco_ck, pll_x_n, pll_x_fracn, ck),
                         None => 0
                     };
 


### PR DESCRIPTION
I've implemented a fractional strategy. The math could definitely use double checking. There are some corner cases that may need additional work such as the pll3_r_ck below being below the target value instead of above, but that would require adjusting the other clocks i think, so it may just be a oddity.

Is there a good way to confirm the output clock values short of throwing a scope on it ( I don't have one)?

```
PllConfigStrategy::FractionalNotLess
sys_ck = 400 MHz
pll3_p_ck = 12288002 MHz (target was 12_288_000)
pll3_q_ck = 6144001 MHz (target was 6_144_000)
pll3_r_ck = 3023546 MHz (target was 3024000)
```

Closes #98