### PR TITLE
ethernet: Remove phy feature flags, allow user to implement their own PHY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - stm32h7b3
           - stm32h7b0
     env:                        # Peripheral Feature flags
-      FLAGS: rt,quadspi,sdmmc,fmc,usb_hs,rtc
+      FLAGS: rt,quadspi,sdmmc,fmc,usb_hs,rtc,ethernet
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
           - log-semihost
           - log-rtt
     env:                        # Peripheral Feature flags
-      FLAGS: rt,quadspi,sdmmc,fmc,usb_hs,rtc
+      FLAGS: rt,quadspi,sdmmc,fmc,usb_hs,rtc,ethernet
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## [Unreleased]
 
+* **Breaking**: Ethernet PHY configuration feature flags removed. The user must now instantiate an instance of the PHY type in order to configure the PHY.
 * pac: Upgrade to stm32-rs v0.12.0
 * timer: add tick_timer and set_tick_freq to configure the timer's counter frequency [#144](https://github.com/stm32-rs/stm32h7xx-hal/pull/144)
 * Add RTC support [#143](https://github.com/stm32-rs/stm32h7xx-hal/pull/143)
 * pwr: add PowerConfiguration to ensure VoltageScale isn't modified from pwr.freeze() to rcc.freeze() [#141](https://github.com/stm32-rs/stm32h7xx-hal/pull/141)
 * impl Copy, Clone, PartialEq for enums [#139](https://github.com/stm32-rs/stm32h7xx-hal/pull/139)
+* ethernet: automatically configure MDC clock based on hclk
 
 ## [v0.7.1] 2020-09-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 exclude = [".gitignore"]
 
 [package.metadata.docs.rs]
-features = ["stm32h743v", "rt", "quadspi", "sdmmc", "fmc", "ethernet", "phy_lan8742a", "rtc"]
+features = ["stm32h743v", "rt", "quadspi", "sdmmc", "fmc", "rtc", "ethernet"]
 targets = ["thumbv7em-none-eabihf"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,6 @@ quadspi = []
 fmc = ["stm32-fmc"]
 sdmmc = ["sdio-host"]
 ethernet = ["smoltcp"]
-phy_ksz8081r = []
-phy_lan8742a = []
 rtc = ["chrono"]
 rt = ["stm32h7/rt"]
 usb_hs = ["synopsys-usb-otg", "synopsys-usb-otg/hs"]
@@ -146,15 +144,15 @@ required-features = ["sdmmc", "rm0433"]
 
 [[example]]
 name = "ethernet-stm32h747i-disco"
-required-features = ["phy_lan8742a", "rt", "stm32h747cm7", "ethernet"]
+required-features = ["rt", "stm32h747cm7", "ethernet"]
 
 [[example]]
 name = "ethernet-rtic-stm32h747i-disco"
-required-features = ["phy_lan8742a", "rt", "stm32h747cm7", "ethernet"]
+required-features = ["rt", "stm32h747cm7", "ethernet"]
 
 [[example]]
 name = "ethernet-nucleo-h743zi2"
-required-features = ["phy_lan8742a", "rt", "revision_v", "stm32h743v", "ethernet"]
+required-features = ["rt", "revision_v", "stm32h743v", "ethernet"]
 
 [[example]]
 name = "tick_timer"

--- a/examples/ethernet-nucleo-h743zi2.rs
+++ b/examples/ethernet-nucleo-h743zi2.rs
@@ -11,10 +11,10 @@ extern crate cortex_m;
 mod utilities;
 use log::info;
 
-use stm32h7xx_hal::ethernet;
 use stm32h7xx_hal::gpio::Speed;
 use stm32h7xx_hal::hal::digital::v2::OutputPin;
 use stm32h7xx_hal::rcc::CoreClocks;
+use stm32h7xx_hal::{ethernet, ethernet::PHY};
 use stm32h7xx_hal::{prelude::*, stm32, stm32::interrupt};
 use Speed::*;
 
@@ -104,7 +104,7 @@ fn main() -> ! {
     assert_eq!(ccdr.clocks.pclk4().0, 100_000_000); // PCLK 100MHz
 
     let mac_addr = smoltcp::wire::EthernetAddress::from_bytes(&MAC_ADDRESS);
-    let (_eth_dma, mut eth_mac) = unsafe {
+    let (_eth_dma, eth_mac) = unsafe {
         ethernet::new_unchecked(
             dp.ETHERNET_MAC,
             dp.ETHERNET_MTL,
@@ -113,6 +113,12 @@ fn main() -> ! {
             mac_addr.clone(),
         )
     };
+
+    // Initialise ethernet PHY...
+    let mut lan8742a = ethernet::phy::LAN8742A::new(eth_mac.set_phy_addr(0));
+    lan8742a.phy_reset();
+    lan8742a.phy_init();
+
     unsafe {
         ethernet::enable_interrupt();
         cp.NVIC.set_priority(stm32::Interrupt::ETH, 196); // Mid prio
@@ -136,7 +142,7 @@ fn main() -> ! {
 
         // Ethernet
         let eth_last = eth_up;
-        eth_up = eth_mac.phy_poll_link();
+        eth_up = lan8742a.poll_link();
         match eth_up {
             true => link_led.set_low(),
             _ => link_led.set_high(),

--- a/examples/ethernet-nucleo-h743zi2.rs
+++ b/examples/ethernet-nucleo-h743zi2.rs
@@ -111,6 +111,8 @@ fn main() -> ! {
             dp.ETHERNET_DMA,
             &mut DES_RING,
             mac_addr.clone(),
+            ccdr.peripheral.ETH1MAC,
+            &ccdr.clocks,
         )
     };
 

--- a/examples/ethernet-rtic-stm32h747i-disco.rs
+++ b/examples/ethernet-rtic-stm32h747i-disco.rs
@@ -27,10 +27,10 @@ use smoltcp::time::Instant;
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv6Cidr};
 
 use gpio::Speed::*;
-use stm32h7xx_hal::ethernet;
 use stm32h7xx_hal::gpio;
 use stm32h7xx_hal::hal::digital::v2::OutputPin;
 use stm32h7xx_hal::rcc::CoreClocks;
+use stm32h7xx_hal::{ethernet, ethernet::PHY};
 use stm32h7xx_hal::{prelude::*, stm32};
 
 use core::sync::atomic::{AtomicU32, Ordering};
@@ -117,7 +117,7 @@ impl<'a, 'b> Net<'a, 'b> {
 const APP: () = {
     struct Resources {
         net: Net<'static, 'static>,
-        eth_mac: ethernet::EthernetMAC,
+        lan8742a: ethernet::phy::LAN8742A<ethernet::EthernetMAC>,
         link_led: gpio::gpioi::PI14<gpio::Output<gpio::PushPull>>,
     }
 
@@ -179,6 +179,13 @@ const APP: () = {
                 mac_addr.clone(),
             )
         };
+
+        // Initialise ethernet PHY...
+        let mut lan8742a = ethernet::phy::LAN8742A::new(eth_mac);
+        lan8742a.phy_reset();
+        lan8742a.phy_init();
+        // The eth_dma should not be used until the PHY reports the link is up
+
         unsafe {
             ethernet::enable_interrupt();
         }
@@ -192,16 +199,16 @@ const APP: () = {
 
         init::LateResources {
             net,
-            eth_mac,
+            lan8742a,
             link_led,
         }
     }
 
-    #[idle(resources = [eth_mac, link_led])]
+    #[idle(resources = [lan8742a, link_led])]
     fn idle(ctx: idle::Context) -> ! {
         loop {
             // Ethernet
-            match ctx.resources.eth_mac.phy_poll_link() {
+            match ctx.resources.lan8742a.poll_link() {
                 true => ctx.resources.link_led.set_low(),
                 _ => ctx.resources.link_led.set_high(),
             }

--- a/examples/ethernet-rtic-stm32h747i-disco.rs
+++ b/examples/ethernet-rtic-stm32h747i-disco.rs
@@ -178,6 +178,8 @@ const APP: () = {
                 ctx.device.ETHERNET_DMA,
                 &mut DES_RING,
                 mac_addr.clone(),
+                ccdr.peripheral.ETH1MAC,
+                &ccdr.clocks,
             )
         };
 

--- a/examples/ethernet-rtic-stm32h747i-disco.rs
+++ b/examples/ethernet-rtic-stm32h747i-disco.rs
@@ -15,6 +15,7 @@ use cortex_m;
 use rtic::app;
 
 #[macro_use]
+#[allow(unused)]
 mod utilities;
 use log::info;
 

--- a/examples/ethernet-stm32h747i-disco.rs
+++ b/examples/ethernet-stm32h747i-disco.rs
@@ -92,6 +92,8 @@ fn main() -> ! {
             dp.ETHERNET_DMA,
             &mut DES_RING,
             mac_addr.clone(),
+            ccdr.peripheral.ETH1MAC,
+            &ccdr.clocks,
         )
     };
 

--- a/examples/ethernet-stm32h747i-disco.rs
+++ b/examples/ethernet-stm32h747i-disco.rs
@@ -13,6 +13,7 @@ use cortex_m_rt as rt;
 use rt::{entry, exception};
 
 #[macro_use]
+#[allow(unused)]
 mod utilities;
 
 use log::info;

--- a/examples/ethernet-stm32h747i-disco.rs
+++ b/examples/ethernet-stm32h747i-disco.rs
@@ -17,9 +17,9 @@ mod utilities;
 
 use log::info;
 
-use stm32h7xx_hal::ethernet;
 use stm32h7xx_hal::gpio::Speed::*;
 use stm32h7xx_hal::hal::digital::v2::OutputPin;
+use stm32h7xx_hal::{ethernet, ethernet::PHY};
 use stm32h7xx_hal::{prelude::*, stm32, stm32::interrupt};
 
 /// Locally administered MAC address
@@ -84,7 +84,7 @@ fn main() -> ! {
     assert_eq!(ccdr.clocks.pclk4().0, 100_000_000); // PCLK 100MHz
 
     let mac_addr = smoltcp::wire::EthernetAddress::from_bytes(&MAC_ADDRESS);
-    let (_eth_dma, mut eth_mac) = unsafe {
+    let (_eth_dma, eth_mac) = unsafe {
         ethernet::new_unchecked(
             dp.ETHERNET_MAC,
             dp.ETHERNET_MTL,
@@ -93,6 +93,12 @@ fn main() -> ! {
             mac_addr.clone(),
         )
     };
+
+    // Initialise ethernet PHY...
+    let mut lan8742a = ethernet::phy::LAN8742A::new(eth_mac.set_phy_addr(0));
+    lan8742a.phy_reset();
+    lan8742a.phy_init();
+
     unsafe {
         ethernet::enable_interrupt();
         cp.NVIC.set_priority(stm32::Interrupt::ETH, 196); // Mid prio
@@ -106,7 +112,7 @@ fn main() -> ! {
     loop {
         // Ethernet
         let eth_last = eth_up;
-        eth_up = eth_mac.phy_poll_link();
+        eth_up = lan8742a.poll_link();
         match eth_up {
             true => link_led.set_low(),
             _ => link_led.set_high(),

--- a/src/ethernet/eth.rs
+++ b/src/ethernet/eth.rs
@@ -22,7 +22,9 @@
 //! [quartiq/stabilizer]: https://github.com/quartiq/stabilizer
 //! [notes]: https://github.com/quartiq/stabilizer/commit/ab1735950b2108eaa8d51eb63efadcd2e25c35c4
 
+use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::stm32;
+
 use smoltcp::{
     self,
     phy::{self, DeviceCapabilities},
@@ -37,27 +39,6 @@ use crate::ethernet::StationManagement;
 const ETH_BUF_SIZE: usize = 1536;
 const ETH_NUM_TD: usize = 4;
 const ETH_NUM_RD: usize = 4;
-
-#[allow(dead_code)]
-mod cr_consts {
-    /* For HCLK 60-100 MHz */
-    pub const ETH_MACMIIAR_CR_HCLK_DIV_42: u8 = 0;
-    /* For HCLK 100-150 MHz */
-    pub const ETH_MACMIIAR_CR_HCLK_DIV_62: u8 = 1;
-    /* For HCLK 20-35 MHz */
-    pub const ETH_MACMIIAR_CR_HCLK_DIV_16: u8 = 2;
-    /* For HCLK 35-60 MHz */
-    pub const ETH_MACMIIAR_CR_HCLK_DIV_26: u8 = 3;
-    /* For HCLK 150-250 MHz */
-    pub const ETH_MACMIIAR_CR_HCLK_DIV_102: u8 = 4;
-    /* For HCLK 250-300 MHz */
-    pub const ETH_MACMIIAR_CR_HCLK_DIV_124: u8 = 5;
-}
-use self::cr_consts::*;
-
-// set clock range in MAC MII address register
-// 200 MHz AHB clock = eth_hclk
-const CLOCK_RANGE: u8 = ETH_MACMIIAR_CR_HCLK_DIV_102;
 
 /// Transmit and Receive Descriptor fields
 #[allow(dead_code)]
@@ -418,27 +399,32 @@ pub struct EthernetMAC {
 /// # Safety
 ///
 /// `EthernetDMA` shall not be moved as it is initialised here
-pub unsafe fn new_unchecked(
+pub unsafe fn new_unchecked<'a>(
     eth_mac: stm32::ETHERNET_MAC,
     eth_mtl: stm32::ETHERNET_MTL,
     eth_dma: stm32::ETHERNET_DMA,
-    ring: &mut DesRing,
+    ring: &'a mut DesRing,
     mac_addr: EthernetAddress,
-) -> (EthernetDMA, EthernetMAC) {
+    prec: rec::Eth1Mac,
+    clocks: &CoreClocks,
+) -> (EthernetDMA<'a>, EthernetMAC) {
     // RCC
     {
         let rcc = &*stm32::RCC::ptr();
         let syscfg = &*stm32::SYSCFG::ptr();
 
+        // Ensure syscfg is enabled (for PMCR)
         rcc.apb4enr.modify(|_, w| w.syscfgen().set_bit());
-        rcc.ahb1enr.modify(|_, w| {
-            w.eth1macen()
-                .set_bit()
-                .eth1txen()
-                .set_bit()
-                .eth1rxen()
-                .set_bit()
-        });
+
+        // AHB1 ETH1MACEN
+        prec.enable();
+
+        // Also need to enable the transmission and reception clocks, which
+        // don't have prec objects. They don't have prec objects because they
+        // can't be reset.
+        rcc.ahb1enr
+            .modify(|_, w| w.eth1txen().set_bit().eth1rxen().set_bit());
+
         syscfg.pmcr.modify(|_, w| w.epis().bits(0b100)); // RMII
     }
 
@@ -652,10 +638,26 @@ pub unsafe fn new_unchecked(
     });
 
     // MAC layer
+
+    // Set the MDC clock frequency in the range 1MHz - 2.5MHz
+    let hclk_mhz = clocks.hclk().0 / 1_000_000;
+    let csr_clock_range = match hclk_mhz {
+        0..=34 => 2,    // Divide by 16
+        35..=59 => 3,   // Divide by 26
+        60..=99 => 0,   // Divide by 42
+        100..=149 => 1, // Divide by 62
+        150..=249 => 4, // Divide by 102
+        250..=310 => 5, // Divide by 124
+        _ => panic!(
+            "HCLK results in MDC clock > 2.5MHz even for the \
+             highest CSR clock divider"
+        ),
+    };
+
     let mac = EthernetMAC {
         eth_mac,
         eth_phy_addr: 0,
-        clock_range: CLOCK_RANGE,
+        clock_range: csr_clock_range,
     };
 
     let dma = EthernetDMA { ring, eth_dma };

--- a/src/ethernet/ksz8081r.rs
+++ b/src/ethernet/ksz8081r.rs
@@ -1,30 +1,37 @@
 //! Micrel KSZ8081R Ethernet PHY
 
-use crate::ethernet::eth::EthernetMAC;
 use crate::ethernet::{StationManagement, PHY};
 
-/// Private implementation of PHY
-impl PHY for EthernetMAC {
+/// Micrel KSZ8081R Ethernet PHY
+pub struct KSZ8081R<MAC: StationManagement> {
+    mac: MAC,
+}
+
+impl<MAC: StationManagement> PHY for KSZ8081R<MAC> {
     /// Reset PHY and wait for it to come out of reset.
     fn phy_reset(&mut self) {
-        self.smi_write(0x00, 1 << 15);
-        while self.smi_read(0x00) & (1 << 15) == (1 << 15) {}
+        self.mac.smi_write(0x00, 1 << 15);
+        while self.mac.smi_read(0x00) & (1 << 15) == (1 << 15) {}
     }
 
     /// PHY initialisation.
     fn phy_init(&mut self) {
         // Enable auto-negotiation
-        self.smi_write(0x00, 1 << 12);
+        self.mac.smi_write(0x00, 1 << 12);
     }
 }
 
-/// Public functions for the KSZ8081
-impl EthernetMAC {
+/// Public functions for the KSZ8081R
+impl<MAC: StationManagement> KSZ8081R<MAC> {
+    pub fn new(mac: MAC) -> Self {
+        KSZ8081R { mac }
+    }
+
     /// Poll PHY to determine link status.
-    pub fn phy_poll_link(&mut self) -> bool {
-        let bsr = self.smi_read(0x01);
-        let bcr = self.smi_read(0x00);
-        let lpa = self.smi_read(0x05);
+    pub fn poll_link(&mut self) -> bool {
+        let bsr = self.mac.smi_read(0x01);
+        let bcr = self.mac.smi_read(0x00);
+        let lpa = self.mac.smi_read(0x05);
 
         // No link without autonegotiate
         if bcr & (1 << 12) == 0 {
@@ -51,7 +58,7 @@ impl EthernetMAC {
     }
 
     pub fn link_established(&mut self) -> bool {
-        return self.phy_poll_link();
+        return self.poll_link();
     }
 
     pub fn block_until_link(&mut self) {
@@ -60,6 +67,6 @@ impl EthernetMAC {
 
     /// Enable the Link Up and Link Down interrupts on INTRP
     pub fn interrupt_enable(&mut self) {
-        self.smi_write(0x1b, 0xA << 8);
+        self.mac.smi_write(0x1b, 0xA << 8);
     }
 }

--- a/src/ethernet/mod.rs
+++ b/src/ethernet/mod.rs
@@ -6,22 +6,6 @@
 //! - Micrel KSZ8081R
 //!
 
-#[cfg(feature = "phy_ksz8081r")]
-mod ksz8081r;
-#[cfg(feature = "phy_lan8742a")]
-mod lan8742a;
-#[cfg(not(any(feature = "phy_ksz8081r", feature = "phy_lan8742a")))]
-compile_error!(
-    "A least one PHY device must be enabled. Use a feature gate to
-enable."
-);
-#[cfg(all(feature = "phy_ksz8081r", feature = "phy_lan8742a"))]
-compile_error!("Cannot enable multiple PHY devices.");
-
-mod eth;
-/// PHY address
-pub const ETH_PHY_ADDR: u8 = 0;
-
 /// Station Management Interface (SMI) on an ethernet PHY
 pub trait StationManagement {
     /// Read a register over SMI.
@@ -31,13 +15,23 @@ pub trait StationManagement {
 }
 
 /// Traits for an Ethernet PHY
-trait PHY {
+pub trait PHY {
     /// Reset PHY and wait for it to come out of reset.
     fn phy_reset(&mut self);
     /// PHY initialisation.
     fn phy_init(&mut self);
 }
 
+mod ksz8081r;
+mod lan8742a;
+
+/// Some common implementations of the [PHY trait](PHY)
+pub mod phy {
+    pub use super::ksz8081r::*;
+    pub use super::lan8742a::*;
+}
+
+mod eth;
 pub use eth::{enable_interrupt, interrupt_handler, new_unchecked};
 pub use eth::{DesRing, EthernetDMA, EthernetMAC};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,11 @@ pub mod dac;
 pub mod delay;
 #[cfg(feature = "device-selected")]
 pub mod dma;
-#[cfg(all(feature = "device-selected", feature = "ethernet"))]
+#[cfg(all(
+    feature = "device-selected",
+    feature = "ethernet",
+    not(feature = "rm0455")
+))]
 pub mod ethernet;
 #[cfg(feature = "device-selected")]
 pub mod exti;


### PR DESCRIPTION
This is a breaking change, because the call to `new_unchecked` no longer resets and initialises the PHY. Now the user has to do that themselves.

* Keep the existing LAN8742A and KSZ8081R implementations available to use
* Add a builder method `set_phy_address` to configure the SMI address for the PHY