### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,11 @@ cortex-m-rt = "^0.6.12"
 stm32h7 = "0.11.0"
 void = { version = "1.0.2", default-features = false }
 cast = { version = "0.2.3", default-features = false }
-nb = "0.1.2"
-paste = "0.1.18"
+nb = "1.0.0"
+paste = "1.0.1"
+bare-metal = "1.0.0"
 sdio-host = { version = "0.4", optional = true }
 stm32-fmc = { version = "0.2", optional = true }
-
-[dependencies.bare-metal]
-version = "0.2.5"
-features = ["const-fn"]
 
 [dependencies.smoltcp]
 version = "0.6.0"


### PR DESCRIPTION
This is a **breaking change** due to changing the re-exported `Nb` types.