### PR TITLE
Updating SPI CS management

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -199,12 +199,23 @@ impl Config {
     }
 
     /// CS pin is automatically managed by the SPI peripheral.
+    ///
+    /// # Note
+    /// SPI is configured in "endless transaction" mode, which means that the SPI CSn pin will
+    /// assert when the first data is sent and will not de-assert.
+    ///
+    /// If CSn should be de-asserted between each data transfer, use `suspend_when_inactive()` as
+    /// well.
     pub fn manage_cs(mut self) -> Self {
         self.managed_cs = true;
         self
     }
 
     /// Suspend a transaction automatically if data is not available in the FIFO.
+    ///
+    /// # Note
+    /// This will de-assert CSn when no data is available for transmission and hardware is managing
+    /// the CSn pin.
     pub fn suspend_when_inactive(mut self) -> Self {
         self.suspend_when_inactive = true;
         self

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -490,6 +490,8 @@ macro_rules! spi {
                                 .msbfirst()
                                 .ssm()
                                 .bit(config.managed_cs == false)
+                                .ssoe()
+                                .bit(config.managed_cs == true)
                                 .mssi()
                                 .bits(cycle_delay)
                                 .ioswp()


### PR DESCRIPTION
This PR fixes #158 by correcting the usage of the SPI management bits.
This PR fixes #71 by working around "endless transaction mode" by allowing more control of the way CS is managed.

This PR also exposes methods to allow SPI to be used in tx-only and rx-only configurations. It also allows for CS to automatically be idled when no data is available in the FIFO for transmission.