### PR TITLE
Implement RTC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - stm32h753v
           - stm32h747cm7
     env:                        # Peripheral Feature flags
-      FLAGS: rt,quadspi,sdmmc,fmc,usb_hs
+      FLAGS: rt,quadspi,sdmmc,fmc,usb_hs,rtc
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
           - log-semihost
           - log-rtt
     env:                        # Peripheral Feature flags
-      FLAGS: rt,quadspi,sdmmc,fmc,usb_hs
+      FLAGS: rt,quadspi,sdmmc,fmc,usb_hs,rtc
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 exclude = [".gitignore"]
 
 [package.metadata.docs.rs]
-features = ["stm32h743", "rt", "quadspi", "sdmmc", "fmc", "ethernet", "phy_lan8742a"]
+features = ["stm32h743v", "rt", "quadspi", "sdmmc", "fmc", "ethernet", "phy_lan8742a", "rtc"]
 targets = ["thumbv7em-none-eabihf"]
 
 [dependencies]
@@ -40,6 +40,11 @@ stm32-fmc = { version = "0.2", optional = true }
 version = "0.6.0"
 default-features = false
 features = ["ethernet", "proto-ipv4", "proto-dhcpv4", "socket-tcp", "socket-raw"]
+optional = true
+
+[dependencies.chrono]
+version = "0.4"
+default-features = false
 optional = true
 
 [dev-dependencies]
@@ -76,6 +81,7 @@ sdmmc = ["sdio-host"]
 ethernet = ["smoltcp"]
 phy_ksz8081r = []
 phy_lan8742a = []
+rtc = ["chrono"]
 rt = ["stm32h7/rt"]
 stm32h742 = ["stm32h7/stm32h743", "device-selected", "singlecore"]
 stm32h743 = ["stm32h7/stm32h743", "device-selected", "singlecore"]
@@ -140,3 +146,7 @@ required-features = ["phy_lan8742a", "rt", "revision_v", "stm32h743v", "ethernet
 [[example]]
 name = "tick_timer"
 required-features = ["rt"]
+
+[[example]]
+name = "rtc"
+required-features = ["rt", "rtc"]

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -18,7 +18,6 @@ mod logger;
 #[entry]
 fn main() -> ! {
     logger::init();
-    let cp = cortex_m::Peripherals::take().unwrap();
     let dp = pac::Peripherals::take().unwrap();
 
     // Constrain and Freeze power
@@ -45,9 +44,17 @@ fn main() -> ! {
         rtc::RtcClock::Lsi,
         &ccdr.clocks,
     );
-    rtc.set_date_time(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0));
+
+    // TODO: Get current time from some source
+    let now = NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0);
+
+    rtc.set_date_time(now);
     rtc.listen(rtc::Event::Wakeup);
     rtc.enable_wakeup(10);
+
+    unsafe {
+        pac::NVIC::unmask(interrupt::RTC_WKUP);
+    }
 
     loop {
         info!("Time: {}", rtc.time().unwrap());

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -1,0 +1,60 @@
+//! Example of configuring the real-time clock using the internal LSI oscillator
+
+#![no_main]
+#![no_std]
+
+use log::info;
+
+use chrono::prelude::*;
+use cortex_m::asm;
+use cortex_m_rt::entry;
+
+use pac::interrupt;
+use stm32h7xx_hal::{pac, prelude::*, rtc};
+
+#[path = "utilities/logger.rs"]
+mod logger;
+
+#[entry]
+fn main() -> ! {
+    logger::init();
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let mut pwrcfg = pwr.freeze();
+
+    // Take the backup power domain
+    let backup = pwrcfg.backup().unwrap();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+
+    let ccdr = rcc.sys_ck(100.mhz()).freeze(pwrcfg, &dp.SYSCFG);
+
+    info!("");
+    info!("stm32h7xx-hal example - RTC");
+    info!("");
+
+    let mut rtc = rtc::Rtc::open_or_init(
+        dp.RTC,
+        backup.RTC,
+        rtc::RtcClock::Lsi,
+        &ccdr.clocks,
+    );
+    rtc.set_date_time(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0));
+    rtc.listen(rtc::Event::Wakeup);
+    rtc.enable_wakeup(10);
+
+    loop {
+        info!("Time: {}", rtc.time().unwrap());
+        rtc.unpend(rtc::Event::Wakeup);
+        asm::wfi();
+    }
+}
+
+#[interrupt]
+fn RTC_WKUP() {}

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -46,7 +46,7 @@ fn main() -> ! {
     );
 
     // TODO: Get current time from some source
-    let now = NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0);
+    let now = NaiveDate::from_ymd(2001, 1, 1).and_hms(0, 0, 0);
 
     rtc.set_date_time(now);
     rtc.listen(rtc::Event::Wakeup);

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -64,4 +64,6 @@ fn main() -> ! {
 }
 
 #[interrupt]
