### PR TITLE
Improvements to serial

### DIFF
--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -6,11 +6,11 @@
 use cortex_m_rt::entry;
 #[path = "utilities/logger.rs"]
 mod logger;
-use stm32h7xx_hal::{pac, prelude::*, serial};
+use log::info;
+
+use stm32h7xx_hal::{pac, prelude::*};
 
 use core::fmt::Write;
-
-use log::info;
 
 use nb::block;
 
@@ -43,12 +43,7 @@ fn main() -> ! {
     // Configure the serial peripheral.
     let serial = dp
         .USART3
-        .usart(
-            (tx, rx),
-            serial::config::Config::default(),
-            ccdr.peripheral.USART3,
-            &ccdr.clocks,
-        )
+        .serial((tx, rx), 19_200.bps(), ccdr.peripheral.USART3, &ccdr.clocks)
         .unwrap();
 
     let (mut tx, mut rx) = serial.split();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 //!
 //! * [Inter Integrated Circuit (I2C)](crate::i2c)
 //! * [Serial Peripheral Interface (SPI)](crate::spi)
+//! * [Serial Data (USART/UART)](crate::serial)
 //! * [Serial Audio Interface](crate::sai)
 //!
 //! Timing functions

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -368,6 +368,7 @@ pub trait SerialExt<USART>: Sized {
         clocks: &CoreClocks,
     ) -> Result<Serial<USART>, config::InvalidConfig>;
 
+    #[deprecated(since = "0.7.0", note = "Deprecated in favour of .serial(..)")]
     fn usart(
         self,
         pins: impl Pins<USART>,
@@ -378,6 +379,10 @@ pub trait SerialExt<USART>: Sized {
         self.serial(pins, config, prec, clocks)
     }
 
+    #[deprecated(
+        since = "0.7.0",
+        note = "Deprecated in favour of .serial_unchecked(..)"
+    )]
     fn usart_unchecked(
         self,
         config: impl Into<config::Config>,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -608,6 +608,20 @@ macro_rules! usart {
                 }
             }
 
+            impl Rx<$USARTX> {
+                /// Start listening for `Rxne` event
+                pub fn listen(&mut self) {
+                    // unsafe: rxneie bit accessed by Rx part only
+                    unsafe { &*$USARTX::ptr() }.cr1.modify(|_, w| w.rxneie().enabled());
+                }
+
+                /// Stop listening for `Rxne` event
+                pub fn unlisten(&mut self) {
+                    // unsafe: rxneie bit accessed by Rx part only
+                    unsafe { &*$USARTX::ptr() }.cr1.modify(|_, w| w.rxneie().disabled());
+                }
+            }
+
             impl serial::Write<u8> for Serial<$USARTX> {
                 type Error = Never;
 
@@ -666,6 +680,20 @@ macro_rules! usart {
                     } else {
                         Err(nb::Error::WouldBlock)
                     }
+                }
+            }
+
+            impl Tx<$USARTX> {
+                /// Start listening for `Txe` event
+                pub fn listen(&mut self) {
+                    // unsafe: txeie bit accessed by Tx part only
+                    unsafe { &*$USARTX::ptr() }.cr1.modify(|_, w| w.txeie().enabled());
+                }
+
+                /// Stop listening for `Txe` event
+                pub fn unlisten(&mut self) {
+                    // unsafe: txeie bit accessed by Tx part only
+                    unsafe { &*$USARTX::ptr() }.cr1.modify(|_, w| w.txeie().disabled());
                 }
             }
         )+

--- a/src/time.rs
+++ b/src/time.rs
@@ -90,6 +90,12 @@ impl U32Ext for u32 {
 }
 
 // Unit conversions
+impl Into<Hertz> for Bps {
+    fn into(self) -> Hertz {
+        Hertz(self.0)
+    }
+}
+
 impl Into<Hertz> for KiloHertz {
     fn into(self) -> Hertz {
         Hertz(self.0 * 1_000)


### PR DESCRIPTION
* Allow baud rate in Hertz/KiloHertz as well as Bps
* Accept a baud rate instead of a configuration struct. In the case that a baud rate is specified, the defaults for the other parameters (8N1) are used.
* Rename `usart` / `usart_unchecked` extension methods to `serial` / `serial_unchecked`. The method names elsewhere match the module name, and also some peripherals are `uart` not `usart`, so I think `serial` is an improvement. Keep the old methods for backwards compatibility.

No breakage, but I have updated the example.