### PR TITLE
Updating DMA macro for SPI types

### DIFF
--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -798,32 +798,11 @@ type P2M = PeripheralToMemory;
 type M2P = MemoryToPeripheral;
 
 peripheral_target_address!(
-    (pac::SPI1, rxdr, u8, P2M, DMAReq::SPI1_RX_DMA),
-    (pac::SPI1, txdr, u8, M2P, DMAReq::SPI1_TX_DMA),
-    (pac::SPI2, rxdr, u8, P2M, DMAReq::SPI2_RX_DMA),
-    (pac::SPI2, txdr, u8, M2P, DMAReq::SPI2_TX_DMA),
-    (
-        // SPI peripheral must be disabled to configure DMA
-        INNER: spi::Spi<pac::SPI2, spi::Disabled, u8>,
-        rxdr,
-        u8,
-        P2M,
-        DMAReq::SPI2_RX_DMA
-    ),
-    (
-        // SPI peripheral must be disabled to configure DMA
-        INNER: spi::Spi<pac::SPI2, spi::Disabled, u8>,
-        txdr,
-        u8,
-        M2P,
-        DMAReq::SPI2_TX_DMA
-    ),
-    (pac::SPI3, rxdr, u8, P2M, DMAReq::SPI3_RX_DMA),
-    (pac::SPI3, txdr, u8, M2P, DMAReq::SPI3_TX_DMA),
-    (pac::SPI4, rxdr, u8, P2M, DMAReq::SPI4_RX_DMA),
-    (pac::SPI4, txdr, u8, M2P, DMAReq::SPI4_TX_DMA),
-    (pac::SPI5, rxdr, u8, P2M, DMAReq::SPI5_RX_DMA),
-    (pac::SPI5, txdr, u8, M2P, DMAReq::SPI5_TX_DMA)
+    (SPI: pac::SPI1, rxdr, txdr, [u8, u16], DMAReq::SPI1_RX_DMA, DMAReq::SPI1_TX_DMA),
+    (SPI: pac::SPI2, rxdr, txdr, [u8, u16], DMAReq::SPI2_RX_DMA, DMAReq::SPI2_TX_DMA),
+    (SPI: pac::SPI3, rxdr, txdr, [u8, u16], DMAReq::SPI3_RX_DMA, DMAReq::SPI3_TX_DMA),
+    (SPI: pac::SPI4, rxdr, txdr, [u8, u16], DMAReq::SPI4_RX_DMA, DMAReq::SPI4_TX_DMA),
+    (SPI: pac::SPI5, rxdr, txdr, [u8, u16], DMAReq::SPI5_RX_DMA, DMAReq::SPI5_TX_DMA)
 );
 
 peripheral_target_address!(

--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -798,11 +798,46 @@ type P2M = PeripheralToMemory;
 type M2P = MemoryToPeripheral;
 
 peripheral_target_address!(
-    (SPI: pac::SPI1, rxdr, txdr, [u8, u16], DMAReq::SPI1_RX_DMA, DMAReq::SPI1_TX_DMA),
-    (SPI: pac::SPI2, rxdr, txdr, [u8, u16], DMAReq::SPI2_RX_DMA, DMAReq::SPI2_TX_DMA),
-    (SPI: pac::SPI3, rxdr, txdr, [u8, u16], DMAReq::SPI3_RX_DMA, DMAReq::SPI3_TX_DMA),
-    (SPI: pac::SPI4, rxdr, txdr, [u8, u16], DMAReq::SPI4_RX_DMA, DMAReq::SPI4_TX_DMA),
-    (SPI: pac::SPI5, rxdr, txdr, [u8, u16], DMAReq::SPI5_RX_DMA, DMAReq::SPI5_TX_DMA)
+    (
+        SPI: pac::SPI1,
+        rxdr,
+        txdr,
+        [u8, u16],
+        DMAReq::SPI1_RX_DMA,
+        DMAReq::SPI1_TX_DMA
+    ),
+    (
+        SPI: pac::SPI2,
+        rxdr,
+        txdr,
+        [u8, u16],
+        DMAReq::SPI2_RX_DMA,
+        DMAReq::SPI2_TX_DMA
+    ),
+    (
+        SPI: pac::SPI3,
+        rxdr,
+        txdr,
+        [u8, u16],
+        DMAReq::SPI3_RX_DMA,
+        DMAReq::SPI3_TX_DMA
+    ),
+    (
+        SPI: pac::SPI4,
+        rxdr,
+        txdr,
+        [u8, u16],
+        DMAReq::SPI4_RX_DMA,
+        DMAReq::SPI4_TX_DMA
+    ),
+    (
+        SPI: pac::SPI5,
+        rxdr,
+        txdr,
+        [u8, u16],
+        DMAReq::SPI5_RX_DMA,
+        DMAReq::SPI5_TX_DMA
+    )
 );
 
 peripheral_target_address!(

--- a/src/dma/macros.rs
+++ b/src/dma/macros.rs
@@ -29,6 +29,56 @@ macro_rules! peripheral_target_instance {
         }
     };
 
+    ((SPI: $peripheral:ty, $rxreg:ident, $txreg:ident, [$($size:ty),+], $rxmux:expr, $txmux:expr)) => {
+        // Access via PAC peripheral structures implies u8 sizing, as the sizing is unknown.
+        unsafe impl TargetAddress<M2P> for $peripheral {
+            #[inline(always)]
+            fn address(&self) -> u32 {
+                &self.$txreg as *const _ as u32
+            }
+
+            type MemSize = u8;
+
+            const REQUEST_LINE: Option<u8> = Some($txmux as u8);
+        }
+
+        unsafe impl TargetAddress<P2M> for $peripheral {
+            #[inline(always)]
+            fn address(&self) -> u32 {
+                &self.$rxreg as *const _ as u32
+            }
+
+            type MemSize = u8;
+
+            const REQUEST_LINE: Option<u8> = Some($rxmux as u8);
+        }
+
+        // For each size
+        $(
+        unsafe impl TargetAddress<M2P> for spi::Spi<$peripheral, spi::Disabled, $size> {
+            #[inline(always)]
+            fn address(&self) -> u32 {
+                &self.inner().$txreg as *const _ as u32
+            }
+
+            type MemSize = $size;
+
+            const REQUEST_LINE: Option<u8> = Some($txmux as u8);
+        }
+
+        unsafe impl TargetAddress<P2M> for spi::Spi<$peripheral, spi::Disabled, $size> {
+            #[inline(always)]
+            fn address(&self) -> u32 {
+                &self.inner().$rxreg as *const _ as u32
+            }
+
+            type MemSize = $size;
+
+            const REQUEST_LINE: Option<u8> = Some($rxmux as u8);
+        }
+        )+
+    };
+
     ((INNER: $peripheral:ty, $register:ident $(($TRBUFF:ident))*, $size:ty,
       $dir:ty $(, $mux:expr)*)) => {
         unsafe impl TargetAddress<$dir> for $peripheral {


### PR DESCRIPTION
This PR updates the DMA macro for SPI types. When SPI is configured for various transaction sizes, the `TargetAddress` needs to have a different associated `MemSize` so that the SPI peripheral can be used by DMA.