### PR TITLE
[DMA] Adding DMA+SPI+RTIC example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,3 +186,7 @@ required-features = ["rm0433"]
 [[example]]
 name = "spi_dma"
 required-features = ["rm0433"]
+
+[[example]]
+name = "spi-dma-rtic"
+required-features = ["rm0433"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,4 +189,4 @@ required-features = ["rm0433"]
 
 [[example]]
 name = "spi-dma-rtic"
-required-features = ["rm0433"]
+required-features = ["rm0433","rt"]

--- a/examples/digital_read.rs
+++ b/examples/digital_read.rs
@@ -1,0 +1,41 @@
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use stm32h7xx_hal::hal::digital::v2::InputPin;
+
+use cortex_m_rt::entry;
+use stm32h7xx_hal::{pac, prelude::*};
+
+#[macro_use]
+mod utilities;
+
+use log::info;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    info!("stm32h7xx-hal example - digitalRead");
+
+    let _cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = example_power!(pwr).freeze();
+
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(100.mhz()).freeze(pwrcfg, &dp.SYSCFG);
+
+    // Push button configuration
+    let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
+
+    let button1 = gpioc.pc5.into_pull_up_input();
+
+    loop {
+        let result = button1.is_high().unwrap();
+        info!("{}", result);
+        cortex_m::asm::delay(10000000);
+    }
+}

--- a/examples/exti_interrupt.rs
+++ b/examples/exti_interrupt.rs
@@ -1,0 +1,129 @@
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use core::cell::{Cell, RefCell};
+use cortex_m::interrupt::{free, Mutex};
+use cortex_m::peripheral::NVIC;
+use cortex_m_rt::entry;
+use stm32h7xx_hal::gpio::{Edge, ExtiPin, Input, Output, PullUp, PushPull};
+use stm32h7xx_hal::hal::digital::v2::OutputPin;
+use stm32h7xx_hal::{interrupt, pac, prelude::*};
+
+// LED pin
+use stm32h7xx_hal::gpio::gpioa::PA1;
+
+// Button pins
+use stm32h7xx_hal::gpio::gpioc::PC5;
+use stm32h7xx_hal::gpio::gpioe::PE3;
+
+#[macro_use]
+mod utilities;
+
+use log::info;
+
+// Semaphore for synchronization
+static SEMAPHORE: Mutex<Cell<bool>> = Mutex::new(Cell::new(true));
+
+// Setup the sharing of pins between the main loop and the interrupts
+static BUTTON1_PIN: Mutex<RefCell<Option<PE3<Input<PullUp>>>>> =
+    Mutex::new(RefCell::new(None));
+static BUTTON2_PIN: Mutex<RefCell<Option<PC5<Input<PullUp>>>>> =
+    Mutex::new(RefCell::new(None));
+static LED: Mutex<RefCell<Option<PA1<Output<PushPull>>>>> =
+    Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    info!("stm32h7xx-hal example - EXTI Interrupt");
+
+    let mut cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    info!("Setup PWR...");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = example_power!(pwr).freeze();
+
+    info!("Setup RCC...");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(100.mhz()).freeze(pwrcfg, &dp.SYSCFG);
+
+    // Push button configuration
+    let mut syscfg = dp.SYSCFG;
+    let mut exti = dp.EXTI;
+
+    let gpioe = dp.GPIOE.split(ccdr.peripheral.GPIOE);
+    let mut button1 = gpioe.pe3.into_pull_up_input();
+    button1.make_interrupt_source(&mut syscfg);
+    button1.trigger_on_edge(&mut exti, Edge::RISING);
+    button1.enable_interrupt(&mut exti);
+
+    let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
+    let mut button2 = gpioc.pc5.into_pull_up_input();
+    button2.make_interrupt_source(&mut syscfg);
+    button2.trigger_on_edge(&mut exti, Edge::RISING);
+    button2.enable_interrupt(&mut exti);
+
+    let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
+    let led = gpioa.pa1.into_push_pull_output();
+
+    // Save information needed by the interrupt handlers to the global variable
+    free(|cs| {
+        BUTTON1_PIN.borrow(cs).replace(Some(button1));
+        BUTTON2_PIN.borrow(cs).replace(Some(button2));
+        LED.borrow(cs).replace(Some(led));
+    });
+
+    // Enable the button interrupts
+    unsafe {
+        cp.NVIC.set_priority(interrupt::EXTI3, 1);
+        cp.NVIC.set_priority(interrupt::EXTI9_5, 1);
+        NVIC::unmask::<interrupt>(interrupt::EXTI3);
+        NVIC::unmask::<interrupt>(interrupt::EXTI9_5);
+    }
+
+    loop {
+        cortex_m::asm::nop();
+    }
+}
+
+fn toggle_led(on_or_off: bool) {
+    free(|cs| {
+        if let Some(b) = LED.borrow(cs).borrow_mut().as_mut() {
+            if on_or_off {
+                b.set_high().unwrap();
+            } else {
+                b.set_low().unwrap();
+            }
+        }
+    });
+}
+
+#[interrupt]
+fn EXTI9_5() {
+    info!("EXTI9_5 fired!");
+    toggle_led(true);
+    free(|cs| {
+        if let Some(b) = BUTTON2_PIN.borrow(cs).borrow_mut().as_mut() {
+            b.clear_interrupt_pending_bit()
+        }
+
+        // Signal that the interrupt fired
+        SEMAPHORE.borrow(cs).set(false);
+    });
+}
+
+#[interrupt]
+fn EXTI3() {
+    info!("EXTI3 fired!");
+    toggle_led(false);
+    free(|cs| {
+        if let Some(b) = BUTTON1_PIN.borrow(cs).borrow_mut().as_mut() {
+            b.clear_interrupt_pending_bit()
+        }
+
+        // Signal that the interrupt fired
+        SEMAPHORE.borrow(cs).set(false);
+    });
+}

