### PR TITLE
Add USB and example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - stm32h753v
           - stm32h747cm7
     env:                        # Peripheral Feature flags
-      FLAGS: rt,quadspi,sdmmc,fmc
+      FLAGS: rt,quadspi,sdmmc,fmc,usb_hs
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
           - log-semihost
           - log-rtt
     env:                        # Peripheral Feature flags
-      FLAGS: rt,quadspi,sdmmc,fmc
+      FLAGS: rt,quadspi,sdmmc,fmc,usb_hs
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ paste = "1.0.1"
 bare-metal = "1.0.0"
 sdio-host = { version = "0.4", optional = true }
 stm32-fmc = { version = "0.2", optional = true }
-synopsys-usb-otg = { version = "^0.2.1", features = ["cortex-m"], optional = true }
+synopsys-usb-otg = { version = "^0.2.2", features = ["cortex-m"], optional = true }
 
 [dependencies.smoltcp]
 version = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,3 +148,7 @@ required-features = ["rt"]
 [[example]]
 name = "usb_serial"
 required-features = ["usb_hs"]
+
+[[example]]
+name = "usb_passthrough"
+required-features = ["usb_hs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ paste = "1.0.1"
 bare-metal = "1.0.0"
 sdio-host = { version = "0.4", optional = true }
 stm32-fmc = { version = "0.2", optional = true }
+synopsys-usb-otg = { version = "^0.2.1", features = ["cortex-m"], optional = true }
 
 [dependencies.smoltcp]
 version = "0.6.0"
@@ -54,6 +55,8 @@ cortex-m-log = { version = "~0.6", features = ["itm", "semihosting", "log-integr
 panic-itm = { version = "~0.4.1" }
 panic-semihosting = { version = "0.5.3" }
 cortex-m-semihosting = { version = "0.3.5" }
+usb-device = "0.2.5"
+usbd-serial = "0.1.0"
 
 [dev-dependencies.smoltcp]
 version = "0.6.0"
@@ -77,6 +80,7 @@ ethernet = ["smoltcp"]
 phy_ksz8081r = []
 phy_lan8742a = []
 rt = ["stm32h7/rt"]
+usb_hs = ["synopsys-usb-otg", "synopsys-usb-otg/hs"]
 stm32h742 = ["stm32h7/stm32h743", "device-selected", "singlecore"]
 stm32h743 = ["stm32h7/stm32h743", "device-selected", "singlecore"]
 stm32h753 = ["stm32h7/stm32h753", "device-selected", "singlecore"]
@@ -140,3 +144,7 @@ required-features = ["phy_lan8742a", "rt", "revision_v", "stm32h743v", "ethernet
 [[example]]
 name = "tick_timer"
 required-features = ["rt"]
+
+[[example]]
+name = "usb_serial"
+required-features = ["usb_hs"]

--- a/examples/usb_passthrough.rs
+++ b/examples/usb_passthrough.rs
@@ -1,0 +1,129 @@
+//! Dual CDC-ACM serial port example using polling in a busy loop.
+//!
+//! Characters written to one serial port appear on both.
+//!
+//! Note: This example must be built in release mode to work reliably
+#![no_std]
+#![no_main]
+
+use panic_itm as _;
+
+use cortex_m_rt::entry;
+
+use stm32h7xx_hal::rcc::rec::UsbClkSel;
+use stm32h7xx_hal::usb_hs::{UsbBus, USB1, USB2};
+use stm32h7xx_hal::{prelude::*, stm32};
+
+use usb_device::prelude::*;
+
+static mut EP_MEMORY_1: [u32; 1024] = [0; 1024];
+static mut EP_MEMORY_2: [u32; 1024] = [0; 1024];
+
+#[entry]
+fn main() -> ! {
+    let mut cp = stm32::CorePeripherals::take().unwrap();
+    let dp = stm32::Peripherals::take().unwrap();
+
+    // Power
+    let pwr = dp.PWR.constrain();
+    let vos = pwr.freeze();
+
+    // RCC
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(120.mhz()).freeze(vos, &dp.SYSCFG);
+
+    // 48MHz CLOCK
+    let _ = ccdr.clocks.hsi48_ck().expect("HSI48 must run");
+    ccdr.peripheral.kernel_usb_clk_mux(UsbClkSel::HSI48);
+
+    // IO
+    let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
+    let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
+
+    let usb1 = USB1 {
+        usb_global: dp.OTG1_HS_GLOBAL,
+        usb_device: dp.OTG1_HS_DEVICE,
+        usb_pwrclk: dp.OTG1_HS_PWRCLK,
+        pin_dm: gpiob.pb14.into_alternate_af12(),
+        pin_dp: gpiob.pb15.into_alternate_af12(),
+        prec: ccdr.peripheral.USB1OTG,
+        hclk: ccdr.clocks.hclk(),
+    };
+    let usb2 = USB2 {
+        usb_global: dp.OTG2_HS_GLOBAL,
+        usb_device: dp.OTG2_HS_DEVICE,
+        usb_pwrclk: dp.OTG2_HS_PWRCLK,
+        pin_dm: gpioa.pa11.into_alternate_af10(),
+        pin_dp: gpioa.pa12.into_alternate_af10(),
+        prec: ccdr.peripheral.USB2OTG,
+        hclk: ccdr.clocks.hclk(),
+    };
+
+    // Port 1
+    let usb1_bus = UsbBus::new(usb1, unsafe { &mut EP_MEMORY_1 });
+    let mut serial1 = usbd_serial::SerialPort::new(&usb1_bus);
+    let mut usb1_dev =
+        UsbDeviceBuilder::new(&usb1_bus, UsbVidPid(0x16c0, 0x27dd))
+            .manufacturer("Fake company")
+            .product("Serial port")
+            .serial_number("TEST PORT 1")
+            .device_class(usbd_serial::USB_CLASS_CDC)
+            .build();
+
+    // Port 2
+    let usb2_bus = UsbBus::new(usb2, unsafe { &mut EP_MEMORY_2 });
+    let mut serial2 = usbd_serial::SerialPort::new(&usb2_bus);
+    let mut usb2_dev =
+        UsbDeviceBuilder::new(&usb2_bus, UsbVidPid(0x16c0, 0x27dd))
+            .manufacturer("Fake company")
+            .product("Serial port")
+            .serial_number("TEST PORT 2")
+            .device_class(usbd_serial::USB_CLASS_CDC)
+            .build();
+
+    loop {
+        let mut buf = [0u8; 64];
+
+        // Port 1
+        if usb1_dev.poll(&mut [&mut serial1]) {
+            match serial1.read(&mut buf) {
+                Ok(count) if count > 0 => {
+                    // Write to both ports
+                    write_serial(&mut serial1, &buf, count);
+                    write_serial(&mut serial2, &buf, count);
+                }
+                _ => {}
+            }
+        }
+
+        // Port 2
+        if usb2_dev.poll(&mut [&mut serial2]) {
+            match serial2.read(&mut buf) {
+                Ok(count) if count > 0 => {
+                    // Write to both ports
+                    write_serial(&mut serial1, &buf, count);
+                    write_serial(&mut serial2, &buf, count);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn write_serial<P: usb_device::bus::UsbBus>(
+    serial: &mut usbd_serial::SerialPort<P>,
+    buf: &[u8],
+    count: usize,
+) {
+    if serial.rts() {
+        let mut write_offset = 0;
+        while write_offset < count {
+            match serial.write(&buf[write_offset..count]) {
+                Ok(len) if len > 0 => {
+                    write_offset += len;
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/examples/usb_passthrough.rs
+++ b/examples/usb_passthrough.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
 
     // RCC
     let rcc = dp.RCC.constrain();
-    let ccdr = rcc.sys_ck(120.mhz()).freeze(vos, &dp.SYSCFG);
+    let mut ccdr = rcc.sys_ck(120.mhz()).freeze(vos, &dp.SYSCFG);
 
     // 48MHz CLOCK
     let _ = ccdr.clocks.hsi48_ck().expect("HSI48 must run");

--- a/examples/usb_passthrough.rs
+++ b/examples/usb_passthrough.rs
@@ -21,7 +21,6 @@ static mut EP_MEMORY_2: [u32; 1024] = [0; 1024];
 
 #[entry]
 fn main() -> ! {
-    let mut cp = stm32::CorePeripherals::take().unwrap();
     let dp = stm32::Peripherals::take().unwrap();
 
     // Power

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -9,7 +9,7 @@ use panic_itm as _;
 use cortex_m_rt::entry;
 
 use stm32h7xx_hal::rcc::rec::UsbClkSel;
-use stm32h7xx_hal::usb_hs::{UsbBus, USB1};
+use stm32h7xx_hal::usb_hs::{UsbBus, USB2};
 use stm32h7xx_hal::{prelude::*, stm32};
 
 use usb_device::prelude::*;
@@ -33,15 +33,15 @@ fn main() -> ! {
     ccdr.peripheral.kernel_usb_clk_mux(UsbClkSel::HSI48);
 
     // IO
-    let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
+    let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
 
-    let usb = USB1 {
-        usb_global: dp.OTG1_HS_GLOBAL,
-        usb_device: dp.OTG1_HS_DEVICE,
-        usb_pwrclk: dp.OTG1_HS_PWRCLK,
-        pin_dm: gpiob.pb14.into_alternate_af12(),
-        pin_dp: gpiob.pb15.into_alternate_af12(),
-        prec: ccdr.peripheral.USB1OTG,
+    let usb = USB2 {
+        usb_global: dp.OTG2_HS_GLOBAL,
+        usb_device: dp.OTG2_HS_DEVICE,
+        usb_pwrclk: dp.OTG2_HS_PWRCLK,
+        pin_dm: gpioa.pa11.into_alternate_af10(),
+        pin_dp: gpioa.pa12.into_alternate_af10(),
+        prec: ccdr.peripheral.USB2OTG,
         hclk: ccdr.clocks.hclk(),
     };
 

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -26,7 +26,7 @@ fn main() -> ! {
 
     // RCC
     let rcc = dp.RCC.constrain();
-    let ccdr = rcc.sys_ck(80.mhz()).freeze(vos, &dp.SYSCFG);
+    let mut ccdr = rcc.sys_ck(80.mhz()).freeze(vos, &dp.SYSCFG);
 
     // 48MHz CLOCK
     let _ = ccdr.clocks.hsi48_ck().expect("HSI48 must run");

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -1,0 +1,89 @@
+//! CDC-ACM serial port example using polling in a busy loop
+//!
+//! Note: This example must be built in release mode to work reliably
+#![no_std]
+#![no_main]
+
+use panic_itm as _;
+
+use cortex_m_rt::entry;
+
+use stm32h7xx_hal::rcc::rec::UsbClkSel;
+use stm32h7xx_hal::usb_hs::{UsbBus, USB1};
+use stm32h7xx_hal::{prelude::*, stm32};
+
+use usb_device::prelude::*;
+
+static mut EP_MEMORY: [u32; 1024] = [0; 1024];
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+
+    // Power
+    let pwr = dp.PWR.constrain();
+    let vos = pwr.freeze();
+
+    // RCC
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(80.mhz()).freeze(vos, &dp.SYSCFG);
+
+    // 48MHz CLOCK
+    let _ = ccdr.clocks.hsi48_ck().expect("HSI48 must run");
+    let usb_rec = ccdr.peripheral.USB1OTG.kernel_clk_mux(UsbClkSel::HSI48);
+
+    // IO
+    let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
+
+    let usb = USB1 {
+        usb_global: dp.OTG1_HS_GLOBAL,
+        usb_device: dp.OTG1_HS_DEVICE,
+        usb_pwrclk: dp.OTG1_HS_PWRCLK,
+        pin_dm: gpiob.pb14.into_alternate_af12(),
+        pin_dp: gpiob.pb15.into_alternate_af12(),
+        prec: usb_rec,
+        hclk: ccdr.clocks.hclk(),
+    };
+
+    let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });
+
+    let mut serial = usbd_serial::SerialPort::new(&usb_bus);
+
+    let mut usb_dev =
+        UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
+            .manufacturer("Fake company")
+            .product("Serial port")
+            .serial_number("TEST")
+            .device_class(usbd_serial::USB_CLASS_CDC)
+            .build();
+
+    loop {
+        if !usb_dev.poll(&mut [&mut serial]) {
+            continue;
+        }
+
+        let mut buf = [0u8; 64];
+
+        match serial.read(&mut buf) {
+            Ok(count) if count > 0 => {
+                // Echo back in upper case
+                for c in buf[0..count].iter_mut() {
+                    if 0x61 <= *c && *c <= 0x7a {
+                        *c &= !0x20;
+                    }
+                }
+
+                let mut write_offset = 0;
+                while write_offset < count {
+                    match serial.write(&buf[write_offset..count]) {
+                        Ok(len) if len > 0 => {
+                            write_offset += len;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
 
     // 48MHz CLOCK
     let _ = ccdr.clocks.hsi48_ck().expect("HSI48 must run");
-    let usb_rec = ccdr.peripheral.USB1OTG.kernel_clk_mux(UsbClkSel::HSI48);
+    ccdr.peripheral.kernel_usb_clk_mux(UsbClkSel::HSI48);
 
     // IO
     let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
@@ -41,7 +41,7 @@ fn main() -> ! {
         usb_pwrclk: dp.OTG1_HS_PWRCLK,
         pin_dm: gpiob.pb14.into_alternate_af12(),
         pin_dp: gpiob.pb15.into_alternate_af12(),
-        prec: usb_rec,
+        prec: ccdr.peripheral.USB1OTG,
         hclk: ccdr.clocks.hclk(),
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,5 +161,7 @@ pub mod spi;
 pub mod time;
 #[cfg(feature = "device-selected")]
 pub mod timer;
+#[cfg(all(feature = "device-selected", feature = "usb_hs"))]
+pub mod usb_hs;
 #[cfg(feature = "device-selected")]
 pub mod watchdog;

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -314,7 +314,8 @@ peripheral_reset_and_enable_control! {
     AHB1, "AMBA High-performance Bus (AHB1) peripherals" => [
         Eth1Mac, Dma2, Dma1,
         #[cfg(any(feature = "dualcore"))] Art,
-        Adc12 [group clk: Adc(Variant) d3ccip "ADC"]
+        Adc12 [group clk: Adc(Variant) d3ccip "ADC"],
+        Usb1Otg [kernel clk: Usb d2ccip2 "USB"]
     ];
 
     AHB2, "AMBA High-performance Bus (AHB2) peripherals" => [

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -312,10 +312,11 @@ macro_rules! variant_return_type {
 // those peripherals must be marked with a common group clk.
 peripheral_reset_and_enable_control! {
     AHB1, "AMBA High-performance Bus (AHB1) peripherals" => [
+        Usb1Otg [group clk: Usb d2ccip2 "USB"],
+        Usb2Otg [group clk: Usb],
         Eth1Mac, Dma2, Dma1,
         #[cfg(any(feature = "dualcore"))] Art,
-        Adc12 [group clk: Adc(Variant) d3ccip "ADC"],
-        Usb1Otg [kernel clk: Usb d2ccip2 "USB"]
+        Adc12 [group clk: Adc(Variant) d3ccip "ADC"]
     ];
 
     AHB2, "AMBA High-performance Bus (AHB2) peripherals" => [

--- a/src/usb_hs.rs
+++ b/src/usb_hs.rs
@@ -1,0 +1,90 @@
+//! USB OTG peripherals
+//!
+//! Requires the `usb_hs` feature.
+//!
+//! Note that only full-speed mode is supported,
+//! external high-speed PHY is not supported.
+
+use crate::rcc;
+use crate::stm32;
+
+// use crate::gpio::{
+//     gpioa::{PA11, PA12},
+//     AF10,
+// };
+use crate::gpio::{
+    gpiob::{PB14, PB15},
+    Alternate, AF12,
+};
+
+use crate::time::Hertz;
+
+pub use synopsys_usb_otg::UsbBus;
+use synopsys_usb_otg::UsbPeripheral;
+
+pub struct USB1 {
+    pub usb_global: stm32::OTG1_HS_GLOBAL,
+    pub usb_device: stm32::OTG1_HS_DEVICE,
+    pub usb_pwrclk: stm32::OTG1_HS_PWRCLK,
+    pub pin_dm: PB14<Alternate<AF12>>,
+    pub pin_dp: PB15<Alternate<AF12>>,
+    pub prec: rcc::rec::Usb1Otg,
+    pub hclk: Hertz,
+}
+
+// pub struct USB2 {
+//     pub usb_global: stm32::OTG2_HS_GLOBAL,
+//     pub usb_device: stm32::OTG2_HS_DEVICE,
+//     pub usb_pwrclk: stm32::OTG2_HS_PWRCLK,
+//     pub pin_dm: PA11<Alternate<AF10>>,
+//     pub pin_dp: PA12<Alternate<AF10>>,
+//     pub hclk: Hertz,
+// }
+
+macro_rules! usb_peripheral {
+    ($USB:ident, $GLOBAL:ident, $en:ident, $rst:ident) => {
+        unsafe impl Sync for $USB {}
+
+        unsafe impl UsbPeripheral for $USB {
+            const REGISTERS: *const () = stm32::$GLOBAL::ptr() as *const ();
+
+            const HIGH_SPEED: bool = true;
+            const FIFO_DEPTH_WORDS: usize = 1024;
+
+            const ENDPOINT_COUNT: usize = 9;
+
+            fn enable() {
+                let pwr = unsafe { &*stm32::PWR::ptr() };
+                let rcc = unsafe { &*stm32::RCC::ptr() };
+
+                cortex_m::interrupt::free(|_| {
+                    // USB Regulator in BYPASS mode
+                    pwr.cr3.modify(|_, w| w.usb33den().set_bit());
+
+                    // Enable USB peripheral
+                    rcc.ahb1enr.modify(|_, w| w.$en().set_bit());
+
+                    // Reset USB peripheral
+                    rcc.ahb1rstr.modify(|_, w| w.$rst().set_bit());
+                    rcc.ahb1rstr.modify(|_, w| w.$rst().clear_bit());
+                });
+            }
+
+            fn ahb_frequency_hz(&self) -> u32 {
+                self.hclk.0
+            }
+        }
+    };
+}
+
+usb_peripheral! {
+    USB1, OTG1_HS_GLOBAL, usb1otgen, usb1otgrst
+}
+pub type Usb1BusType = UsbBus<USB1>;
+
+// Not supported in synopsys_usb_otg yet
+//
+// usb_peripheral! {
+//     USB2, OTG2_HS_GLOBAL, usb2otghsen, usb2otgrst
+// }
+// pub type Usb2BusType = UsbBus<USB2>;

--- a/src/usb_hs.rs
+++ b/src/usb_hs.rs
@@ -73,8 +73,8 @@ macro_rules! usb_peripheral {
 
             fn ahb_frequency_hz(&self) -> u32 {
                 // For correct operation, the AHB frequency should be higher
-                // than 30MHz. See RM0433 Rev 7. Section 57.4.4
-                assert!(self.hclk.0 > 30_000_000);
+                // than 30MHz. See RM0433 Rev 7. Section 57.4.4. This is checked
+                // by the UsbBus implementation in synopsys-usb-otg.
 
                 self.hclk.0
             }


### PR DESCRIPTION
The examples require release mode to run correctly.

~~Blocked on:~~
* ~~https://github.com/stm32-rs/synopsys-usb-otg/pull/4~~
* ~~https://github.com/stm32-rs/stm32-rs/pull/401~~
* ~~https://github.com/stm32-rs/stm32h7xx-hal/pull/103~~

There are actually two USB peripherals:

| Name | Type | Base Address | Pin Name
| --- | --- | --- | --- 
| `OTG1_HS` | HS | 0x4004_0000 | `OTG_HS`
| `OTG2_HS` | HS | 0x4008_0000 | `OTG_FS`

~~This PR only adds support for `OTG1_HS`. [synopsys-usb-otg](https://github.com/stm32-rs/synopsys-usb-otg) could support `OTG2_HS` too, except it currently hard-codes the base address (0x4004_0000). It would be interesting to see if this could be fixed with no runtime cost by adding a `const fn` to the `UsbPeripheral` trait. If anyone is interested in picking this up I would be happy to help.~~

Supports both `OTG1_HS` and `OTG2_HS` with https://github.com/stm32-rs/synopsys-usb-otg/pull/5

~~Otherwise I will look at merging this once the blocking PRs are resolved.~~

It would also be interesting to understand why release mode is required for the example. Likely the inlining in release mode is needed to reduce the latency when responding to events, but more experimentation is needed.