### PR TITLE
Timer: Allow configuring tick frequency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,3 +136,7 @@ required-features = ["phy_lan8742a", "rt", "stm32h747cm7", "ethernet"]
 [[example]]
 name = "ethernet-nucleo-h743zi2"
 required-features = ["phy_lan8742a", "rt", "revision_v", "stm32h743v", "ethernet"]
+
+[[example]]
+name = "tick_timer"
+required-features = ["rt"]

--- a/examples/tick_timer.rs
+++ b/examples/tick_timer.rs
@@ -1,0 +1,74 @@
+//! Demonstrates a microsecond-scale 64-bit timestamp counter
+
+#![no_main]
+#![no_std]
+
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use log::info;
+
+use cortex_m::asm;
+use cortex_m_rt::entry;
+
+use pac::interrupt;
+use stm32h7xx_hal::{pac, prelude::*, timer};
+
+#[path = "utilities/logger.rs"]
+mod logger;
+
+pub static OVERFLOWS: AtomicU32 = AtomicU32::new(0);
+
+#[entry]
+fn main() -> ! {
+    logger::init();
+    let mut cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = pwr.freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+
+    let ccdr = rcc.sys_ck(100.mhz()).freeze(pwrcfg, &dp.SYSCFG);
+
+    info!("");
+    info!("stm32h7xx-hal example - Tick Timer");
+    info!("");
+
+    let mut timer =
+        dp.TIM2
+            .tick_timer(1.mhz(), ccdr.peripheral.TIM2, &ccdr.clocks);
+    timer.listen(timer::Event::TimeOut);
+
+    unsafe {
+        cp.NVIC.set_priority(interrupt::TIM2, 1);
+        pac::NVIC::unmask(interrupt::TIM2);
+    }
+
+    loop {
+        info!("timestamp: {}", timestamp());
+        asm::delay(1000);
+    }
+}
+
+/// Handle timer overflow and count past 32-bits.
+///
+/// The interrupt should be configured at maximum priority, it won't take very long.
+#[interrupt]
+fn TIM2() {
+    OVERFLOWS.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
+    let timer = unsafe { &*pac::TIM2::ptr() };
+    timer.sr.modify(|_, w| w.uif().clear());
+}
+
+/// Returns the 64-bit number of microseconds since startup
+pub fn timestamp() -> u64 {
+    let overflows = OVERFLOWS.load(Ordering::SeqCst) as u64;
+    let timer = unsafe { &*pac::TIM2::ptr() };
+    let ctr = timer.cnt.read().bits() as u64;
+    (overflows << 32) + ctr
+}

--- a/examples/tick_timer.rs
+++ b/examples/tick_timer.rs
@@ -3,11 +3,14 @@
 #![no_main]
 #![no_std]
 
-use core::{cell::RefCell, sync::atomic::{AtomicU32, Ordering}};
+use core::{
+    cell::RefCell,
+    sync::atomic::{AtomicU32, Ordering},
+};
 
-use log::info;
 use cortex_m::{asm, interrupt::Mutex};
 use cortex_m_rt::entry;
+use log::info;
 
 use pac::interrupt;
 use stm32h7xx_hal::{pac, prelude::*, timer};
@@ -16,7 +19,8 @@ use stm32h7xx_hal::{pac, prelude::*, timer};
 mod logger;
 
 static OVERFLOWS: AtomicU32 = AtomicU32::new(0);
-static TIMER: Mutex<RefCell<Option<timer::Timer<pac::TIM2>>>> = Mutex::new(RefCell::new(None));
+static TIMER: Mutex<RefCell<Option<timer::Timer<pac::TIM2>>>> =
+    Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -327,7 +327,11 @@ macro_rules! hal {
                     self.tim.arr.write(|w| unsafe { w.bits(counter_max) });
                 }
 
-                /// Updates the timer prescaler and auto-reload value
+                /// Applies frequency/timeout changes immediately
+                ///
+                /// The timer will normally update its prescaler and auto-reload
+                /// value when its counter overflows. This function causes
+                /// those changes to happen immediately. Also clears the counter.
                 pub fn apply_freq(&mut self) {
                     self.tim.egr.write(|w| w.ug().set_bit());
                 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -113,7 +113,7 @@ impl_clk_lptim345! { LPTIM3, LPTIM4, LPTIM5 }
 pub trait TimerExt<TIM> {
     type Rec: ResetEnable;
 
-    #[deprecated(since = "0.7.0", note = "Use countdown_timer()")]
+    #[deprecated(since = "0.8.0", note = "Use countdown_timer()")]
     fn timer<T>(
         self,
         timeout: T,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -9,7 +9,8 @@ use core::marker::PhantomData;
 use crate::hal::timer::{CountDown, Periodic};
 use crate::stm32::{LPTIM1, LPTIM2, LPTIM3, LPTIM4, LPTIM5};
 use crate::stm32::{
-    TIM1, TIM12, TIM13, TIM14, TIM15, TIM16, TIM17, TIM2, TIM3, TIM4, TIM5, TIM6, TIM7, TIM8,
+    TIM1, TIM12, TIM13, TIM14, TIM15, TIM16, TIM17, TIM2, TIM3, TIM4, TIM5,
+    TIM6, TIM7, TIM8,
 };
 
 use cast::{u16, u32};
@@ -113,15 +114,30 @@ pub trait TimerExt<TIM> {
     type Rec: ResetEnable;
 
     #[deprecated(since = "0.7.0", note = "Use countdown_timer()")]
-    fn timer<T>(self, timeout: T, prec: Self::Rec, clocks: &CoreClocks) -> Timer<TIM>
+    fn timer<T>(
+        self,
+        timeout: T,
+        prec: Self::Rec,
+        clocks: &CoreClocks,
+    ) -> Timer<TIM>
     where
         T: Into<Hertz>;
 
-    fn countdown_timer<T>(self, timeout: T, prec: Self::Rec, clocks: &CoreClocks) -> Timer<TIM>
+    fn countdown_timer<T>(
+        self,
+        timeout: T,
+        prec: Self::Rec,
+        clocks: &CoreClocks,
+    ) -> Timer<TIM>
     where
         T: Into<Hertz>;
-    
-    fn tick_timer<T>(self, frequency: T, prec: Self::Rec, clocks: &CoreClocks) -> Timer<TIM>
+
+    fn tick_timer<T>(
+        self,
+        frequency: T,
+        prec: Self::Rec,
+        clocks: &CoreClocks,
+    ) -> Timer<TIM>
     where
         T: Into<Hertz>;
 }
@@ -213,7 +229,7 @@ macro_rules! hal {
                     T: Into<Hertz>,
                 {
                     let mut timer = Timer::$timX(self, prec, clocks);
-                    
+
                     timer.pause();
 
                     // UEV event occours on next overflow


### PR DESCRIPTION
I want to be able to create a timer which counts up at a specific frequency.  I think this solution is pretty good.

It's a bit awkward since the existing constructors and methods are built around the reload-overflow timer, but the HAL makes it be that way. I can foresee confusion if someone creates a tick_timer than calls `start` or `wait` on it.

I thought about creating a separate timer type for this, we already do for `Pwm`, but it seems silly to duplicate 80% of that code just so we can configure the timer slightly differently.

Perhaps an overhaul of the timer system is in order, but I don't have the energy for that right now.