### PR TITLE
Add low_power method to PREC structure

### DIFF
--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -160,7 +160,7 @@ pub mod rec;
 
 pub use core_clocks::CoreClocks;
 pub use pll::{PllConfig, PllConfigStrategy};
-pub use rec::{PeripheralREC, ResetEnable};
+pub use rec::{LowPowerMode, PeripheralREC, ResetEnable};
 
 mod mco;
 use mco::{MCO1Config, MCO2Config, MCO1, MCO2};


### PR DESCRIPTION
Actually quite a simple addition. This method could be added to the `ResetEnable` trait, but since it is intended for the user and not the HAL, I haven't done this.

Also implement LPTIM[1-5] and add an example that uses this.

* Breaking change to the type of TimerExt (but hopefully no-one was using that).
* Removes `ResetEnable` implementation for HSEM as this doesn't support any low power modes (somewhat obviously), but HSEM needs more consideration anyhow (particularly for dual-core parts).

Blocked on:
* https://github.com/stm32-rs/stm32-rs/pull/404