### PR TITLE
Re-export stm32h7::generic::Variant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ pub mod traits;
 pub use nb;
 pub use nb::block;
 
+pub use stm32h7::Variant;
+
 // Single core
 #[cfg(any(
     feature = "stm32h742",


### PR DESCRIPTION
Sometimes we need access to the `stm32h7::generic::Variant` enum type when working with hal methods like:

`pub fn get_kernel_clk_mux(&self) -> Variant<u8, Sai1ClkSel>`

For example:

```
use hal::rcc::rec::Sai1ClkSel; 
use hal::Variant::Val; 

match rec.get_kernel_clk_mux() {
    Val(Sai1ClkSel::PLL1_Q) => clocks.pll1_q_ck(),
    Val(Sai1ClkSel::PLL2_P) => clocks.pll2_p_ck(),
    Val(Sai1ClkSel::PLL3_P) => clocks.pll3_p_ck(),
    Val(Sai1ClkSel::I2S_CKIN) => unimplemented!(),
    Val(Sai1ClkSel::PER) => clocks.per_ck(),
    _ => unreachable!(),
}
```