### PR TITLE
Fix Delay clock divider on Rev V chips

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -61,7 +61,13 @@ impl DelayUs<u32> for Delay {
         const MAX_RVR: u32 = 0x00FF_FFFF;
 
         // With c_ck up to 480e6, we need u64 for delays > 8.9s
-        #[cfg(any(feature = "singlecore"))]
+
+        #[cfg(all(feature = "singlecore", feature = "revision_v"))]
+        let mut total_rvr =
+            u64::from(us) * u64::from(self.clocks.c_ck().0 / 8_000_000);
+
+        // See errata ES0392 §2.2.3. Revision Y does not have the /8 divider
+        #[cfg(all(feature = "singlecore", not(feature = "revision_v")))]
         let mut total_rvr =
             u64::from(us) * u64::from(self.clocks.c_ck().0 / 1_000_000);
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/853158/89590271-13685300-d80d-11ea-91ac-06b44dfd64fc.png)

![image](https://user-images.githubusercontent.com/853158/89590241-fe8bbf80-d80c-11ea-9b5c-589fce5f5914.png)
