### PR TITLE
Added time types for microseconds and nanoseconds

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -24,6 +24,14 @@ pub struct MegaHertz(pub u32);
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
 pub struct MilliSeconds(pub u32);
 
+/// MicroSeconds
+#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+pub struct MicroSeconds(pub u32);
+
+/// NanoSeconds
+#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+pub struct NanoSeconds(pub u32);
+
 impl fmt::Display for Bps {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} bits per second", self.0)
@@ -49,6 +57,16 @@ impl fmt::Display for MilliSeconds {
         write!(f, "{} ms", self.0)
     }
 }
+impl fmt::Display for MicroSeconds {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} us", self.0)
+    }
+}
+impl fmt::Display for NanoSeconds {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} ns", self.0)
+    }
+}
 
 /// Extension trait that adds convenience methods to the `u32` type
 pub trait U32Ext {
@@ -66,6 +84,12 @@ pub trait U32Ext {
 
     /// Wrap in "MilliSeconds"
     fn ms(self) -> MilliSeconds;
+
+    /// Wrap in "MicroSeconds"
+    fn us(self) -> MicroSeconds;
+
+    /// Wrap in "NanoSeconds"
+    fn ns(self) -> NanoSeconds;
 }
 
 impl U32Ext for u32 {
@@ -87,6 +111,14 @@ impl U32Ext for u32 {
 
     fn ms(self) -> MilliSeconds {
         MilliSeconds(self)
+    }
+
+    fn us(self) -> MicroSeconds {
+        MicroSeconds(self)
+    }
+
+    fn ns(self) -> NanoSeconds {
+        NanoSeconds(self)
     }
 }
 
@@ -112,6 +144,24 @@ impl Into<Hertz> for MegaHertz {
 impl Into<KiloHertz> for MegaHertz {
     fn into(self) -> KiloHertz {
         KiloHertz(self.0 * 1_000)
+    }
+}
+
+impl Into<NanoSeconds> for MicroSeconds {
+    fn into(self) -> NanoSeconds {
+        NanoSeconds(self.0 * 1_000)
+    }
+}
+
+impl Into<NanoSeconds> for MilliSeconds {
+    fn into(self) -> NanoSeconds {
+        NanoSeconds(self.0 * 1_000_000)
+    }
+}
+
+impl Into<MicroSeconds> for MilliSeconds {
+    fn into(self) -> MicroSeconds {
+        MicroSeconds(self.0 * 1_000)
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -188,6 +188,20 @@ impl Into<Duration> for MilliSeconds {
     }
 }
 
+// Into core::time::Duration
+impl Into<Duration> for MicroSeconds {
+    fn into(self) -> Duration {
+        Duration::from_micros(self.0 as u64)
+    }
+}
+
+// Into core::time::Duration
+impl Into<Duration> for NanoSeconds {
+    fn into(self) -> Duration {
+        Duration::from_nanos(self.0 as u64)
+    }
+}
+
 // /// A monotonic nondecreasing timer
 // #[derive(Clone, Copy)]
 // pub struct MonoTimer {


### PR DESCRIPTION
Operations like specifying timer dead time or pulse width or time delay
make more sense as times rather than frequencies. These time durations
can be measured in (tens or hundreds of) nanoseconds, so it makes sense
to have units to specify durations or delays measured in ns or us.

This PR only adds MicroSeconds and NanoSeconds and conversions between
them and MilliSeconds. I would like to have the 'advanced' timer functions
I'm working on take NanoSeconds as a parameter.