### PR TITLE
Add SPI enable disable

### DIFF
--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -43,13 +43,14 @@ fn main() -> ! {
     info!("");
 
     // Initialise the SPI peripheral.
-    let mut spi = dp.SPI3.spi(
+    let spi: spi::Spi<_, _, u8> = dp.SPI3.spi(
         (sck, miso, mosi),
         spi::MODE_0,
         3.mhz(),
         ccdr.peripheral.SPI3,
         &ccdr.clocks,
     );
+    let mut spi = spi.enable();
 
     // Write fixed data
     spi.write(&[0x11u8, 0x22, 0x33]).unwrap();

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -43,14 +43,13 @@ fn main() -> ! {
     info!("");
 
     // Initialise the SPI peripheral.
-    let spi: spi::Spi<_, _, u8> = dp.SPI3.spi(
+    let mut spi = dp.SPI3.spi(
         (sck, miso, mosi),
         spi::MODE_0,
         3.mhz(),
         ccdr.peripheral.SPI3,
         &ccdr.clocks,
     );
-    let mut spi = spi.enable();
 
     // Write fixed data
     spi.write(&[0x11u8, 0x22, 0x33]).unwrap();

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -55,7 +55,9 @@
 //! [embedded_hal]: https://docs.rs/embedded-hal/0.2.3/embedded_hal/spi/index.html
 
 use crate::hal;
-pub use crate::hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
+pub use crate::hal::spi::{
+    Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3,
+};
 use crate::stm32;
 use crate::stm32::rcc::{d2ccip1r, d3ccipr};
 use crate::stm32::spi1::cfg1::MBR_A as MBR;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -551,6 +551,26 @@ macro_rules! spi {
                         self.spi.sr.read().ovr().is_overrun()
                     }
 
+                    /// Clears the MODF flag.
+                    pub fn clear_modf(&mut self) {
+                        self.spi.ifcr.write(|w| w.modfc().clear());
+                    }
+
+                    /// Disables the SPI peripheral.
+                    /// Any SPI operation is stopped and disabled, the internal state machine is reset, all
+                    /// the FIFOs content is flushed, CRC calculation is re-initialized.
+                    pub fn disable(&mut self) {
+                        self.clear_modf();
+                        self.spi.cr1.write(|w| w.ssi().slave_not_selected().spe().disabled());
+                    }
+
+                    /// Enables the SPI peripheral.
+                    pub fn enable(&mut self) {
+                        self.spi.cr1.write(|w| w.ssi().slave_not_selected().spe().enabled());
+                    }
+
+                    /// Deconstructs the SPI peripheral and returns the owned parts.
+                    /// Does not deinitialize the SPI peripheral.
                     pub fn free(self) -> ($SPIX, rec::$Rec) {
                         (self.spi, rec::$Rec { _marker: PhantomData })
                     }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -487,8 +487,9 @@ macro_rules! spi {
                     }
 
                     /// Enables the SPI peripheral.
-                    /// Clears the SSI flag, and sets the SPE bit.
-                    pub fn enable(self) -> Spi<$SPIX, Enabled, $TY> {
+                    /// Clears the MODF flag, the SSI flag, and sets the SPE bit.
+                    pub fn enable(mut self) -> Spi<$SPIX, Enabled, $TY> {
+                        self.clear_modf(); // SPE cannot be set when MODF is set
                         self.spi.cr1.write(|w| w.ssi().slave_not_selected().spe().enabled());
                         Spi {
                             spi: self.spi,
@@ -593,11 +594,10 @@ macro_rules! spi {
                     /// flag is cleared, the SSI flag is cleared, and the
                     /// CRC calculation is re-initialized. Clocks are not
                     /// disabled.
-                    pub fn disable(mut self) -> Spi<$SPIX, Disabled, $TY> {
+                    pub fn disable(self) -> Spi<$SPIX, Disabled, $TY> {
                         // Master communication must be suspended before the peripheral is disabled
                         self.spi.cr1.modify(|_, w| w.csusp().requested());
                         while self.spi.sr.read().eot().is_completed() {}
-                        self.clear_modf();
                         self.spi.cr1.write(|w| w.ssi().slave_not_selected().spe().disabled());
                         Spi {
                             spi: self.spi,

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -104,10 +104,6 @@ pub struct Enabled;
 /// Disabled SPI peripheral (type state)
 pub struct Disabled;
 
-pub trait ED {}
-impl ED for Enabled {}
-impl ED for Disabled {}
-
 pub trait Pins<SPI> {}
 pub trait PinSck<SPI> {}
 pub trait PinMiso<SPI> {}
@@ -528,8 +524,6 @@ macro_rules! spi {
                 }
 
                 impl<EN> Spi<$SPIX, EN, $TY>
-                where
-                    EN: ED,
                 {
                     /// Enable interrupts for the given `event`:
                     ///  - Received data ready to be read (RXP)

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -55,9 +55,7 @@
 //! [embedded_hal]: https://docs.rs/embedded-hal/0.2.3/embedded_hal/spi/index.html
 
 use crate::hal;
-pub use crate::hal::spi::{
-    Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3,
-};
+pub use crate::hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 use crate::stm32;
 use crate::stm32::rcc::{d2ccip1r, d3ccipr};
 use crate::stm32::spi1::cfg1::MBR_A as MBR;
@@ -551,26 +549,31 @@ macro_rules! spi {
                         self.spi.sr.read().ovr().is_overrun()
                     }
 
-                    /// Clears the MODF flag.
+                    /// Clears the MODF flag, which indicates that a
+                    /// mode fault has occurred.
                     pub fn clear_modf(&mut self) {
                         self.spi.ifcr.write(|w| w.modfc().clear());
                     }
 
-                    /// Disables the SPI peripheral.
-                    /// Any SPI operation is stopped and disabled, the internal state machine is reset, all
-                    /// the FIFOs content is flushed, CRC calculation is re-initialized.
+                    /// Disables the SPI peripheral. Any SPI operation is
+                    /// stopped and disabled, the internal state machine is
+                    /// reset, all the FIFOs content is flushed, the MODF
+                    /// flag is cleared, the SSI flag is cleared, and the
+                    /// CRC calculation is re-initialized. Clocks are not
+                    /// disabled.
                     pub fn disable(&mut self) {
                         self.clear_modf();
                         self.spi.cr1.write(|w| w.ssi().slave_not_selected().spe().disabled());
                     }
 
                     /// Enables the SPI peripheral.
+                    /// Clears the SSI flag, and sets the SPE bit.
                     pub fn enable(&mut self) {
                         self.spi.cr1.write(|w| w.ssi().slave_not_selected().spe().enabled());
                     }
 
-                    /// Deconstructs the SPI peripheral and returns the owned parts.
-                    /// Does not deinitialize the SPI peripheral.
+                    /// Deconstructs the SPI peripheral and returns the
+                    /// owned parts. Does not disable the SPI peripheral.
                     pub fn free(self) -> ($SPIX, rec::$Rec) {
                         (self.spi, rec::$Rec { _marker: PhantomData })
                     }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -488,8 +488,13 @@ macro_rules! spi {
 
                     /// Enables the SPI peripheral.
                     /// Clears the SSI flag, and sets the SPE bit.
-                    pub fn enable(&mut self) {
+                    pub fn enable(self) -> Spi<$SPIX, Enabled, $TY> {
                         self.spi.cr1.write(|w| w.ssi().slave_not_selected().spe().enabled());
+                        Spi {
+                            spi: self.spi,
+                            _word: PhantomData,
+                            _ed: PhantomData,
+                        }
                     }
 
                     /// Deconstructs the SPI peripheral and returns the component parts.
@@ -588,19 +593,17 @@ macro_rules! spi {
                     /// flag is cleared, the SSI flag is cleared, and the
                     /// CRC calculation is re-initialized. Clocks are not
                     /// disabled.
-                    pub fn disable(&mut self) {
+                    pub fn disable(mut self) -> Spi<$SPIX, Disabled, $TY> {
                         // Master communication must be suspended before the peripheral is disabled
                         self.spi.cr1.modify(|_, w| w.csusp().requested());
                         while self.spi.sr.read().eot().is_completed() {}
                         self.clear_modf();
                         self.spi.cr1.write(|w| w.ssi().slave_not_selected().spe().disabled());
-                    }
-
-                    /// Disables the SPI peripheral, then deconstructs it
-                    /// and returns the component parts.
-                    pub fn free(self) -> ($SPIX, rec::$Rec) {
-                        self.disable(); // SPI constructor requires SPE=0
-                        (self.spi, rec::$Rec { _marker: PhantomData })
+                        Spi {
+                            spi: self.spi,
+                            _word: PhantomData,
+                            _ed: PhantomData,
+                        }
                     }
                 }
 


### PR DESCRIPTION
With the addition of these functions, it becomes quite easy to share an SPI peripheral between multiple devices which require different configuration. You can `disable()`, `free()`, then pass ownership between the different devices which can then configure the SPI peripheral.