### PR TITLE
Impl Copy, Clone, PartialEq for enums

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -47,6 +47,7 @@ pub struct OpenDrain;
 pub struct Analog;
 
 /// GPIO Pin speed selection
+#[derive(Copy, Clone, PartialEq)]
 pub enum Speed {
     Low = 0,
     Medium = 1,
@@ -55,6 +56,7 @@ pub enum Speed {
 }
 
 /// GPIO Edge selection
+#[derive(Copy, Clone, PartialEq)]
 pub enum Edge {
     RISING,
     FALLING,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -19,6 +19,7 @@ use cast::u16;
 /// I2C Events
 ///
 /// Each event is a possible interrupt sources, if enabled
+#[derive(Copy, Clone, PartialEq)]
 pub enum Event {
     /// (TXIE)
     Transmit,

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -86,7 +86,7 @@ pub struct Pwr {
 /// Generated when the PWR peripheral is frozen. The existence of this
 /// value indicates that the voltage scaling configuration can no
 /// longer be changed.
-#[derive(PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum VoltageScale {
     Scale0,
     Scale1,

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -86,7 +86,7 @@ pub struct Pwr {
 /// Generated when the PWR peripheral is frozen. The existence of this
 /// value indicates that the voltage scaling configuration can no
 /// longer be changed.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(PartialEq)]
 pub enum VoltageScale {
     Scale0,
     Scale1,

--- a/src/qspi.rs
+++ b/src/qspi.rs
@@ -52,7 +52,7 @@ use crate::{
 use core::ptr;
 
 /// Represents operation modes of the QSPI interface.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum QspiMode {
     /// Only a single IO line (IO0) is used for transmit and a separate line (IO1) is used for receive.
     OneBit,
@@ -65,14 +65,14 @@ pub enum QspiMode {
 }
 
 /// Indicates an error with the QSPI peripheral.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum QspiError {
     Busy,
     Underflow,
 }
 
 /// Indicates a specific QSPI bank to use.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Bank {
     One,
     Two,

--- a/src/sai/mod.rs
+++ b/src/sai/mod.rs
@@ -71,12 +71,14 @@ pub trait INTERFACE {}
 /// SAI Events
 ///
 /// Each event is a possible interrupt sources, if enabled
+#[derive(Copy, Clone, PartialEq)]
 pub enum Event {
     /// Data is available / is required in the FIFO
     Data,
 }
 
 /// SAI Channels
+#[derive(Copy, Clone, PartialEq)]
 pub enum SaiChannel {
     ChannelA,
     ChannelB,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -54,6 +54,7 @@ pub enum Error {
 }
 
 /// Interrupt event
+#[derive(Copy, Clone, PartialEq)]
 pub enum Event {
     /// New data has been received
     Rxne,
@@ -66,17 +67,20 @@ pub enum Event {
 pub mod config {
     use crate::time::Hertz;
 
+    #[derive(Copy, Clone, PartialEq)]
     pub enum WordLength {
         DataBits8,
         DataBits9,
     }
 
+    #[derive(Copy, Clone, PartialEq)]
     pub enum Parity {
         ParityNone,
         ParityEven,
         ParityOdd,
     }
 
+    #[derive(Copy, Clone, PartialEq)]
     pub enum StopBits {
         #[doc = "1 stop bit"]
         STOP1,

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -328,6 +328,7 @@ pins! {
 }
 
 /// Interrupt events
+#[derive(Copy, Clone, PartialEq)]
 pub enum Event {
     /// New data has been received
     Rxp,


### PR DESCRIPTION
I was annoyed when an enum didn't impl Copy so I decided to add these impls to all enums that could use them. I chose `Copy, Clone, PartialEq` since I thought those would be uncontroversial. `Debug` could be useful as well, and some of the enums already impl it, but having lots of `Debug` impls slows compile times and bloats binaries. I didn't add impls to error types since maybe they might want to include some information which would conflict with the impls.