### PR TITLE
Add a set_timeout method for timers

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -1,6 +1,7 @@
 //! Time units
 
 use core::fmt;
+use core::time::Duration;
 use cortex_m::peripheral::DWT;
 
 /// Bits per second
@@ -127,6 +128,13 @@ impl Into<Hertz> for MilliSeconds {
         let period = self.0;
         assert!(period != 0 && period <= 1_000);
         Hertz(1_000 / period)
+    }
+}
+
+// Into core::time::Duration
+impl Into<Duration> for MilliSeconds {
+    fn into(self) -> Duration {
+        Duration::from_millis(self.0 as u64)
     }
 }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -227,11 +227,7 @@ macro_rules! hal {
                     let frequency = self.timeout.0;
                     let ticks = clk / frequency;
 
-                    let psc = u16((ticks - 1) / (1 << 16)).unwrap();
-                    self.tim.psc.write(|w| { w.psc().bits(psc) });
-
-                    let arr = u16(ticks / u32(psc + 1)).unwrap();
-                    self.tim.arr.write(|w| unsafe { w.bits(u32(arr)) });
+                    self.set_timeout_ticks(ticks);
                 }
 
                 pub fn set_timeout(&mut self, timeout: core::time::Duration) {
@@ -246,8 +242,11 @@ macro_rules! hal {
                     )
                     .unwrap_or(u32::max_value());
 
+                    self.set_timeout_ticks(ticks.max(1));
+                }
 
-                    let psc = u16((ticks.max(1) - 1) / (1 << 16)).unwrap();
+                fn set_timeout_ticks(&mut self, ticks: u32) {
+                    let psc = u16((ticks - 1) / (1 << 16)).unwrap();
                     self.tim.psc.write(|w| { w.psc().bits(psc) });
 
                     let arr = u16(ticks / u32(psc + 1)).unwrap();

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -3,6 +3,7 @@
 // TODO: on the h7x3 at least, only TIM2, TIM3, TIM4, TIM5 can support 32 bits.
 // TIM1 is 16 bit.
 
+use core::convert::TryFrom;
 use core::marker::PhantomData;
 
 use crate::hal::timer::{CountDown, Periodic};
@@ -230,10 +231,28 @@ macro_rules! hal {
                     self.set_timeout_ticks(ticks);
                 }
 
-                pub fn set_timeout(&mut self, timeout: core::time::Duration) {
-                    use core::convert::TryFrom;
-
+                /// Sets the timer period from a time duration
+                ///
+                /// ```
+                /// // Set timeout to 100ms
+                /// timer.set_timeout(100.ms());
+                /// ```
+                ///
+                /// Alternatively, the duration can be set using the
+                /// core::time::Duration type
+                ///
+                /// ```
+                /// let duration = core::time::Duration::from_nanos(2_500);
+                ///
+                /// // Set timeout to 2.5µs
+                /// timer.set_timeout(duration);
+                /// ```
+                pub fn set_timeout<T>(&mut self, timeout: T)
+                where
+                    T: Into<core::time::Duration>
+                {
                     const NANOS_PER_SECOND: u64 = 1_000_000_000;
+                    let timeout = timeout.into();
 
                     let clk = self.clk as u64;
                     let ticks = u32::try_from(

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -242,7 +242,7 @@ macro_rules! hal {
                         clk * timeout.as_secs() as u32 +
                         clk * timeout.subsec_nanos() / NANOS_PER_SECOND;
 
-                    let psc = u16((ticks - 1) / (1 << 16)).unwrap();
+                    let psc = u16((ticks.max(1) - 1) / (1 << 16)).unwrap();
                     self.tim.psc.write(|w| { w.psc().bits(psc) });
 
                     let arr = u16(ticks / u32(psc + 1)).unwrap();


### PR DESCRIPTION
I have a use-case where I need to set a specific timer timeout (using interrupts).

Of course it would be possible to convert the delay into a frequency, but then it would involve one division (delay -> Hz) and another one back (Hz -> delay).  It seemed more natural to support duration delays directly.

It might also make sense to use `CountDown<Time=Duration>` as well, but since there is already a `CountDown<Time=Hz>` I couldn't add a conflicting one.  However it might make sense to reconsider whether it makes sense to measure a duration in Hz, as is currently the case in this crate?