--- a/examples/spi-dma-rtic.rs
+++ b/examples/spi-dma-rtic.rs
@@ -6,7 +6,7 @@
 #![no_main]
 #![no_std]
 
-use core::{mem, mem::MaybeUninit};
+use core::mem::MaybeUninit;
 
 use embedded_hal::digital::v2::OutputPin;
 use rtic::app;
@@ -91,8 +91,10 @@ const APP: () = {
 
         // Initialize our transmit buffer.
         let buffer: &'static mut [u8; BUFFER_SIZE] = {
-            let buf: &mut [MaybeUninit<u8>; BUFFER_SIZE] =
-                unsafe { mem::transmute(&mut BUFFER) };
+            let buf: &mut [MaybeUninit<u8>; BUFFER_SIZE] = unsafe {
+                &mut *(&mut BUFFER as *mut MaybeUninit<[u8; BUFFER_SIZE]>
+                    as *mut [MaybeUninit<u8>; BUFFER_SIZE])
+            };
 
             for (i, value) in buf.iter_mut().enumerate() {
                 unsafe {
@@ -100,7 +102,10 @@ const APP: () = {
                 }
             }
 
-            unsafe { mem::transmute(buf) }
+            unsafe {
+                &mut *(buf as *mut [MaybeUninit<u8>; BUFFER_SIZE]
+                    as *mut [u8; BUFFER_SIZE])
+            }
         };
 
         let streams = hal::dma::dma::StreamsTuple::new(

--- a/examples/spi-dma-rtic.rs
+++ b/examples/spi-dma-rtic.rs
@@ -1,0 +1,141 @@
+//! Demo for STM32H747I-NUCLEO eval board using the Real Time Interrupt-driven Concurrency (RTIC)
+//! framework.
+//!
+//! This example demonstrates using DMA to continuously write a data stream over SPI.
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use core::{mem, mem::MaybeUninit};
+
+use embedded_hal::digital::v2::OutputPin;
+use rtic::app;
+
+#[macro_use]
+#[allow(unused)]
+mod utilities;
+use log::info;
+
+use hal::prelude::*;
+use stm32h7xx_hal as hal;
+
+// The number of bytes to transfer.
+const BUFFER_SIZE: usize = 100;
+
+// DMA1/DMA2 cannot interact with our stack. Instead, buffers for use with the
+// DMA must be placed somewhere that DMA1/DMA2 can access. In this case we use
+// AXI SRAM.
+//
+// The runtime does not initialise these SRAM banks
+#[link_section = ".axisram.buffers"]
+static mut BUFFER: MaybeUninit<[u8; BUFFER_SIZE]> = MaybeUninit::uninit();
+
+#[app(device = stm32h7xx_hal::stm32, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        transfer: hal::dma::Transfer<
+            hal::dma::dma::Stream0<hal::stm32::DMA1>,
+            hal::spi::Spi<hal::stm32::SPI2, hal::spi::Disabled, u8>,
+            hal::dma::MemoryToPeripheral,
+            &'static mut [u8; BUFFER_SIZE],
+        >,
+    }
+
+    #[init]
+    fn init(ctx: init::Context) -> init::LateResources {
+        utilities::logger::init();
+
+        // Initialise power...
+        let pwr = ctx.device.PWR.constrain();
+        let pwrcfg = example_power!(pwr).freeze();
+
+        // Initialise clocks...
+        let rcc = ctx.device.RCC.constrain();
+        let ccdr = rcc
+            .sys_ck(200.mhz())
+            .hclk(200.mhz())
+            .freeze(pwrcfg, &ctx.device.SYSCFG);
+
+        let gpiob = ctx.device.GPIOB.split(ccdr.peripheral.GPIOB);
+
+        // Initialize a SPI transmitter on SPI2.
+        let spi = {
+            let mosi = gpiob.pb15.into_alternate_af5();
+            let sck = gpiob.pb13.into_alternate_af5();
+            let config = hal::spi::Config::new(hal::spi::MODE_0)
+                .communication_mode(hal::spi::CommunicationMode::Transmitter);
+
+            let spi: hal::spi::Spi<_, _, u8> = ctx.device.SPI2.spi(
+                (sck, hal::spi::NoMiso, mosi),
+                config,
+                3.mhz(),
+                ccdr.peripheral.SPI2,
+                &ccdr.clocks,
+            );
+
+            spi.disable()
+        };
+
+        let mut cs = gpiob.pb12.into_push_pull_output();
+        cs.set_high().unwrap();
+
+        // Initialize our transmit buffer.
+        let buffer: &'static mut [u8; BUFFER_SIZE] = {
+            let buf: &mut [MaybeUninit<u8>; BUFFER_SIZE] =
+                unsafe { mem::transmute(&mut BUFFER) };
+
+            for (i, value) in buf.iter_mut().enumerate() {
+                unsafe {
+                    value.as_mut_ptr().write(i as u8 + 0x60); // 0x60, 0x61, 0x62...
+                }
+            }
+
+            unsafe { mem::transmute(buf) }
+        };
+
+        let streams = hal::dma::dma::StreamsTuple::new(
+            ctx.device.DMA1,
+            ccdr.peripheral.DMA1,
+        );
+
+        // Configure the DMA stream to increment the memory address and generate a transfer complete
+        // interrupt so we know when transmission is done.
+        let config = hal::dma::dma::DmaConfig::default()
+            .memory_increment(true)
+            .transfer_complete_interrupt(true);
+
+        let mut transfer: hal::dma::Transfer<
+            _,
+            _,
+            hal::dma::MemoryToPeripheral,
+            _,
+        > = hal::dma::Transfer::init(streams.0, spi, buffer, None, config);
+
+        transfer.start(|spi| {
+            // For this example, we will always drive CSn as we are simply streaming data over SPI.
+            cs.set_low().unwrap();
+
+            // Enable TX DMA support, enable the SPI peripheral, and start the transaction.
+            spi.inner_mut().cfg1.modify(|_, w| w.txdmaen().enabled());
+            spi.inner_mut().cr1.modify(|_, w| w.spe().enabled());
+            spi.inner_mut().cr1.modify(|_, w| w.cstart().started());
+
+            // The transaction immediately begins as the TX FIFO is now being filled by DMA.
+        });
+
+        init::LateResources { transfer }
+    }
+
+    #[task(binds=DMA1_STR0, resources=[transfer])]
+    fn dma_complete(ctx: dma_complete::Context) {
+        info!("DMA transmission completed!");
+
+        // If desired, the transfer can scheduled again here to continue transmitting.
+        ctx.resources.transfer.clear_transfer_complete_interrupt();
+    }
+
+    #[idle]
+    fn idle(_c: idle::Context) -> ! {
+        loop {}
+    }
+};

