### PR TITLE
CI: Continue if nightly fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ name: Continuous integration
 jobs:
   ci:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:                   # All permutations of {rust, mcu}
         rust:
@@ -19,6 +20,7 @@ jobs:
           - stm32h743v
           - stm32h753v
           - stm32h747cm7
+        experimental: [false]
         include:                # One additional job, as follows:
           - rust: nightly
             mcu: stm32h743v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ name: Continuous integration
 jobs:
   ci:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:                   # All permutations of {rust, mcu}
         rust:
@@ -20,11 +19,6 @@ jobs:
           - stm32h743v
           - stm32h753v
           - stm32h747cm7
-        experimental: [false]
-        include:                # One additional job, as follows:
-          - rust: nightly
-            mcu: stm32h743v
-            experimental: true
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches: [ staging, trying, master ]
+  pull_request:
+
+name: Clippy
+
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: clippy
+          toolchain: stable
+          target: thumbv7em-none-eabihf
+          override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --examples --target thumbv7em-none-eabihf --features=rt,stm32h743v

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -8,7 +8,6 @@ name: Clippy
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches: [ master ]        # Do not run on staging / trying
+  pull_request:
+
+name: Nightly rust
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          target: thumbv7em-none-eabihf
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --verbose --release --examples --target thumbv7em-none-eabihf --features rt,stm32h743v
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --lib --target x86_64-unknown-linux-gnu --features rt,stm32h743v

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -4,7 +4,6 @@
 
 extern crate panic_itm;
 
-use cortex_m;
 use cortex_m_rt::entry;
 
 use stm32h7xx_hal::{adc, delay::Delay, pac, prelude::*};

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -5,7 +5,6 @@
 
 extern crate panic_itm;
 
-use cortex_m;
 use cortex_m_rt::entry;
 use stm32h7xx_hal::hal::digital::v2::OutputPin;
 use stm32h7xx_hal::{pac, prelude::*};

--- a/examples/blinky_random.rs
+++ b/examples/blinky_random.rs
@@ -5,7 +5,6 @@
 
 extern crate panic_itm;
 
-use cortex_m;
 use cortex_m_rt::entry;
 use stm32h7xx_hal::hal::digital::v2::ToggleableOutputPin;
 use stm32h7xx_hal::{pac, prelude::*};

--- a/examples/blinky_timer.rs
+++ b/examples/blinky_timer.rs
@@ -8,7 +8,6 @@ extern crate panic_itm;
 #[macro_use(block)]
 extern crate nb;
 
-use cortex_m;
 use cortex_m_rt::entry;
 use stm32h7xx_hal::hal::digital::v2::{OutputPin, ToggleableOutputPin};
 use stm32h7xx_hal::{pac, prelude::*};

--- a/examples/dac.rs
+++ b/examples/dac.rs
@@ -5,7 +5,6 @@
 
 extern crate panic_itm;
 
-use cortex_m;
 use cortex_m::asm;
 use cortex_m_rt::entry;
 use stm32h7xx_hal::hal::Direction;

--- a/examples/mco.rs
+++ b/examples/mco.rs
@@ -5,7 +5,6 @@
 
 extern crate panic_itm;
 
-use cortex_m;
 use cortex_m_rt::entry;
 use stm32h7xx_hal::{gpio::Speed, pac, prelude::*, rcc::PllConfigStrategy};
 

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -5,7 +5,6 @@
 
 extern crate panic_itm;
 
-use cortex_m;
 use cortex_m::asm;
 use cortex_m_rt::entry;
 use stm32h7xx_hal::{pac, prelude::*};

--- a/examples/rcc.rs
+++ b/examples/rcc.rs
@@ -5,7 +5,6 @@
 
 extern crate panic_itm;
 
-use cortex_m;
 use cortex_m_rt::entry;
 use stm32h7xx_hal::{pac, prelude::*};
 

--- a/examples/sai_pdm.rs
+++ b/examples/sai_pdm.rs
@@ -5,7 +5,6 @@
 
 extern crate panic_itm;
 
-use cortex_m;
 use cortex_m_rt::entry;
 use stm32h7xx_hal::{pac, prelude::*};
 

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -5,7 +5,6 @@
 
 extern crate panic_itm;
 
-use cortex_m;
 use cortex_m_rt::entry;
 use stm32h7xx_hal::{pac, prelude::*, serial};
 

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -5,7 +5,6 @@
 
 extern crate panic_itm;
 
-use cortex_m;
 use cortex_m_rt::entry;
 use stm32h7xx_hal::{pac, prelude::*, spi};
 

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -4,7 +4,6 @@
 
 extern crate panic_itm;
 
-use cortex_m;
 use cortex_m_rt::entry;
 
 use stm32h7xx_hal::{

--- a/examples/vos0.rs
+++ b/examples/vos0.rs
@@ -5,7 +5,6 @@
 
 extern crate panic_itm;
 
-use cortex_m;
 use cortex_m_rt::entry;
 use stm32h7xx_hal::{pac, prelude::*, rcc};
 


### PR DESCRIPTION
Also provide clippy lints. Only `deny`/`forbid` lints will fail the build, unless `#[deny(warnings)]` is also specified.