### PR TITLE
Ensure VoltageScale remains frozen from Pwr::freeze() to Rcc::freeze()

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,13 +13,13 @@ PWR. For instance if your board uses the internal LDO to supply VCORE, you
 can replace:
 
 ```rust
-let vos = pwr.freeze();
+let pwrcfg = pwr.freeze();
 ```
 
 with
 
 ```rust
-let vos = pwr.ldo().freeze();
+let pwrcfg = pwr.ldo().freeze();
 ```
 
 The results of calling the wrong builder method for your hardware are

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -24,7 +24,7 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
@@ -39,7 +39,7 @@ fn main() -> ! {
     let ccdr = rcc
         .sys_ck(100.mhz())
         .per_ck(4.mhz())
-        .freeze(vos, &dp.SYSCFG);
+        .freeze(pwrcfg, &dp.SYSCFG);
 
     // Switch adc_ker_ck_input multiplexer to per_ck
     let d3ccipr = &unsafe { &*pac::RCC::ptr() }.d3ccipr;

--- a/examples/adc12.rs
+++ b/examples/adc12.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
@@ -32,7 +32,7 @@ fn main() -> ! {
     let ccdr = rcc
         .sys_ck(100.mhz())
         .pll2_p_ck(4.mhz()) // Default adc_ker_ck_input
-        .freeze(vos, &dp.SYSCFG);
+        .freeze(pwrcfg, &dp.SYSCFG);
 
     info!("");
     info!("stm32h7xx-hal example - ADC1 and ADC2");

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -20,12 +20,12 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(100.mhz()).freeze(pwrcfg, &dp.SYSCFG);
 
     info!("");
     info!("stm32h7xx-hal example - Blinky");

--- a/examples/blinky_random.rs
+++ b/examples/blinky_random.rs
@@ -20,12 +20,12 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(100.mhz()).freeze(pwrcfg, &dp.SYSCFG);
 
     info!("");
     info!("stm32h7xx-hal example - Random Blinky");

--- a/examples/blinky_timer.rs
+++ b/examples/blinky_timer.rs
@@ -22,12 +22,12 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let ccdr = rcc.freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.freeze(pwrcfg, &dp.SYSCFG);
 
     info!("");
     info!("stm32h7xx-hal example - Blinky timer");

--- a/examples/dac.rs
+++ b/examples/dac.rs
@@ -22,12 +22,12 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let ccdr = rcc.sys_ck(8.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(8.mhz()).freeze(pwrcfg, &dp.SYSCFG);
 
     let mut delay = cp.SYST.delay(ccdr.clocks);
 

--- a/examples/ethernet-nucleo-h743zi2.rs
+++ b/examples/ethernet-nucleo-h743zi2.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
     // Initialise power...
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Initialise SRAM3
     info!("Setup RCC...                  ");
@@ -67,7 +67,7 @@ fn main() -> ! {
         .sys_ck(200.mhz())
         .hclk(200.mhz())
         .pll1_r_ck(100.mhz()) // for TRACECK
-        .freeze(vos, &dp.SYSCFG);
+        .freeze(pwrcfg, &dp.SYSCFG);
 
     // Get the delay provider.
     let delay = cp.SYST.delay(ccdr.clocks);

--- a/examples/ethernet-rtic-stm32h747i-disco.rs
+++ b/examples/ethernet-rtic-stm32h747i-disco.rs
@@ -126,7 +126,7 @@ const APP: () = {
         logger::init();
         // Initialise power...
         let pwr = ctx.device.PWR.constrain();
-        let vos = pwr.smps().freeze();
+        let pwrcfg = pwr.smps().freeze();
 
         // Link the SRAM3 power state to CPU1
         ctx.device.RCC.ahb2enr.modify(|_, w| w.sram3en().set_bit());
@@ -136,7 +136,7 @@ const APP: () = {
         let ccdr = rcc
             .sys_ck(200.mhz())
             .hclk(200.mhz())
-            .freeze(vos, &ctx.device.SYSCFG);
+            .freeze(pwrcfg, &ctx.device.SYSCFG);
 
         // Initialise system...
         ctx.core.SCB.invalidate_icache();

--- a/examples/ethernet-stm32h747i-disco.rs
+++ b/examples/ethernet-stm32h747i-disco.rs
@@ -39,7 +39,7 @@ fn main() -> ! {
     // Initialise power...
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.smps().freeze();
+    let pwrcfg = pwr.smps().freeze();
 
     // Link the SRAM3 power state to CPU1
     info!("Setup RCC...                  ");
@@ -50,7 +50,7 @@ fn main() -> ! {
     let ccdr = rcc
         .sys_ck(200.mhz())
         .hclk(200.mhz())
-        .freeze(vos, &dp.SYSCFG);
+        .freeze(pwrcfg, &dp.SYSCFG);
 
     // Initialise system...
     cp.SCB.invalidate_icache();

--- a/examples/fmc.rs
+++ b/examples/fmc.rs
@@ -116,14 +116,14 @@ const APP: () = {
 
         // Initialise power...
         let pwr = dp.PWR.constrain();
-        let vos = pwr.freeze();
+        let pwrcfg = pwr.freeze();
 
         // Initialise clocks...
         let rcc = dp.RCC.constrain();
         let ccdr = rcc
             .sys_ck(200.mhz())
             .hclk(200.mhz()) // FMC clock from HCLK by default
-            .freeze(vos, &dp.SYSCFG);
+            .freeze(pwrcfg, &dp.SYSCFG);
 
         // Get the delay provider.
         let mut delay = ctx.core.SYST.delay(ccdr.clocks);

--- a/examples/fractional-pll.rs
+++ b/examples/fractional-pll.rs
@@ -18,7 +18,7 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
@@ -32,7 +32,7 @@ fn main() -> ! {
         .pll2_r_ck((48_000 * 63).hz())
         // pll2_p / 2 --> mco2
         .mco2_from_pll2_p_ck(7.mhz())
-        .freeze(vos, &dp.SYSCFG);
+        .freeze(pwrcfg, &dp.SYSCFG);
 
     // Enable MCO2 output pin
     let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -17,12 +17,12 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(100.mhz()).freeze(pwrcfg, &dp.SYSCFG);
     let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
 
     // Configure the SCL and the SDA pin for our I2C bus

--- a/examples/mco.rs
+++ b/examples/mco.rs
@@ -17,7 +17,7 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
@@ -27,7 +27,7 @@ fn main() -> ! {
         .mco1_from_hsi48(24.mhz())
         .pll2_strategy(PllConfigStrategy::Iterative)
         .mco2_from_pll2_p_ck(25_600.khz())
-        .freeze(vos, &dp.SYSCFG);
+        .freeze(pwrcfg, &dp.SYSCFG);
 
     let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
     let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);

--- a/examples/prec_kernel_clocks.rs
+++ b/examples/prec_kernel_clocks.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
 
     // Constrain and Freeze power
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     let rcc = dp.RCC.constrain();
@@ -32,7 +32,7 @@ fn main() -> ! {
         .pll1_q_ck(4.mhz())
         .pll3_p_ck(4.mhz())
         .pll3_r_ck(4.mhz())
-        .freeze(vos, &dp.SYSCFG);
+        .freeze(pwrcfg, &dp.SYSCFG);
 
     // Set group kernel clock to PLL3 R CK. Needs mutable ccdr
     ccdr.peripheral.kernel_i2c123_clk_mux(I2c123ClkSel::PLL3_R);

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -18,12 +18,12 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let ccdr = rcc.sys_ck(8.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(8.mhz()).freeze(pwrcfg, &dp.SYSCFG);
 
     // Acquire the GPIOE peripheral. This also enables the clock for
     // GPIOE in the RCC register.

--- a/examples/qspi.rs
+++ b/examples/qspi.rs
@@ -17,11 +17,11 @@ fn main() -> ! {
 
     // Constrain and Freeze power
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     let rcc = dp.RCC.constrain();
-    let ccdr = rcc.sys_ck(96.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(96.mhz()).freeze(pwrcfg, &dp.SYSCFG);
 
     // Acquire the GPIO peripherals. This also enables the clock for
     // the GPIOs in the RCC register.

--- a/examples/rcc.rs
+++ b/examples/rcc.rs
@@ -18,12 +18,12 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(100.mhz()).freeze(pwrcfg, &dp.SYSCFG);
 
     info!("");
     info!("stm32h7xx-hal example - RCC");

--- a/examples/rtic.rs
+++ b/examples/rtic.rs
@@ -25,14 +25,14 @@ const APP: () = {
     #[init]
     fn init(mut ctx: init::Context) -> init::LateResources {
         let pwr = ctx.device.PWR.constrain();
-        let vos = pwr.freeze();
+        let pwrcfg = pwr.freeze();
 
         // RCC
         let rcc = ctx.device.RCC.constrain();
         let ccdr = rcc
             .use_hse(25.mhz())
             .sys_ck(400.mhz())
-            .freeze(vos, &ctx.device.SYSCFG);
+            .freeze(pwrcfg, &ctx.device.SYSCFG);
 
         // GPIO
         let gpioc = ctx.device.GPIOC.split(ccdr.peripheral.GPIOC);

--- a/examples/rtic_timers.rs
+++ b/examples/rtic_timers.rs
@@ -33,14 +33,14 @@ const APP: () = {
     #[init]
     fn init(ctx: init::Context) -> init::LateResources {
         let pwr = ctx.device.PWR.constrain();
-        let vos = pwr.freeze();
+        let pwrcfg = pwr.freeze();
 
         // RCC
         let rcc = ctx.device.RCC.constrain();
         let ccdr = rcc
             .use_hse(25.mhz())
             .sys_ck(400.mhz())
-            .freeze(vos, &ctx.device.SYSCFG);
+            .freeze(pwrcfg, &ctx.device.SYSCFG);
 
         // Timers
         let mut timer1 =

--- a/examples/sai_pdm.rs
+++ b/examples/sai_pdm.rs
@@ -19,7 +19,7 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
@@ -27,7 +27,7 @@ fn main() -> ! {
     let ccdr = rcc
         .sys_ck(100.mhz())
         .pll1_q_ck(20_480.khz()) // SAI1 clock source
-        .freeze(vos, &dp.SYSCFG);
+        .freeze(pwrcfg, &dp.SYSCFG);
 
     // Acquire GPIO peripherals. This also enables the clock for each
     // GPIO in the RCC register.

--- a/examples/sdmmc.rs
+++ b/examples/sdmmc.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
@@ -32,7 +32,7 @@ fn main() -> ! {
     let ccdr = rcc
         .sys_ck(400.mhz())
         .pll1_q_ck(100.mhz())
-        .freeze(vos, &dp.SYSCFG);
+        .freeze(pwrcfg, &dp.SYSCFG);
 
     let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
     gpiob.pb3.into_alternate_af0();

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -21,12 +21,12 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let ccdr = rcc.sys_ck(160.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(160.mhz()).freeze(pwrcfg, &dp.SYSCFG);
 
     // Acquire the GPIOC peripheral. This also enables the clock for
     // GPIOC in the RCC register.

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -19,7 +19,7 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
@@ -27,7 +27,7 @@ fn main() -> ! {
     let ccdr = rcc
         .sys_ck(96.mhz())
         .pll1_q_ck(48.mhz())
-        .freeze(vos, &dp.SYSCFG);
+        .freeze(pwrcfg, &dp.SYSCFG);
 
     // Acquire the GPIOC peripheral. This also enables the clock for
     // GPIOC in the RCC register.

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
@@ -38,7 +38,7 @@ fn main() -> ! {
     let ccdr = rcc
         .sys_ck(100.mhz())
         .pll2_p_ck(4.mhz()) // Default adc_ker_ck_input
-        .freeze(vos, &dp.SYSCFG);
+        .freeze(pwrcfg, &dp.SYSCFG);
 
     info!("");
     info!("stm32h7xx-hal example - Temperature");

--- a/examples/vos0.rs
+++ b/examples/vos0.rs
@@ -17,7 +17,7 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.vos0(&dp.SYSCFG).freeze();
+    let pwrcfg = pwr.vos0(&dp.SYSCFG).freeze();
 
     // Constrain and Freeze clock
     // The PllConfigStrategy::Normal strategy uses the medium range VCO which has a maximum of 420 Mhz
@@ -27,7 +27,7 @@ fn main() -> ! {
     let ccdr = rcc
         .sys_ck(480.mhz())
         .pll1_strategy(rcc::PllConfigStrategy::Iterative)
-        .freeze(vos, &dp.SYSCFG);
+        .freeze(pwrcfg, &dp.SYSCFG);
 
     info!("");
     info!("stm32h7xx-hal example - VOS0");

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -17,12 +17,12 @@ fn main() -> ! {
     // Constrain and Freeze power
     info!("Setup PWR...                  ");
     let pwr = dp.PWR.constrain();
-    let vos = pwr.freeze();
+    let pwrcfg = pwr.freeze();
 
     // Constrain and Freeze clock
     info!("Setup RCC...                  ");
     let rcc = dp.RCC.constrain();
-    let ccdr = rcc.sys_ck(96.mhz()).freeze(vos, &dp.SYSCFG);
+    let ccdr = rcc.sys_ck(96.mhz()).freeze(pwrcfg, &dp.SYSCFG);
 
     #[cfg(any(feature = "singlecore"))]
     let mut watchdog = SystemWindowWatchdog::new(dp.WWDG, &ccdr);

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -282,9 +282,13 @@ impl Pwr {
                 &(*SYSCFG::ptr()).pwrcr.modify(|_, w| w.oden().bits(1))
             };
             while self.rb.d3cr.read().vosrdy().bit_is_clear() {}
-            return PowerConfiguration { vos: VoltageScale::Scale0 };
+            return PowerConfiguration {
+                vos: VoltageScale::Scale0,
+            };
         }
 
-        PowerConfiguration { vos: VoltageScale::Scale1 }
+        PowerConfiguration {
+            vos: VoltageScale::Scale1,
+        }
     }
 }

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -139,8 +139,8 @@
 //!
 #![deny(missing_docs)]
 
-use crate::pwr::VoltageScale as Voltage;
 use crate::pwr::PowerConfiguration;
+use crate::pwr::VoltageScale as Voltage;
 use crate::stm32::rcc::cfgr::SW_A as SW;
 use crate::stm32::rcc::cfgr::TIMPRE_A as TIMPRE;
 use crate::stm32::rcc::d1ccipr::CKPERSEL_A as CKPERSEL;
@@ -560,7 +560,11 @@ impl Rcc {
     /// function may also panic if a clock specification can be
     /// achieved, but the mechanism for doing so is not yet
     /// implemented here.
-    pub fn freeze(mut self, pwrcfg: PowerConfiguration, syscfg: &SYSCFG) -> Ccdr {
+    pub fn freeze(
+        mut self,
+        pwrcfg: PowerConfiguration,
+        syscfg: &SYSCFG,
+    ) -> Ccdr {
         // We do not reset RCC here. This routine must assert when
         // the previous state of the RCC peripheral is unacceptable.
 

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -23,7 +23,7 @@
 //! // Constrain and Freeze power
 //! ...
 //! let rcc = dp.RCC.constrain();
-//! let ccdr = rcc.sys_ck(100.mhz()).freeze(vos, &dp.SYSCFG);
+//! let ccdr = rcc.sys_ck(100.mhz()).freeze(pwrcfg, &dp.SYSCFG);
 //!
 //! // Enable the clock to a peripheral and reset it
 //! ccdr.peripheral.FDCAN.enable().reset();

--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -23,7 +23,7 @@
 //! ```
 //! let ccdr = rcc
 //!     .pll1_q_ck(100.mhz())
-//!     .freeze(vos, &dp.SYSCFG);
+//!     .freeze(pwrcfg, &dp.SYSCFG);
 //! ```
 //!
 //! There is an [extension trait](crate::sdmmc::SdmmcExt) implemented for the


### PR DESCRIPTION
This ensures that the `VoltageScale` configured by `Pwr::freeze()` cannot be changed when it is passed to `Rcc::freeze()`, while still allowing access to the `VoltageScale` value.

See https://github.com/stm32-rs/stm32h7xx-hal/pull/139#discussion_r494572457

This is a **breaking change**.