### PR TITLE
Reduce smoltcp dependency features to a minimum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ synopsys-usb-otg = { version = "^0.2.2", features = ["cortex-m"], optional = tru
 [dependencies.smoltcp]
 version = "0.6.0"
 default-features = false
-features = ["ethernet", "proto-ipv4", "proto-dhcpv4", "socket-tcp", "socket-raw"]
+features = ["ethernet", "proto-ipv4"]
 optional = true
 
 [dependencies.chrono]


### PR DESCRIPTION
Since [*Dependencies are resolved with the union of all features enabled on them*](https://doc.rust-lang.org/cargo/reference/resolver.html#features), it's good practice to remove unnecessary dependencies.

More features are added by the dev-dependency so that the examples build