### PR TITLE
examples: fix for ITM logging in examples that use CorePeripherals

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -55,3 +55,7 @@ cargo build --features=stm32h750v,rt,log-itm --examples
 
 Note that you may need to configure your debugger to output ITM, and/or
 configure the ITM yourself. See [ITM.md](ITM.md)
+
+If you select this feature flag, then the call to `logger::init()` internally
+configures the ITM peripheral. If you also interact with the ITM peripheral
+yourself, you should be aware that it has already been configured.

--- a/examples/adc12.rs
+++ b/examples/adc12.rs
@@ -3,7 +3,6 @@
 //! For an example of using ADC3, see examples/temperature.rs
 //! For an example of using ADC1 alone, see examples/adc.rs
 
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/blinky_random.rs
+++ b/examples/blinky_random.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/blinky_timer.rs
+++ b/examples/blinky_timer.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/dac.rs
+++ b/examples/dac.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/fractional-pll.rs
+++ b/examples/fractional-pll.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/mco.rs
+++ b/examples/mco.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/prec_kernel_clocks.rs
+++ b/examples/prec_kernel_clocks.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/qspi.rs
+++ b/examples/qspi.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/rcc.rs
+++ b/examples/rcc.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/sai_pdm.rs
+++ b/examples/sai_pdm.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/sdmmc.rs
+++ b/examples/sdmmc.rs
@@ -1,7 +1,6 @@
 //! SDMMC card example
 
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -3,7 +3,6 @@
 //! For an example of using ADC1, see examples/adc.rs
 //! For an example of using ADC1 and ADC2 together, see examples/adc12.rs
 
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/utilities/logger.rs
+++ b/examples/utilities/logger.rs
@@ -17,7 +17,11 @@ cfg_if::cfg_if! {
         lazy_static! {
             static ref LOGGER: Logger<ItmSync<InterruptFree>> = Logger {
                 level: LevelFilter::Info,
-                inner: InterruptSync::new(ItmDest::new(cortex_m::Peripherals::take().unwrap().ITM)),
+                inner: unsafe {
+                    InterruptSync::new(
+                        ItmDest::new(cortex_m::Peripherals::steal().ITM)
+                    )
+                },
             };
         }
 

--- a/examples/vos0.rs
+++ b/examples/vos0.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 


### PR DESCRIPTION
ITM logging as added by PR #107

`stm32::CorePeripherals::take()` ([re-exported here](https://github.com/stm32-rs/stm32-rs-nightlies/blob/master/stm32h7/src/stm32h743v/mod.rs#L701)) will only return `Some` once.

Use `steal()` instead, and assume the user won't try to access the ITM
peripheral from any of the examples.