### PR TITLE
Added pwm channel info to pwm::Pins

### DIFF
--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -30,7 +30,8 @@
 //!   let (c0, c1, c2, c3) = device.TIM1.pwm(
 //!       pins,
 //!       100.hz(),
-//!       &mut ccdr
+//!       prec,
+//!       &clocks
 //!   );
 //!
 //!   // Set the duty cycle of channel 0 to 50%
@@ -76,17 +77,22 @@ use crate::gpio::{Alternate, AF1, AF2, AF3, AF4, AF9};
 // TIM is the timer being used
 // CHANNEL is a marker struct for the channel (or multi channels for tuples)
 // Example: impl Pins<TIM1, C1> for PA8<Alternate<AF1>> { type Channel = Pwm<TIM1, C1>; }
+/// Pins is a trait that marks which GPIO pins may be used as PWM channels; it should not be directly used.
+/// See the device datasheet 'Pin descriptions' chapter for which pins can be used with which timer PWM channels (or look at Implementors)
 pub trait Pins<TIM, CHANNEL> {
     type Channel;
 }
 
-// Marker structs for PWM channels on Pins trait and Pwm struct
+/// Marker struct for PWM channel 1 on Pins trait and Pwm struct
 pub struct C1;
+/// Marker struct for PWM channel 2 on Pins trait and Pwm struct
 pub struct C2;
+/// Marker struct for PWM channel 3 on Pins trait and Pwm struct
 pub struct C3;
+/// Marker struct for PWM channel 4 on Pins trait and Pwm struct
 pub struct C4;
 
-// One PWM channel, the type that actually implements PwmPin
+/// Pwm represents one PWM channel; it is created by calling TIM?.pwm(...) and lets you control the channel through the PwmPin trait
 pub struct Pwm<TIM, CHANNEL> {
     _channel: PhantomData<CHANNEL>,
     _tim: PhantomData<TIM>,
@@ -509,7 +515,7 @@ pins! {
 }
 
 // PwmExt trait
-// Allows the pwm() method to be added to the peripheral register structs from the device crate
+/// Allows the pwm() method to be added to the peripheral register structs from the device crate
 pub trait PwmExt: Sized {
     type Rec: ResetEnable;
 


### PR DESCRIPTION
Before, it was possible to pass any tuple of TIMx pins to TIMx.pwm(...)
and it would succeed: you could pass two different pins for CH1 or pins
for CH3 and CH4 and either way you would get PWM channels 1 and 2
which would end up writing to the wrong peripheral registers and trying
to use PWM channels with no pins configured.

To fix this, pwm::Pins<TIM> was changed to pwm::Pins<TIM, CHANNEL> and
a pin is now associated with a specific PWM channel.

Tuples of pins and channels are now marked with which channels they
are associated, such as (C1, C2, C3) or (C4, C2)

Pins is only implemented for tuples of channels with no repeated
channels, and each Pins implementation uses the correct Channels tuple
based on the channels for the tuples of pins it is implemented for.

The implementation of Pins<TIM, CHANNEL> for tuples of pins is now
provided by the macro pins_tuples! and includes every valid pin
combination in any possible order (60 total: 6 combinations of 2
channels with 2 orders each, 4 combinations of 3 channels with 6
orders each, and 1 combination of 4 channels with 24 orders)

A tuple of pins passed to pwm(...) now is checked to make sure that
the right pins are associated with the
right channels.