-fn RTC_WKUP() {}
+fn RTC_WKUP() {
+    // Just cause the asm::wfi() above to complete so the loop runs one more time
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,8 @@ pub mod qspi;
 pub mod rcc;
 #[cfg(feature = "device-selected")]
 pub mod rng;
+#[cfg(all(feature = "device-selected", feature = "rtc"))]
+pub mod rtc;
 #[cfg(feature = "device-selected")]
 pub mod sai;
 #[cfg(all(feature = "device-selected", feature = "sdmmc"))]

--- a/src/rcc/backup.rs
+++ b/src/rcc/backup.rs
@@ -1,0 +1,133 @@
+//! Backup Power Domain Reset, Enable, and Clock Control
+//!
+//! Reset, enable and Clock functionality for Backup Power Domain
+//! peripherals. The backup power domain can run separately and be
+//! powered separately from the other domains; these peripherals may
+//! be enabled even after a core reset.
+//!
+//! # Example
+//!
+//! ```
+//! ...
+//! // Constrain and Freeze power
+//! let pwr = dp.PWR.constrain();
+//! let mut pwrcfg = pwr.freeze();
+//!
+//! // Take the backup power domain
+//! let backup = pwrcfg.backup().unwrap();
+//!
+//! if backup.RTC.is_enabled() {
+//!     println!("RTC Enabled");
+//! }
+//! ```
+
+/// Backup Power Domain Peripheral Reset and Enable Control
+#[allow(non_snake_case, missing_docs)]
+#[non_exhaustive]
+pub struct BackupREC {
+    #[cfg(feature = "rtc")]
+    pub RTC: Rtc,
+}
+
+impl BackupREC {
+    /// Creates a new `Backup`
+    ///
+    /// # Safety
+    ///
+    /// Must only be called once, after the backup domain write
+    /// protection is disabled.
+    pub(crate) unsafe fn new_singleton() -> Self {
+        Self {
+            #[cfg(feature = "rtc")]
+            RTC: Rtc {
+                _marker: core::marker::PhantomData,
+            },
+        }
+    }
+}
+
+#[cfg(feature = "rtc")]
+pub use rtc::{Rtc, RtcClkSel};
+
+#[cfg(feature = "rtc")]
+mod rtc {
+    use crate::rcc::rec::ResetEnable;
+    use crate::stm32::RCC;
+    use core::marker::PhantomData;
+    use cortex_m::interrupt;
+
+    /// Reset, Enable and Clock functionality for RTC
+    pub struct Rtc {
+        pub(super) _marker: PhantomData<*const ()>,
+    }
+
+    unsafe impl Send for Rtc {}
+
+    impl ResetEnable for Rtc {
+        #[inline(always)]
+        fn enable(self) -> Self {
+            // unsafe: Owned exclusive access to this bitfield
+            interrupt::free(|_| {
+                let bdcr = unsafe { &(*RCC::ptr()).bdcr };
+                bdcr.modify(|_, w| w.rtcen().set_bit());
+            });
+            self
+        }
+        #[inline(always)]
+        fn disable(self) -> Self {
+            // unsafe: Owned exclusive access to this bitfield
+            interrupt::free(|_| {
+                let bdcr = unsafe { &(*RCC::ptr()).bdcr };
+                bdcr.modify(|_, w| w.rtcen().clear_bit());
+            });
+            self
+        }
+        #[inline(always)]
+        fn reset(self) -> Self {
+            // unsafe: Owned exclusive access to this bitfield
+            interrupt::free(|_| {
+                let bdcr = unsafe { &(*RCC::ptr()).bdcr };
+                bdcr.modify(|_, w| w.bdrst().set_bit());
+                bdcr.modify(|_, w| w.bdrst().clear_bit());
+            });
+            self
+        }
+    }
+
+    /// RTC kernel clock source selection
+    pub type RtcClkSel = crate::stm32::rcc::bdcr::RTCSEL_A;
+
+    impl Rtc {
+        /// Returns true if the RTC is enabled.
+        pub fn is_enabled(&self) -> bool {
+            // unsafe: Owned exclusive access to this bitfield
+            interrupt::free(|_| {
+                let bdcr = unsafe { &(*RCC::ptr()).bdcr };
+                bdcr.read().rtcen().bit_is_set()
+            })
+        }
+
+        #[inline(always)]
+        /// Modify a kernel clock for this
+        /// peripheral. See RM0433 Section 8.5.8.
+        ///
+        /// # NOTE
+        ///
+        /// This may only be written one time per peripheral reset.
+        /// Check `get_kernel_clk_mux()` to see if the write succeeded.
+        pub fn kernel_clk_mux(&mut self, sel: RtcClkSel) {
+            // unsafe: Owned exclusive access to this bitfield
+            interrupt::free(|_| {
+                let bdcr = unsafe { &(*RCC::ptr()).bdcr };
+                bdcr.modify(|_, w| w.rtcsel().variant(sel));
+            });
+        }
+
+        /// Return the current kernel clock selection
+        pub fn get_kernel_clk_mux(&self) -> RtcClkSel {
+            // unsafe: We only read from this bitfield
+            let bdcr = unsafe { &(*RCC::ptr()).bdcr };
+            bdcr.read().rtcsel().variant()
+        }
+    }
+}

--- a/src/rcc/core_clocks.rs
+++ b/src/rcc/core_clocks.rs
@@ -20,6 +20,7 @@ pub struct CoreClocks {
     pub(super) csi_ck: Option<Hertz>,
     pub(super) hsi_ck: Option<Hertz>,
     pub(super) hsi48_ck: Option<Hertz>,
+    pub(super) lsi_ck: Option<Hertz>,
     pub(super) per_ck: Option<Hertz>,
     pub(super) hse_ck: Option<Hertz>,
     pub(super) mco1_ck: Option<Hertz>,
@@ -106,6 +107,7 @@ impl CoreClocks {
         hsi48_ck: "hsi48_ck",
         per_ck: "per_ck",
         hse_ck: "hse_ck",
+        lsi_ck: "lsi_ck",
     }
 
     /// Returns `Some(frequency)` if the MCO1 output is running, otherwise

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -615,7 +615,7 @@ impl Rtc {
         Ok(())
     }
 
-    /// Configures the wakeup timer to trigger periodically after `interval` seconds
+    /// Configures the wakeup timer to trigger periodically every `interval` seconds
     ///
     /// # Panics
     ///
@@ -629,7 +629,7 @@ impl Rtc {
             self.reg
                 .cr
                 .modify(|_, w| unsafe { w.wucksel().bits(0b110) });
-            let interval = u16(interval - 1 << 16)
+            let interval = u16(interval - (1 << 16) - 1)
                 .expect("Interval was too large for wakeup timer");
             self.reg.wutr.write(|w| unsafe { w.wut().bits(interval) });
         } else {
@@ -637,7 +637,7 @@ impl Rtc {
                 .cr
                 .modify(|_, w| unsafe { w.wucksel().bits(0b100) });
             let interval =
-                u16(interval).expect("Interval was too large for wakeup timer");
+                u16(interval - 1).expect("Interval was too large for wakeup timer");
             self.reg.wutr.write(|w| unsafe { w.wut().bits(interval) });
         }
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -482,6 +482,7 @@ impl Rtc {
     fn ss_to_us(&self, ss: u16) -> u32 {
         let ss = u32(ss);
         let prediv_s = u32(self.reg.prer.read().prediv_s().bits());
+        assert!(ss <= prediv_s); // See RM0433 Rev 7 46.6.10, shift operations not supported
         // Multiplying (prediv_s - ss) by 1,000,000 could overflow a u32 if prediv_s is large enough.
         // u64 division would call `__aeabi_uldivmod` which is large and slow.
         // Our maximum resolution is 1/32768 seconds or 32.5 us, so we can get away with rounding to

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -208,7 +208,10 @@ impl Rtc {
             let s_pre = total_div / a_pre;
             (a_pre, s_pre)
         };
-        assert!(a_pre <= a_pre_max && s_pre <= s_pre_max, "Invalid RTC prescaler value");
+        assert!(
+            a_pre <= a_pre_max && s_pre <= s_pre_max,
+            "Invalid RTC prescaler value"
+        );
 
         rtc.prer.write(|w| unsafe {
             w.prediv_s()
@@ -573,7 +576,9 @@ impl Rtc {
                 .expect("Interval was too large for wakeup timer");
             self.reg.wutr.write(|w| unsafe { w.wut().bits(interval) });
         } else {
-            self.reg.cr.modify(|_, w| unsafe { w.wucksel().bits(0b100) });
+            self.reg
+                .cr
+                .modify(|_, w| unsafe { w.wucksel().bits(0b100) });
             let interval =
                 u16(interval).expect("Interval was too large for wakeup timer");
             self.reg.wutr.write(|w| unsafe { w.wut().bits(interval) });
@@ -636,7 +641,9 @@ impl Rtc {
 
         // Clear timestamp interrupt and internal timestamp interrupt (VBat transition)
         // TODO: Timestamp overflow flag
-        self.reg.isr.modify(|_, w| w.tsf().clear_bit().itsf().clear_bit());
+        self.reg
+            .isr
+            .modify(|_, w| w.tsf().clear_bit().itsf().clear_bit());
 
         Some(date.and_time(time))
     }

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -636,8 +636,8 @@ impl Rtc {
             self.reg
                 .cr
                 .modify(|_, w| unsafe { w.wucksel().bits(0b100) });
-            let interval =
-                u16(interval - 1).expect("Interval was too large for wakeup timer");
+            let interval = u16(interval - 1)
+                .expect("Interval was too large for wakeup timer");
             self.reg.wutr.write(|w| unsafe { w.wut().bits(interval) });
         }
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -322,7 +322,7 @@ impl Rtc {
     ///
     /// # Panics
     ///
-    /// Panics if `date_time` is before 01-01-2000 or after 12-31-2099
+    /// Panics if `date_time` is before 01-01-2001 or after 12-31-2099
     /// when debug assertions are enabled.
     pub fn set_date_time(&mut self, date_time: NaiveDateTime) {
         // Enter initialization mode
@@ -359,7 +359,7 @@ impl Rtc {
         });
 
         let year = date_time.year();
-        debug_assert!(year >= 2000 && year < 2100);
+        debug_assert!(year > 2000 && year < 2100);
         let yt = ((year - 2000) / 10) as u8;
         let yu = ((year - 2000) % 10) as u8;
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -1,0 +1,642 @@
+//! Real-Time Clock
+
+use cast::{f32, i32, u16, u32, u8};
+use chrono::prelude::*;
+
+use crate::rcc::backup;
+use crate::rcc::rec::ResetEnable;
+use crate::rcc::CoreClocks;
+use crate::stm32::{RCC, RTC};
+use crate::time::Hertz;
+
+pub enum Event {
+    AlarmA,
+    AlarmB,
+    Wakeup,
+    Timestamp,
+    LseCss,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum DstState {
+    /// Standard Time
+    Standard = 0,
+    /// Daylight Savings Time
+    ///
+    /// One hour ahead of Standard Time
+    Dst = 1,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum RtcClock {
+    /// LSE (Low-Speed External)
+    ///
+    /// This is in the Backup power domain, and so it can
+    /// remain operational as long as VBat is present.
+    Lse {
+        freq: Hertz,
+        bypass: bool,
+        css: bool,
+    },
+    /// LSI (Low-Speed Internal)
+    ///
+    /// This clock remains functional in Stop or Standby mode,
+    /// but requires VDD to remain powered. LSI is an RC
+    /// oscillator and has poor accuracy.
+    Lsi,
+    /// HSE (High-Speed External) divided by 2..=63
+    ///
+    /// The resulting clock must be lower than 1MHz. This clock is
+    /// automatically disabled by hardware when the CPU enters Stop or
+    /// standby mode.
+    Hse { divider: u8 },
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+/// An error preventing the RTC from initializing
+pub enum InitError {
+    RtcNotRunning,
+    ClockNotRunning,
+    ConfigMismatch,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum DstError {
+    ClockNotInitialized,
+    AlreadyDst,
+    AlreadyStandardTime,
+    CannotSubtract,
+}
+
+/// Real-Time Clock
+pub struct Rtc {
+    reg: RTC,
+    prec: backup::Rtc,
+}
+
+impl Rtc {
+    /// Opens the RTC if it is running and its configuration matches, otherwise resets and inits the RTC
+    pub fn open_or_init(
+        rtc: RTC,
+        prec: backup::Rtc,
+        clock_source: RtcClock,
+        clocks: &CoreClocks,
+    ) -> Self {
+        match Rtc::try_open(rtc, prec, clock_source, clocks) {
+            Ok(rtc) => rtc,
+            Err((rtc, prec, _err)) => {
+                Rtc::init(rtc, prec, clock_source, clocks)
+            }
+        }
+    }
+
+    /// Opens the RTC if it is running and its configuration matches
+    pub fn try_open(
+        rtc: RTC,
+        prec: backup::Rtc,
+        clock_source: RtcClock,
+        clocks: &CoreClocks,
+    ) -> Result<Self, (RTC, backup::Rtc, InitError)> {
+        if !prec.is_enabled() {
+            return Err((rtc, prec, InitError::RtcNotRunning));
+        }
+
+        let rcc = unsafe { &*RCC::ptr() };
+        let bdcr = rcc.bdcr.read();
+
+        let clock_source_matches =
+            match (clock_source, prec.get_kernel_clk_mux()) {
+                (RtcClock::Lsi, backup::RtcClkSel::LSI) => true,
+                (RtcClock::Hse { divider }, backup::RtcClkSel::HSE) => {
+                    rcc.cfgr.read().rtcpre().bits() == divider
+                }
+                (RtcClock::Lse { bypass, css, .. }, backup::RtcClkSel::LSE) => {
+                    bypass == bdcr.lsebyp().is_bypassed()
+                        && css == bdcr.lsecsson().is_security_on()
+                }
+                _ => false,
+            };
+        if !clock_source_matches {
+            return Err((rtc, prec, InitError::ConfigMismatch));
+        }
+
+        let clock_source_running = match clock_source {
+            RtcClock::Lsi => clocks.lsi_ck().is_some(),
+            RtcClock::Hse { .. } => clocks.hse_ck().is_some(),
+            RtcClock::Lse { .. } => bdcr.lserdy().is_ready(),
+        };
+        if !clock_source_running {
+            return Err((rtc, prec, InitError::ClockNotRunning));
+        }
+
+        Ok(Rtc { reg: rtc, prec })
+    }
+
+    /// Resets the RTC, including the backup registers, then initializes it.
+    pub fn init(
+        rtc: RTC,
+        prec: backup::Rtc,
+        clock_source: RtcClock,
+        clocks: &CoreClocks,
+    ) -> Self {
+        let mut prec = prec.reset().enable();
+
+        let rcc = unsafe { &*RCC::ptr() };
+
+        // Check and configure clock source
+        let ker_ck = match clock_source {
+            RtcClock::Lse { bypass, freq, .. } => {
+                // Ensure LSE is on and stable
+                rcc.bdcr.modify(|_, w| w.lseon().on().lsebyp().bit(bypass));
+                while rcc.bdcr.read().lserdy().is_not_ready() {}
+
+                Some(freq)
+            }
+            RtcClock::Hse { divider } => {
+                // Set HSE divider
+                assert!(divider < 64, "HSE Divider larger than 63");
+                rcc.cfgr.modify(|_, w| w.rtcpre().bits(divider));
+
+                clocks.hse_ck().map(|x| Hertz(x.0 / u32(divider)))
+            }
+            RtcClock::Lsi => clocks.lsi_ck(),
+        }
+        .expect("rtc_ker_ck not running")
+        .0;
+
+        assert!(ker_ck <= 1 << 22, "rtc_ker_ck too fast for prescaler");
+
+        // Select RTC kernel clock
+        prec.kernel_clk_mux(match clock_source {
+            RtcClock::Hse { .. } => backup::RtcClkSel::HSE,
+            RtcClock::Lsi => backup::RtcClkSel::LSI,
+            RtcClock::Lse { .. } => backup::RtcClkSel::LSE,
+        });
+
+        // Now we can enable CSS, if required
+        if let RtcClock::Lse { css: true, .. } = clock_source {
+            rcc.bdcr.modify(|_, w| w.lsecsson().security_on());
+        }
+
+        // Disable RTC register write protection
+        rtc.wpr.write(|w| w.key().bits(0xCA));
+        rtc.wpr.write(|w| w.key().bits(0x53));
+
+        // Enter initialization mode
+        rtc.isr.modify(|_, w| w.init().init_mode());
+        while rtc.isr.read().initf().is_not_allowed() {}
+
+        // Configure prescaler for 1Hz clock
+        // Want to maximize a_pre_max for power reasons, though it reduces the
+        // subsecond precision.
+        let total_div = ker_ck;
+        let a_pre_max = 1 << 7;
+        let s_pre_max = 1 << 15;
+
+        let (a_pre, s_pre) = if total_div <= a_pre_max {
+            (total_div, 1)
+        } else if total_div % a_pre_max == 0 {
+            (a_pre_max, total_div / a_pre_max)
+        } else {
+            let mut a_pre = a_pre_max;
+            while a_pre > 1 {
+                if total_div % a_pre == 0 {
+                    break;
+                }
+                a_pre -= 1;
+            }
+            let s_pre = total_div / a_pre;
+            (a_pre, s_pre)
+        };
+        assert!(a_pre <= a_pre_max && s_pre <= s_pre_max, "Invalid RTC prescaler value");
+
+        rtc.prer.write(|w| {
+            w.prediv_s()
+                .bits(u16(s_pre - 1).unwrap())
+                .prediv_a()
+                .bits(u8(a_pre - 1).unwrap())
+        });
+
+        // Exit initialization mode
+        rtc.isr.modify(|_, w| w.init().free_running_mode());
+
+        Rtc { reg: rtc, prec }
+    }
+
+    /// Reads the value of a 32-bit backup register
+    ///
+    /// # Panics
+    ///
+    /// Panics if `reg` is greater than 31.
+    pub fn read_backup_reg(&self, reg: u8) -> u32 {
+        self.reg.bkpr[reg as usize].read().bkp().bits()
+    }
+
+    /// Writes `value` to a 32-bit backup register
+    ///
+    /// # Panics
+    ///
+    /// Panics if `reg` is greater than 31.
+    pub fn write_backup_reg(&mut self, reg: u8, value: u32) {
+        self.reg.bkpr[reg as usize].write(|w| w.bkp().bits(value));
+    }
+
+    /// Sets the date and time of the RTC
+    pub fn set_date_time(&mut self, date_time: NaiveDateTime) {
+        // Enter initialization mode
+        self.reg.isr.modify(|_, w| w.init().init_mode());
+        while self.reg.isr.read().initf().is_not_allowed() {}
+
+        let hour = date_time.hour() as u8;
+        let ht = hour / 10;
+        let hu = hour % 10;
+
+        let minute = date_time.minute() as u8;
+        let mnt = minute / 10;
+        let mnu = minute % 10;
+
+        let second = date_time.second() as u8;
+        let st = second / 10;
+        let su = second % 10;
+
+        self.reg.tr.write(|w| {
+            w.pm()
+                .clear_bit()
+                .ht()
+                .bits(ht)
+                .hu()
+                .bits(hu)
+                .mnt()
+                .bits(mnt)
+                .mnu()
+                .bits(mnu)
+                .st()
+                .bits(st)
+                .su()
+                .bits(su)
+        });
+
+        let year = date_time.year();
+        let yt = ((year - 2000) / 10) as u8;
+        let yu = ((year - 2000) % 10) as u8;
+
+        let wdu = date_time.weekday().number_from_monday() as u8;
+
+        let month = date_time.month() as u8;
+        let mt = month > 9;
+        let mu = month % 10;
+
+        let day = date_time.day() as u8;
+        let dt = day / 10;
+        let du = day % 10;
+
+        self.reg.dr.write(|w| unsafe {
+            w.yt()
+                .bits(yt)
+                .yu()
+                .bits(yu)
+                .wdu()
+                .bits(wdu)
+                .mt()
+                .bit(mt)
+                .mu()
+                .bits(mu)
+                .dt()
+                .bits(dt)
+                .du()
+                .bits(du)
+        });
+
+        // Exit initialization mode
+        self.reg.isr.modify(|_, w| w.init().free_running_mode());
+    }
+
+    /// De-initializes the calendar and clock
+    ///
+    /// For when you lose confidince in the stored time e.g. if the LSE clock fails.
+    pub fn clear_date_time(&mut self) {
+        // Enter initialization mode
+        self.reg.isr.modify(|_, w| w.init().init_mode());
+        while self.reg.isr.read().initf().is_not_allowed() {}
+
+        self.reg.tr.reset();
+        self.reg.dr.reset();
+
+        // Exit initialization mode
+        self.reg.isr.modify(|_, w| w.init().free_running_mode());
+    }
+
+    /// Returns `None` if the calendar is uninitialized
+    fn calendar_initialized(&self) -> Option<()> {
+        match self.reg.isr.read().inits().is_initalized() {
+            true => Some(()),
+            false => None,
+        }
+    }
+
+    /// Wait for initialization or shift to complete
+    fn wait_for_sync(&self) {
+        while self.reg.isr.read().rsf().is_not_synced() {}
+    }
+
+    /// Calendar Date
+    ///
+    /// Returns `None` if the calendar has not been initialized
+    pub fn date(&self) -> Option<NaiveDate> {
+        self.calendar_initialized()?;
+        self.wait_for_sync();
+        let data = self.reg.dr.read();
+        let year = 2000 + i32(data.yt().bits()) * 10 + i32(data.yu().bits());
+        let month = data.mt().bits() as u8 * 10 + data.mu().bits();
+        let day = data.dt().bits() * 10 + data.du().bits();
+        NaiveDate::from_ymd_opt(year, u32(month), u32(day))
+    }
+
+    /// Current Time
+    ///
+    /// Returns `None` if the calendar has not been initialized
+    pub fn time(&self) -> Option<NaiveTime> {
+        self.calendar_initialized()?;
+        self.wait_for_sync();
+        let data = self.reg.tr.read();
+        let mut hour = data.ht().bits() * 10 + data.hu().bits();
+        if data.pm().bit_is_set() {
+            hour += 12;
+        }
+        let minute = data.mnt().bits() * 10 + data.mnu().bits();
+        let second = data.st().bits() * 10 + data.su().bits();
+        let micro = self.ss_to_us(self.reg.ssr.read().ss().bits());
+        NaiveTime::from_hms_micro_opt(
+            u32(hour),
+            u32(minute),
+            u32(second),
+            micro,
+        )
+    }
+
+    /// Calendar Date and Time
+    ///
+    /// Returns `None` if the calendar has not been initialized
+    pub fn date_time(&self) -> Option<NaiveDateTime> {
+        let date = self.date()?;
+        let time = self.time()?;
+        Some(date.and_time(time))
+    }
+
+    /// Returns the fraction of seconds that have occurred since the last second tick
+    ///
+    /// The precision of this value depends on the value of the synchronous prescale divider
+    /// (prediv_s) which depends on the frequency of the RTC clock. E.g. with a 32,768 Hz
+    /// crystal this value has a resolution of 1/256 of a second.
+    pub fn subseconds(&self) -> Option<f32> {
+        self.calendar_initialized()?;
+        self.wait_for_sync();
+        let ss = f32(self.reg.ssr.read().ss().bits());
+        let prediv_s = f32(self.reg.prer.read().prediv_s().bits());
+        Some((prediv_s - ss) / (prediv_s + 1.0))
+    }
+
+    fn ss_to_us(&self, ss: u16) -> u32 {
+        let ss = u32(ss);
+        let prediv_s = u32(self.reg.prer.read().prediv_s().bits());
+        ((prediv_s - ss) * 1_000) / (prediv_s + 1)
+    }
+
+    /// Returns the fraction of seconds that have occurred since the last second tick
+    /// as a number of milliseconds rounded to the nearest whole number.
+    pub fn subsec_micros(&self) -> Option<u32> {
+        self.calendar_initialized()?;
+        self.wait_for_sync();
+        let ss = self.reg.ssr.read().ss().bits();
+        Some(self.ss_to_us(ss))
+    }
+
+    /// Returns the raw value of the synchronous subsecond counter
+    ///
+    /// This counts up to `self.subsec_res()` then resets to zero once per second.
+    pub fn subsec_raw(&self) -> Option<u16> {
+        self.calendar_initialized()?;
+        self.wait_for_sync();
+        Some(self.reg.ssr.read().ss().bits())
+    }
+
+    /// Returns the resolution of subsecond values
+    ///
+    /// The RTC counter increments this number of times per second.
+    pub fn subsec_res(&self) -> Option<u16> {
+        self.calendar_initialized()?;
+        Some(self.reg.prer.read().prediv_s().bits())
+    }
+
+    /// Returns the stored Daylight Savings Time status
+    pub fn dst(&self) -> DstState {
+        if self.reg.cr.read().bkp().is_dst_changed() {
+            DstState::Dst
+        } else {
+            DstState::Standard
+        }
+    }
+
+    /// Sets the stored Daylight Savings Time status without adjusting the clock
+    pub fn set_dst(&mut self, dst: DstState) {
+        self.reg.cr.modify(|_, w| w.bkp().bit(dst == DstState::Dst));
+    }
+
+    /// Begin Daylight Savings Time
+    ///
+    /// Adds an hour to the stored time and sets the stored DST status.
+    /// Returns an error if the clock has not been initialized, or if the stored DST status
+    /// indicates it has already begun.
+    pub fn begin_dst(&mut self) -> Result<(), DstError> {
+        self.calendar_initialized()
+            .ok_or(DstError::ClockNotInitialized)?;
+        if self.reg.cr.read().bkp().is_dst_changed() {
+            return Err(DstError::AlreadyDst);
+        }
+        self.reg
+            .cr
+            .modify(|_, w| w.add1h().add1().bkp().dst_changed());
+        Ok(())
+    }
+
+    /// End Daylight Savings Time
+    ///
+    /// Subtracts an hour from the stored time and sets the stored DST status.
+    /// Returns an error if the clock has not been initialized, if the stored DST status
+    /// indicates it is already standard time, or if we cannot subtract an hour because
+    /// it is not at least one hour past midnight.
+    pub fn end_dst(&mut self) -> Result<(), DstError> {
+        self.calendar_initialized()
+            .ok_or(DstError::ClockNotInitialized)?;
+        if self.reg.cr.read().bkp().is_dst_not_changed() {
+            return Err(DstError::AlreadyStandardTime);
+        }
+        let time = self.reg.tr.read();
+        if time.ht().bits() == 0 && time.hu().bits() == 0 {
+            return Err(DstError::CannotSubtract);
+        }
+        self.reg
+            .cr
+            .modify(|_, w| w.sub1h().sub1().bkp().dst_not_changed());
+        Ok(())
+    }
+
+    /// Configures the wakeup timer to trigger periodically after `interval` seconds
+    ///
+    /// # Panics
+    ///
+    /// Panics if interval is greater than 2¹⁷-1.
+    pub fn enable_wakeup(&mut self, interval: u32) {
+        self.reg.cr.modify(|_, w| w.wute().disabled());
+        self.reg.isr.modify(|_, w| w.wutf().clear());
+        while self.reg.isr.read().wutwf().is_update_not_allowed() {}
+
+        if interval > 1 << 16 {
+            self.reg
+                .cr
+                .modify(|_, w| w.wucksel().clock_spare_with_offset());
+            let interval = u16(interval - 1 << 16)
+                .expect("Interval was too large for wakeup timer");
+            self.reg.wutr.write(|w| w.wut().bits(interval));
+        } else {
+            self.reg.cr.modify(|_, w| w.wucksel().clock_spare());
+            let interval =
+                u16(interval).expect("Interval was too large for wakeup timer");
+            self.reg.wutr.write(|w| w.wut().bits(interval));
+        }
+
+        self.reg.cr.modify(|_, w| w.wute().enabled());
+    }
+
+    /// Disables the wakeup timer
+    pub fn disable_wakeup(&mut self) {
+        self.reg.cr.modify(|_, w| w.wute().disabled());
+        self.reg.isr.modify(|_, w| w.wutf().clear());
+    }
+
+    /// Configures the timestamp to be captured when the RTC switches to Vbat power
+    pub fn enable_vbat_timestamp(&mut self) {
+        self.reg.cr.modify(|_, w| w.tse().disabled());
+        self.reg.isr.modify(|_, w| w.tsf().clear());
+        self.reg.cr.modify(|_, w| w.itse().enabled());
+        self.reg.cr.modify(|_, w| w.tse().enabled());
+    }
+
+    /// Disables the timestamp
+    pub fn disable_timestamp(&mut self) {
+        self.reg.cr.modify(|_, w| w.tse().disabled());
+        self.reg.isr.modify(|_, w| w.tsf().clear());
+    }
+
+    /// Reads the stored value of the timestamp if present
+    ///
+    /// Clears the timestamp interrupt flags.
+    pub fn read_timestamp(&self) -> Option<NaiveDateTime> {
+        if !self.reg.isr.read().tsf().is_timestamp_event() {
+            return None;
+        }
+
+        // Timestamp doesn't include year, get it from the main calendar
+        let data = self.reg.dr.read();
+        let year = 2000 + i32(data.yt().bits()) * 10 + i32(data.yu().bits());
+
+        let data = self.reg.tsdr.read();
+        let month = data.mt().bits() as u8 * 10 + data.mu().bits();
+        let day = data.dt().bits() * 10 + data.du().bits();
+        let date = NaiveDate::from_ymd_opt(year, u32(month), u32(day))?;
+
+        let data = self.reg.tstr.read();
+        let mut hour = data.ht().bits() * 10 + data.hu().bits();
+        if data.pm().bit_is_set() {
+            hour += 12; // Shouldn't be configured this way, but handle it anyway
+        }
+        let minute = data.mnt().bits() * 10 + data.mnu().bits();
+        let second = data.st().bits() * 10 + data.su().bits();
+        let micro = self.ss_to_us(self.reg.tsssr.read().ss().bits());
+        let time = NaiveTime::from_hms_micro_opt(
+            u32(hour),
+            u32(minute),
+            u32(second),
+            u32(micro),
+        )?;
+
+        // Clear timestamp interrupt and internal timestamp interrupt (VBat transition)
+        // TODO: Timestamp overflow flag
+        self.reg.isr.modify(|_, w| w.tsf().clear().itsf().clear());
+
+        Some(date.and_time(time))
+    }
+
+    // TODO: Alarms
+
+    /// Start listening for `event`
+    pub fn listen(&mut self, event: Event) {
+        match event {
+            Event::LseCss => unsafe {
+                (&*RCC::ptr()).cier.modify(|_, w| w.lsecssie().enabled());
+            },
+            Event::AlarmA => self.reg.cr.modify(|_, w| w.alraie().enabled()),
+            Event::AlarmB => self.reg.cr.modify(|_, w| w.alrbie().enabled()),
+            Event::Wakeup => self.reg.cr.modify(|_, w| w.wutie().enabled()),
+            Event::Timestamp => self.reg.cr.modify(|_, w| w.tsie().enabled()),
+        }
+    }
+
+    /// Stop listening for `event`
+    pub fn unlisten(&mut self, event: Event) {
+        match event {
+            Event::LseCss => unsafe {
+                (&*RCC::ptr()).cier.modify(|_, w| w.lsecssie().disabled());
+            },
+            Event::AlarmA => self.reg.cr.modify(|_, w| w.alraie().disabled()),
+            Event::AlarmB => self.reg.cr.modify(|_, w| w.alrbie().disabled()),
+            Event::Wakeup => self.reg.cr.modify(|_, w| w.wutie().disabled()),
+            Event::Timestamp => self.reg.cr.modify(|_, w| w.tsie().disabled()),
+        }
+    }
+
+    /// Returns `true` if `event` is pending
+    pub fn is_pending(&self, event: Event) -> bool {
+        match event {
+            Event::LseCss => unsafe {
+                (&*RCC::ptr()).cifr.read().lsecssf().bit_is_set()
+            },
+            Event::AlarmA => self.reg.isr.read().alraf().bit_is_set(),
+            Event::AlarmB => self.reg.isr.read().alrbf().bit_is_set(),
+            Event::Wakeup => self.reg.isr.read().wutf().bit_is_set(),
+            Event::Timestamp => self.reg.isr.read().tsf().bit_is_set(),
+        }
+    }
+
+    /// Clears the interrupt flag for `event`
+    pub fn unpend(&mut self, event: Event) {
+        match event {
+            Event::LseCss => unsafe {
+                (&*RCC::ptr()).cicr.write(|w| w.lsecssc().clear())
+            },
+            Event::AlarmA => self.reg.isr.modify(|_, w| w.alraf().clear_bit()),
+            Event::AlarmB => self.reg.isr.modify(|_, w| w.alrbf().clear_bit()),
+            Event::Wakeup => self.reg.isr.modify(|_, w| w.wutf().clear_bit()),
+            Event::Timestamp => self.reg.isr.modify(|_, w| w.tsf().clear_bit()),
+        }
+    }
+
+    /// Handle a Clock Security Subsystem failure for the LSE clock
+    ///
+    /// Disables the LSE, disables the LSE CSS, and changes the RTC to use the LSI clock.
+    /// You may want to call `clear_date_time()`.
+    pub fn handle_lse_css(&mut self) {
+        if !self.is_pending(Event::LseCss) {
+            return;
+        }
+
+        let rcc = unsafe { &*RCC::ptr() };
+        rcc.bdcr
+            .modify(|_, w| w.lsecsson().security_off().lseon().off());
+
+        // We're allowed to change this once after the LSE fails
+        self.prec.kernel_clk_mux(backup::RtcClkSel::LSI);
+
+        self.unpend(Event::LseCss);
+    }
+}

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -179,12 +179,12 @@ impl Rtc {
         }
 
         // Disable RTC register write protection
-        rtc.wpr.write(|w| w.key().bits(0xCA));
-        rtc.wpr.write(|w| w.key().bits(0x53));
+        rtc.wpr.write(|w| unsafe { w.bits(0xCA) });
+        rtc.wpr.write(|w| unsafe { w.bits(0x53) });
 
         // Enter initialization mode
-        rtc.isr.modify(|_, w| w.init().init_mode());
-        while rtc.isr.read().initf().is_not_allowed() {}
+        rtc.isr.modify(|_, w| w.init().set_bit());
+        while rtc.isr.read().initf().bit_is_clear() {}
 
         // Configure prescaler for 1Hz clock
         // Want to maximize a_pre_max for power reasons, though it reduces the
@@ -210,7 +210,7 @@ impl Rtc {
         };
         assert!(a_pre <= a_pre_max && s_pre <= s_pre_max, "Invalid RTC prescaler value");
 
-        rtc.prer.write(|w| {
+        rtc.prer.write(|w| unsafe {
             w.prediv_s()
                 .bits(u16(s_pre - 1).unwrap())
                 .prediv_a()
@@ -218,7 +218,7 @@ impl Rtc {
         });
 
         // Exit initialization mode
-        rtc.isr.modify(|_, w| w.init().free_running_mode());
+        rtc.isr.modify(|_, w| w.init().clear_bit());
 
         Rtc { reg: rtc, prec }
     }
@@ -229,7 +229,44 @@ impl Rtc {
     ///
     /// Panics if `reg` is greater than 31.
     pub fn read_backup_reg(&self, reg: u8) -> u32 {
-        self.reg.bkpr[reg as usize].read().bkp().bits()
+        match reg {
+            0 => self.reg.bkp0r.read().bkp().bits(),
+            1 => self.reg.bkp1r.read().bkp().bits(),
+            2 => self.reg.bkp2r.read().bkp().bits(),
+            3 => self.reg.bkp3r.read().bkp().bits(),
+            4 => self.reg.bkp4r.read().bkp().bits(),
+            5 => self.reg.bkp5r.read().bkp().bits(),
+            6 => self.reg.bkp6r.read().bkp().bits(),
+            7 => self.reg.bkp7r.read().bkp().bits(),
+            8 => self.reg.bkp8r.read().bkp().bits(),
+            9 => self.reg.bkp9r.read().bkp().bits(),
+            10 => self.reg.bkp10r.read().bkp().bits(),
+            11 => self.reg.bkp11r.read().bkp().bits(),
+            12 => self.reg.bkp12r.read().bkp().bits(),
+            13 => self.reg.bkp13r.read().bkp().bits(),
+            14 => self.reg.bkp14r.read().bkp().bits(),
+            15 => self.reg.bkp15r.read().bkp().bits(),
+            16 => self.reg.bkp16r.read().bkp().bits(),
+            17 => self.reg.bkp17r.read().bkp().bits(),
+            18 => self.reg.bkp18r.read().bkp().bits(),
+            19 => self.reg.bkp19r.read().bkp().bits(),
+            20 => self.reg.bkp20r.read().bkp().bits(),
+            21 => self.reg.bkp21r.read().bkp().bits(),
+            22 => self.reg.bkp22r.read().bkp().bits(),
+            23 => self.reg.bkp23r.read().bkp().bits(),
+            24 => self.reg.bkp24r.read().bkp().bits(),
+            25 => self.reg.bkp25r.read().bkp().bits(),
+            26 => self.reg.bkp26r.read().bkp().bits(),
+            27 => self.reg.bkp27r.read().bkp().bits(),
+            28 => self.reg.bkp28r.read().bkp().bits(),
+            29 => self.reg.bkp29r.read().bkp().bits(),
+            30 => self.reg.bkp30r.read().bkp().bits(),
+            31 => self.reg.bkp31r.read().bkp().bits(),
+            _ => panic!("Backup reg index out of range"),
+        }
+
+        // TODO: stm32h7 0.13.0
+        // self.reg.bkpr[reg as usize].read().bkp().bits()
     }
 
     /// Writes `value` to a 32-bit backup register
@@ -238,14 +275,51 @@ impl Rtc {
     ///
     /// Panics if `reg` is greater than 31.
     pub fn write_backup_reg(&mut self, reg: u8, value: u32) {
-        self.reg.bkpr[reg as usize].write(|w| w.bkp().bits(value));
+        match reg {
+            0 => self.reg.bkp0r.write(|w| unsafe { w.bkp().bits(value) }),
+            1 => self.reg.bkp1r.write(|w| unsafe { w.bkp().bits(value) }),
+            2 => self.reg.bkp2r.write(|w| unsafe { w.bkp().bits(value) }),
+            3 => self.reg.bkp3r.write(|w| unsafe { w.bkp().bits(value) }),
+            4 => self.reg.bkp4r.write(|w| unsafe { w.bkp().bits(value) }),
+            5 => self.reg.bkp5r.write(|w| unsafe { w.bkp().bits(value) }),
+            6 => self.reg.bkp6r.write(|w| unsafe { w.bkp().bits(value) }),
+            7 => self.reg.bkp7r.write(|w| unsafe { w.bkp().bits(value) }),
+            8 => self.reg.bkp8r.write(|w| unsafe { w.bkp().bits(value) }),
+            9 => self.reg.bkp9r.write(|w| unsafe { w.bkp().bits(value) }),
+            10 => self.reg.bkp10r.write(|w| unsafe { w.bkp().bits(value) }),
+            11 => self.reg.bkp11r.write(|w| unsafe { w.bkp().bits(value) }),
+            12 => self.reg.bkp12r.write(|w| unsafe { w.bkp().bits(value) }),
+            13 => self.reg.bkp13r.write(|w| unsafe { w.bkp().bits(value) }),
+            14 => self.reg.bkp14r.write(|w| unsafe { w.bkp().bits(value) }),
+            15 => self.reg.bkp15r.write(|w| unsafe { w.bkp().bits(value) }),
+            16 => self.reg.bkp16r.write(|w| unsafe { w.bkp().bits(value) }),
+            17 => self.reg.bkp17r.write(|w| unsafe { w.bkp().bits(value) }),
+            18 => self.reg.bkp18r.write(|w| unsafe { w.bkp().bits(value) }),
+            19 => self.reg.bkp19r.write(|w| unsafe { w.bkp().bits(value) }),
+            20 => self.reg.bkp20r.write(|w| unsafe { w.bkp().bits(value) }),
+            21 => self.reg.bkp21r.write(|w| unsafe { w.bkp().bits(value) }),
+            22 => self.reg.bkp22r.write(|w| unsafe { w.bkp().bits(value) }),
+            23 => self.reg.bkp23r.write(|w| unsafe { w.bkp().bits(value) }),
+            24 => self.reg.bkp24r.write(|w| unsafe { w.bkp().bits(value) }),
+            25 => self.reg.bkp25r.write(|w| unsafe { w.bkp().bits(value) }),
+            26 => self.reg.bkp26r.write(|w| unsafe { w.bkp().bits(value) }),
+            27 => self.reg.bkp27r.write(|w| unsafe { w.bkp().bits(value) }),
+            28 => self.reg.bkp28r.write(|w| unsafe { w.bkp().bits(value) }),
+            29 => self.reg.bkp29r.write(|w| unsafe { w.bkp().bits(value) }),
+            30 => self.reg.bkp30r.write(|w| unsafe { w.bkp().bits(value) }),
+            31 => self.reg.bkp31r.write(|w| unsafe { w.bkp().bits(value) }),
+            _ => panic!("Backup reg index out of range"),
+        }
+
+        // TODO: stm32h7 0.13.0
+        // self.reg.bkpr[reg as usize].write(|w| w.bkp().bits(value));
     }
 
     /// Sets the date and time of the RTC
     pub fn set_date_time(&mut self, date_time: NaiveDateTime) {
         // Enter initialization mode
-        self.reg.isr.modify(|_, w| w.init().init_mode());
-        while self.reg.isr.read().initf().is_not_allowed() {}
+        self.reg.isr.modify(|_, w| w.init().set_bit());
+        while self.reg.isr.read().initf().bit_is_clear() {}
 
         let hour = date_time.hour() as u8;
         let ht = hour / 10;
@@ -259,7 +333,7 @@ impl Rtc {
         let st = second / 10;
         let su = second % 10;
 
-        self.reg.tr.write(|w| {
+        self.reg.tr.write(|w| unsafe {
             w.pm()
                 .clear_bit()
                 .ht()
@@ -308,7 +382,7 @@ impl Rtc {
         });
 
         // Exit initialization mode
-        self.reg.isr.modify(|_, w| w.init().free_running_mode());
+        self.reg.isr.modify(|_, w| w.init().clear_bit());
     }
 
     /// De-initializes the calendar and clock
@@ -316,19 +390,19 @@ impl Rtc {
     /// For when you lose confidince in the stored time e.g. if the LSE clock fails.
     pub fn clear_date_time(&mut self) {
         // Enter initialization mode
-        self.reg.isr.modify(|_, w| w.init().init_mode());
-        while self.reg.isr.read().initf().is_not_allowed() {}
+        self.reg.isr.modify(|_, w| w.init().set_bit());
+        while self.reg.isr.read().initf().bit_is_clear() {}
 
         self.reg.tr.reset();
         self.reg.dr.reset();
 
         // Exit initialization mode
-        self.reg.isr.modify(|_, w| w.init().free_running_mode());
+        self.reg.isr.modify(|_, w| w.init().clear_bit());
     }
 
     /// Returns `None` if the calendar is uninitialized
     fn calendar_initialized(&self) -> Option<()> {
-        match self.reg.isr.read().inits().is_initalized() {
+        match self.reg.isr.read().inits().bit() {
             true => Some(()),
             false => None,
         }
@@ -336,7 +410,7 @@ impl Rtc {
 
     /// Wait for initialization or shift to complete
     fn wait_for_sync(&self) {
-        while self.reg.isr.read().rsf().is_not_synced() {}
+        while self.reg.isr.read().rsf().bit_is_clear() {}
     }
 
     /// Calendar Date
@@ -430,7 +504,7 @@ impl Rtc {
 
     /// Returns the stored Daylight Savings Time status
     pub fn dst(&self) -> DstState {
-        if self.reg.cr.read().bkp().is_dst_changed() {
+        if self.reg.cr.read().bkp().bit_is_set() {
             DstState::Dst
         } else {
             DstState::Standard
@@ -450,12 +524,12 @@ impl Rtc {
     pub fn begin_dst(&mut self) -> Result<(), DstError> {
         self.calendar_initialized()
             .ok_or(DstError::ClockNotInitialized)?;
-        if self.reg.cr.read().bkp().is_dst_changed() {
+        if self.reg.cr.read().bkp().bit_is_set() {
             return Err(DstError::AlreadyDst);
         }
         self.reg
             .cr
-            .modify(|_, w| w.add1h().add1().bkp().dst_changed());
+            .modify(|_, w| w.add1h().set_bit().bkp().set_bit());
         Ok(())
     }
 
@@ -468,7 +542,7 @@ impl Rtc {
     pub fn end_dst(&mut self) -> Result<(), DstError> {
         self.calendar_initialized()
             .ok_or(DstError::ClockNotInitialized)?;
-        if self.reg.cr.read().bkp().is_dst_not_changed() {
+        if self.reg.cr.read().bkp().bit_is_clear() {
             return Err(DstError::AlreadyStandardTime);
         }
         let time = self.reg.tr.read();
@@ -477,7 +551,7 @@ impl Rtc {
         }
         self.reg
             .cr
-            .modify(|_, w| w.sub1h().sub1().bkp().dst_not_changed());
+            .modify(|_, w| w.sub1h().set_bit().bkp().clear_bit());
         Ok(())
     }
 
@@ -487,52 +561,52 @@ impl Rtc {
     ///
     /// Panics if interval is greater than 2¹⁷-1.
     pub fn enable_wakeup(&mut self, interval: u32) {
-        self.reg.cr.modify(|_, w| w.wute().disabled());
-        self.reg.isr.modify(|_, w| w.wutf().clear());
-        while self.reg.isr.read().wutwf().is_update_not_allowed() {}
+        self.reg.cr.modify(|_, w| w.wute().clear_bit());
+        self.reg.isr.modify(|_, w| w.wutf().clear_bit());
+        while self.reg.isr.read().wutwf().bit_is_clear() {}
 
         if interval > 1 << 16 {
             self.reg
                 .cr
-                .modify(|_, w| w.wucksel().clock_spare_with_offset());
+                .modify(|_, w| unsafe { w.wucksel().bits(0b110) });
             let interval = u16(interval - 1 << 16)
                 .expect("Interval was too large for wakeup timer");
-            self.reg.wutr.write(|w| w.wut().bits(interval));
+            self.reg.wutr.write(|w| unsafe { w.wut().bits(interval) });
         } else {
-            self.reg.cr.modify(|_, w| w.wucksel().clock_spare());
+            self.reg.cr.modify(|_, w| unsafe { w.wucksel().bits(0b100) });
             let interval =
                 u16(interval).expect("Interval was too large for wakeup timer");
-            self.reg.wutr.write(|w| w.wut().bits(interval));
+            self.reg.wutr.write(|w| unsafe { w.wut().bits(interval) });
         }
 
-        self.reg.cr.modify(|_, w| w.wute().enabled());
+        self.reg.cr.modify(|_, w| w.wute().set_bit());
     }
 
     /// Disables the wakeup timer
     pub fn disable_wakeup(&mut self) {
-        self.reg.cr.modify(|_, w| w.wute().disabled());
-        self.reg.isr.modify(|_, w| w.wutf().clear());
+        self.reg.cr.modify(|_, w| w.wute().clear_bit());
+        self.reg.isr.modify(|_, w| w.wutf().clear_bit());
     }
 
     /// Configures the timestamp to be captured when the RTC switches to Vbat power
     pub fn enable_vbat_timestamp(&mut self) {
-        self.reg.cr.modify(|_, w| w.tse().disabled());
-        self.reg.isr.modify(|_, w| w.tsf().clear());
-        self.reg.cr.modify(|_, w| w.itse().enabled());
-        self.reg.cr.modify(|_, w| w.tse().enabled());
+        self.reg.cr.modify(|_, w| w.tse().clear_bit());
+        self.reg.isr.modify(|_, w| w.tsf().clear_bit());
+        self.reg.cr.modify(|_, w| w.itse().set_bit());
+        self.reg.cr.modify(|_, w| w.tse().set_bit());
     }
 
     /// Disables the timestamp
     pub fn disable_timestamp(&mut self) {
-        self.reg.cr.modify(|_, w| w.tse().disabled());
-        self.reg.isr.modify(|_, w| w.tsf().clear());
+        self.reg.cr.modify(|_, w| w.tse().clear_bit());
+        self.reg.isr.modify(|_, w| w.tsf().clear_bit());
     }
 
     /// Reads the stored value of the timestamp if present
     ///
     /// Clears the timestamp interrupt flags.
     pub fn read_timestamp(&self) -> Option<NaiveDateTime> {
-        if !self.reg.isr.read().tsf().is_timestamp_event() {
+        if !self.reg.isr.read().tsf().bit_is_clear() {
             return None;
         }
 
@@ -562,7 +636,7 @@ impl Rtc {
 
         // Clear timestamp interrupt and internal timestamp interrupt (VBat transition)
         // TODO: Timestamp overflow flag
-        self.reg.isr.modify(|_, w| w.tsf().clear().itsf().clear());
+        self.reg.isr.modify(|_, w| w.tsf().clear_bit().itsf().clear_bit());
 
         Some(date.and_time(time))
     }
@@ -575,10 +649,10 @@ impl Rtc {
             Event::LseCss => unsafe {
                 (&*RCC::ptr()).cier.modify(|_, w| w.lsecssie().enabled());
             },
-            Event::AlarmA => self.reg.cr.modify(|_, w| w.alraie().enabled()),
-            Event::AlarmB => self.reg.cr.modify(|_, w| w.alrbie().enabled()),
-            Event::Wakeup => self.reg.cr.modify(|_, w| w.wutie().enabled()),
-            Event::Timestamp => self.reg.cr.modify(|_, w| w.tsie().enabled()),
+            Event::AlarmA => self.reg.cr.modify(|_, w| w.alraie().set_bit()),
+            Event::AlarmB => self.reg.cr.modify(|_, w| w.alrbie().set_bit()),
+            Event::Wakeup => self.reg.cr.modify(|_, w| w.wutie().set_bit()),
+            Event::Timestamp => self.reg.cr.modify(|_, w| w.tsie().set_bit()),
         }
     }
 
@@ -588,10 +662,10 @@ impl Rtc {
             Event::LseCss => unsafe {
                 (&*RCC::ptr()).cier.modify(|_, w| w.lsecssie().disabled());
             },
-            Event::AlarmA => self.reg.cr.modify(|_, w| w.alraie().disabled()),
-            Event::AlarmB => self.reg.cr.modify(|_, w| w.alrbie().disabled()),
-            Event::Wakeup => self.reg.cr.modify(|_, w| w.wutie().disabled()),
-            Event::Timestamp => self.reg.cr.modify(|_, w| w.tsie().disabled()),
+            Event::AlarmA => self.reg.cr.modify(|_, w| w.alraie().clear_bit()),
+            Event::AlarmB => self.reg.cr.modify(|_, w| w.alrbie().clear_bit()),
+            Event::Wakeup => self.reg.cr.modify(|_, w| w.wutie().clear_bit()),
+            Event::Timestamp => self.reg.cr.modify(|_, w| w.tsie().clear_bit()),
         }
     }
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -319,6 +319,11 @@ impl Rtc {
     }
 
     /// Sets the date and time of the RTC
+    ///
+    /// # Panics
+    ///
+    /// Panics if `date_time` is before 01-01-2000 or after 12-31-2099
+    /// when debug assertions are enabled.
     pub fn set_date_time(&mut self, date_time: NaiveDateTime) {
         // Enter initialization mode
         self.reg.isr.modify(|_, w| w.init().set_bit());
@@ -354,6 +359,7 @@ impl Rtc {
         });
 
         let year = date_time.year();
+        debug_assert!(year >= 2000 && year < 2100);
         let yt = ((year - 2000) / 10) as u8;
         let yu = ((year - 2000) % 10) as u8;
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,19 +5,19 @@ use core::time::Duration;
 use cortex_m::peripheral::DWT;
 
 /// Bits per second
-#[derive(Clone, Copy, Debug)]
+#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
 pub struct Bps(pub u32);
 
 /// Hertz
-#[derive(Clone, Copy, Debug)]
+#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
 pub struct Hertz(pub u32);
 
 /// KiloHertz
-#[derive(Clone, Copy, Debug)]
+#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
 pub struct KiloHertz(pub u32);
 
 /// MegaHertz
-#[derive(Clone, Copy, Debug)]
+#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
 pub struct MegaHertz(pub u32);
 
 /// MilliSeconds


### PR DESCRIPTION
The RTC is a bit strange due to the backup power domain. I tried varying amounts of integration with the standard RCC, REC, PWR methods, but the implementation and semantics conflicted. Instead I added `Backup` to manage the backup power domain. Right now it's just the RTC but hypothetically it could help manage the backup SRAM and the LSE.

~~I started out with a minimal `Date`/`Time` implementation but found myself implementing more and more functionality so I replaced it with the `time` crate. It has a `no_std` mode but always requires an allocator. This isn't an issue for me but I might re-introduce the simple `Date`/`Time` and maybe genericize functions that take one of those as an argument.~~

I moved to the `chrono` crate since it doesn't require allocation.

Interested in any feedback you have.

### Blocked on:

- [x] https://github.com/time-rs/time/issues/280
- [x] RTC HSE divider is configurable according to CubeMX
- [x] stm32h7 (https://github.com/stm32-rs/stm32-rs/pull/446, https://github.com/stm32-rs/stm32-rs/pull/445)
