### PR TITLE
Add MCUDev DevEBox and WeAct MiniSTM32H7 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Board | Manufacturer | BSP / Examples?
 [Portenta H7](https://store.arduino.cc/portenta-h7) ⚠️ | Arduino |
 [OpenH743I-C](https://www.waveshare.com/openh743i-c-standard.htm) | Waveshare |
 [Toasty](https://www.tindie.com/products/webtronics/toasty-480mhz-stm32-usb-development-board/) | Webtronics |
+[DevEBox](https://item.taobao.com/item.htm?id=601083694791) | MCUDev |
+[MiniSTM32H7xx](https://github.com/WeActTC/MiniSTM32H7xx) | WeAct Studio |
 
 ⚠️: Programming this board via its USB connector requires interacting with
 an unknown proprietary(?) bootloader. This bootloader may make it difficult


### PR DESCRIPTION
Adds the MCUDev DevEBox and WeAct MiniSTM32H7 to the readme, relatively cheap development boards.

I've done the basic blinky test for both of these boards. In the case of the DevEBox, I tested the STM32H743VIT6 version.

I'd prefer to link to a documentation source for the DevEBox, rather than their Taobao store, but I cannot find any site they run other than their store. There's a [MicroPython board definition repo by mcauser](https://github.com/mcauser/MCUDEV_DEVEBOX_H7XX_M) that documents some aspects of the board.

I didn't add it to the readme but the WeAct board has read-out protection enabled and I had to manually issue a mass erase command to be able to connect to it. STM32CubeProg's read unprotect command just disconnected the board from USB with no other effect.