### PR TITLE
i2c: Extend i2c::Write implementation method and add events

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -410,7 +410,7 @@ macro_rules! i2c {
                             .nbytes()
                             .bits(bytes.len() as u8)
                             .autoend()
-                            .automatic()
+                            .software()
                     });
 
                     for byte in bytes {
@@ -422,7 +422,12 @@ macro_rules! i2c {
                         // Put byte on the wire
                         self.i2c.txdr.write(|w| w.txdata().bits(*byte));
                     }
-                    // automatic STOP
+
+                    // Wait until the write finishes
+                    busy_wait!(self.i2c, tc, is_complete);
+
+                    // Stop
+                    self.i2c.cr2.write(|w| w.stop().set_bit());
 
                     Ok(())
                 }


### PR DESCRIPTION
Currently the `write()` method returns once the final byte is written to the FIFO, not when the transaction finishes. Although this saves one byte of time, it is somewhat awkward because:

* Calling another i2c method during this time will fail.
* I2C events are not raised until the transfer ends.

At some point we will need to re-write all of this for async and DMA, but for now I think this is less confusing.