--- a/src/qspi.rs
+++ b/src/qspi.rs
@@ -341,9 +341,17 @@ impl Qspi {
             _ => panic!("Invalid QSPI frequency requested"),
         };
 
-        // Write the prescaler
-        regs.cr
-            .write(|w| unsafe { w.prescaler().bits(divisor as u8) });
+        // Write the prescaler and the SSHIFT bit. Note that SSHIFT is required because it appears
+        // that the QSPI may have signal contention issues when reading. SSHIFT forces the read to
+        // occur on the falling edge instead of the rising edge. Refer to
+        // https://github.com/quartiq/stabilizer/issues/101 for more information
+        //
+        // This is also noted in the docstring for the read() method.
+        //
+        // SSHIFT must not be set in DDR mode.
+        regs.cr.write(|w| unsafe {
+            w.prescaler().bits(divisor as u8).sshift().set_bit()
+        });
 
         match bank {
             Bank::One => regs.cr.modify(|_, w| w.fsel().clear_bit()),
@@ -447,9 +455,16 @@ impl Qspi {
     /// Read data over the QSPI interface.
     ///
     /// # Note
-    /// There is an issue where the QSPI peripheral will erroneously drive the output pins for an
-    /// extra half clock cycle before IO is swapped from output to input. Refer to
+    ///
+    /// Without any dummy cycles, the QSPI peripheral will erroneously drive the
+    /// output pins for an extra half clock cycle before IO is swapped from
+    /// output to input. Refer to
     /// https://github.com/quartiq/stabilizer/issues/101 for more information.
+    ///
+    /// Although it doesn't stop the possible bus contention, this HAL sets the
+    /// SSHIFT bit in the CR register. With this bit set, the QSPI receiver
+    /// sampling point is delayed by an extra half cycle. Then the receiver
+    /// sampling point is after the bus contention.
     ///
     /// # Args
     /// * `addr` - The address to read data from.

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -65,7 +65,7 @@ use crate::stm32::rcc::{cdccip1r as ccip1r, srdccipr};
 use crate::stm32::rcc::{d2ccip1r as ccip1r, d3ccipr as srdccipr};
 
 use crate::stm32;
-use crate::stm32::spi1::cfg1::MBR_A as MBR;
+use crate::stm32::spi1::{cfg1::MBR_A as MBR, cfg2::COMM_A as COMM};
 use core::convert::From;
 use core::marker::PhantomData;
 use core::ptr;
@@ -124,6 +124,19 @@ where
 {
 }
 
+/// Specifies the communication mode of the SPI interface.
+#[derive(Copy, Clone)]
+pub enum CommunicationMode {
+    /// Both RX and TX are used.
+    FullDuplex,
+
+    /// Only the SPI TX functionality is used.
+    Transmitter,
+
+    /// Only the SPI RX functionality is used.
+    Receiver,
+}
+
 /// A structure for specifying SPI configuration.
 ///
 /// This structure uses builder semantics to generate the configuration.
@@ -141,6 +154,8 @@ pub struct Config {
     swap_miso_mosi: bool,
     cs_delay: f32,
     managed_cs: bool,
+    suspend_when_inactive: bool,
+    communication_mode: CommunicationMode,
 }
 
 impl Config {
@@ -154,6 +169,8 @@ impl Config {
             swap_miso_mosi: false,
             cs_delay: 0.0,
             managed_cs: false,
+            suspend_when_inactive: false,
+            communication_mode: CommunicationMode::FullDuplex,
         }
     }
 
@@ -182,8 +199,31 @@ impl Config {
     }
 
     /// CS pin is automatically managed by the SPI peripheral.
+    ///
+    /// # Note
+    /// SPI is configured in "endless transaction" mode, which means that the SPI CSn pin will
+    /// assert when the first data is sent and will not de-assert.
+    ///
+    /// If CSn should be de-asserted between each data transfer, use `suspend_when_inactive()` as
+    /// well.
     pub fn manage_cs(mut self) -> Self {
         self.managed_cs = true;
+        self
+    }
+
+    /// Suspend a transaction automatically if data is not available in the FIFO.
+    ///
+    /// # Note
+    /// This will de-assert CSn when no data is available for transmission and hardware is managing
+    /// the CSn pin.
+    pub fn suspend_when_inactive(mut self) -> Self {
+        self.suspend_when_inactive = true;
+        self
+    }
+
+    /// Select the communication mode of the SPI bus.
+    pub fn communication_mode(mut self, mode: CommunicationMode) -> Self {
+        self.communication_mode = mode;
         self
     }
 }
@@ -455,7 +495,7 @@ macro_rules! spi {
                         spi.cr1.write(|w| w.ssi().slave_not_selected());
 
                         // Calculate the CS->transaction cycle delay bits.
-                        let cycle_delay: u8 = {
+                        let (start_cycle_delay, interdata_cycle_delay) = {
                             let mut delay: u32 = (config.cs_delay * spi_freq as f32) as u32;
 
                             // If the cs-delay is specified as non-zero, add 1 to the delay cycles
@@ -469,11 +509,22 @@ macro_rules! spi {
                                 delay = 0xF;
                             }
 
-                            delay as u8
+                            // If CS suspends while data is inactive, we also require an
+                            // "inter-data" delay.
+                            if config.suspend_when_inactive {
+                                (delay as u8, delay as u8)
+                            } else {
+                                (delay as u8, 0_u8)
+                            }
                         };
 
                         // The calculated cycle delay may not be more than 4 bits wide for the
                         // configuration register.
+                        let communication_mode = match config.communication_mode {
+                            CommunicationMode::Transmitter => COMM::TRANSMITTER,
+                            CommunicationMode::Receiver => COMM::RECEIVER,
+                            CommunicationMode::FullDuplex => COMM::FULLDUPLEX,
+                        };
 
                         // mstr: master configuration
                         // lsbfrst: MSB first
@@ -488,14 +539,20 @@ macro_rules! spi {
                                 .master()
                                 .lsbfrst()
                                 .msbfirst()
+                                .ssom()
+                                .bit(config.suspend_when_inactive)
                                 .ssm()
                                 .bit(config.managed_cs == false)
+                                .ssoe()
+                                .bit(config.managed_cs == true)
                                 .mssi()
-                                .bits(cycle_delay)
+                                .bits(start_cycle_delay)
+                                .midi()
+                                .bits(interdata_cycle_delay)
                                 .ioswp()
                                 .bit(config.swap_miso_mosi == true)
                                 .comm()
-                                .full_duplex()
+                                .variant(communication_mode)
                         });
 
                         // spe: enable the SPI bus


### PR DESCRIPTION
This PR adds in an `example/spi-dma-rtic.rs` example that demonstrates how to use RTIC, DMA transfers, and SPi together.
I also did a merge of `master` to gain access to the spi transmit-only functionality for the example.