### PR TITLE
DMA buffer swap logic

### DIFF
--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -521,30 +521,31 @@ macro_rules! dma_stream {
 
             impl<I: Instance> DoubleBufferedStream for $name<I> {
                 #[inline(always)]
-                unsafe fn set_peripheral_address(&mut self, value: u32) {
+                unsafe fn set_peripheral_address(&mut self, value: usize) {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dma = &*I::ptr();
-                    dma.st[Self::NUMBER].par.write(|w| w.pa().bits(value));
+                    dma.st[Self::NUMBER].par.write(|w| w.pa().bits(value as u32));
                 }
 
                 #[inline(always)]
-                unsafe fn set_memory_address(&mut self, buffer: CurrentBuffer, value: u32) {
+                unsafe fn set_memory_address(&mut self, buffer: CurrentBuffer, value: usize) {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dma = &*I::ptr();
                     match buffer {
-                        CurrentBuffer::Buffer0 => dma.st[Self::NUMBER].m0ar.write(|w| w.m0a().bits(value)),
-                        CurrentBuffer::Buffer1 => dma.st[Self::NUMBER].m1ar.write(|w| w.m1a().bits(value)),
+                        CurrentBuffer::Buffer0 => dma.st[Self::NUMBER].m0ar.write(|w| w.m0a().bits(value as u32)),
+                        CurrentBuffer::Buffer1 => dma.st[Self::NUMBER].m1ar.write(|w| w.m1a().bits(value as u32)),
                     }
                 }
 
                 #[inline(always)]
-                fn get_memory_address(&self, buffer: CurrentBuffer) -> u32 {
+                fn get_memory_address(&self, buffer: CurrentBuffer) -> usize {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
-                    match buffer {
+                    let addr = match buffer {
                         CurrentBuffer::Buffer0 => dma.st[Self::NUMBER].m0ar.read().m0a().bits(),
                         CurrentBuffer::Buffer1 => dma.st[Self::NUMBER].m1ar.read().m1a().bits(),
-                    }
+                    };
+                    addr as usize
                 }
 
                 #[inline(always)]

--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -528,31 +528,23 @@ macro_rules! dma_stream {
                 }
 
                 #[inline(always)]
-                unsafe fn set_memory_address(&mut self, value: u32) {
+                unsafe fn set_memory_address(&mut self, buffer: CurrentBuffer, value: u32) {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dma = &*I::ptr();
-                    dma.st[Self::NUMBER].m0ar.write(|w| w.m0a().bits(value));
+                    match buffer {
+                        CurrentBuffer::Buffer0 => dma.st[Self::NUMBER].m0ar.write(|w| w.m0a().bits(value)),
+                        CurrentBuffer::Buffer1 => dma.st[Self::NUMBER].m1ar.write(|w| w.m1a().bits(value)),
+                    }
                 }
 
                 #[inline(always)]
-                fn get_memory_address(&self) -> u32 {
+                fn get_memory_address(&self, buffer: CurrentBuffer) -> u32 {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
-                    dma.st[Self::NUMBER].m0ar.read().m0a().bits()
-                }
-
-                #[inline(always)]
-                unsafe fn set_memory_double_buffer_address(&mut self, value: u32) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma = &*I::ptr();
-                    dma.st[Self::NUMBER].m1ar.write(|w| w.m1a().bits(value));
-                }
-
-                #[inline(always)]
-                fn get_memory_double_buffer_address(&self) -> u32 {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.st[Self::NUMBER].m1ar.read().m1a().bits()
+                    match buffer {
+                        CurrentBuffer::Buffer0 => dma.st[Self::NUMBER].m0ar.read().m0a().bits(),
+                        CurrentBuffer::Buffer1 => dma.st[Self::NUMBER].m1ar.read().m1a().bits(),
+                    }
                 }
 
                 #[inline(always)]
@@ -635,9 +627,9 @@ macro_rules! dma_stream {
                     //NOTE(unsafe) Atomic read with no side effects
                     let dma = unsafe { &*I::ptr() };
                     if dma.st[Self::NUMBER].cr.read().ct().bit_is_set() {
-                        CurrentBuffer::DoubleBuffer
+                        CurrentBuffer::Buffer1
                     } else {
-                        CurrentBuffer::FirstBuffer
+                        CurrentBuffer::Buffer0
                     }
                 }
             }

--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -624,15 +624,18 @@ macro_rules! dma_stream {
                     dma.st[Self::NUMBER].cr.modify(|_, w| w.dbm().bit(double_buffer));
                 }
 
+                #[inline(always)]
                 fn get_current_buffer() -> CurrentBuffer {
                     //NOTE(unsafe) Atomic read with no side effects
                     let dma = unsafe { &*I::ptr() };
-                    match dma.st[Self::NUMBER].cr.read().ct().bit_is_set() {
-                        false => CurrentBuffer::Buffer0,
-                        true => CurrentBuffer::Buffer1,
+                    if dma.st[Self::NUMBER].cr.read().ct().bit_is_set() {
+                        CurrentBuffer::Buffer0
+                    } else {
+                        CurrentBuffer::Buffer1
                     }
                 }
 
+                #[inline(always)]
                 fn get_inactive_buffer() -> Option<CurrentBuffer> {
                     //NOTE(unsafe) Atomic read with no side effects
                     let dma = unsafe { &*I::ptr() };

--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -624,25 +624,24 @@ macro_rules! dma_stream {
                     dma.st[Self::NUMBER].cr.modify(|_, w| w.dbm().bit(double_buffer));
                 }
 
-                fn set_current_buffer(buffer: CurrentBuffer) {
+                fn get_current_buffer() -> CurrentBuffer {
                     //NOTE(unsafe) Atomic read with no side effects
                     let dma = unsafe { &*I::ptr() };
-                    dma.st[Self::NUMBER].cr.modify(|_, w| w.ct().bit(
-                            match buffer {
-                                CurrentBuffer::Buffer0 => false,
-                                CurrentBuffer::Buffer1 => true,
-                            }))
+                    match dma.st[Self::NUMBER].cr.read().ct().bit_is_set() {
+                        false => CurrentBuffer::Buffer0,
+                        true => CurrentBuffer::Buffer1,
+                    }
                 }
 
-                fn get_current_buffer() -> Option<CurrentBuffer> {
+                fn get_inactive_buffer() -> Option<CurrentBuffer> {
                     //NOTE(unsafe) Atomic read with no side effects
                     let dma = unsafe { &*I::ptr() };
                     let cr = dma.st[Self::NUMBER].cr.read();
                     if cr.dbm().bit_is_set() {
                         Some(if cr.ct().bit_is_set() {
-                            CurrentBuffer::Buffer1
-                        } else {
                             CurrentBuffer::Buffer0
+                        } else {
+                            CurrentBuffer::Buffer1
                         })
                     } else {
                         None

--- a/src/dma/macros.rs
+++ b/src/dma/macros.rs
@@ -15,8 +15,8 @@ macro_rules! peripheral_target_instance {
       $dir:ty $(, $mux:expr)*)) => {
         unsafe impl TargetAddress<$dir> for $peripheral {
             #[inline(always)]
-            fn address(&self) -> u32 {
-                &self.$register as *const _ as u32
+            fn address(&self) -> usize {
+                &self.$register as *const _ as usize
             }
 
             type MemSize = $size;
@@ -33,8 +33,8 @@ macro_rules! peripheral_target_instance {
         // Access via PAC peripheral structures implies u8 sizing, as the sizing is unknown.
         unsafe impl TargetAddress<M2P> for $peripheral {
             #[inline(always)]
-            fn address(&self) -> u32 {
-                &self.$txreg as *const _ as u32
+            fn address(&self) -> usize {
+                &self.$txreg as *const _ as usize
             }
 
             type MemSize = u8;
@@ -44,8 +44,8 @@ macro_rules! peripheral_target_instance {
 
         unsafe impl TargetAddress<P2M> for $peripheral {
             #[inline(always)]
-            fn address(&self) -> u32 {
-                &self.$rxreg as *const _ as u32
+            fn address(&self) -> usize {
+                &self.$rxreg as *const _ as usize
             }
 
             type MemSize = u8;
@@ -57,8 +57,8 @@ macro_rules! peripheral_target_instance {
         $(
         unsafe impl TargetAddress<M2P> for spi::Spi<$peripheral, spi::Disabled, $size> {
             #[inline(always)]
-            fn address(&self) -> u32 {
-                &self.inner().$txreg as *const _ as u32
+            fn address(&self) -> usize {
+                &self.inner().$txreg as *const _ as usize
             }
 
             type MemSize = $size;
@@ -68,8 +68,8 @@ macro_rules! peripheral_target_instance {
 
         unsafe impl TargetAddress<P2M> for spi::Spi<$peripheral, spi::Disabled, $size> {
             #[inline(always)]
-            fn address(&self) -> u32 {
-                &self.inner().$rxreg as *const _ as u32
+            fn address(&self) -> usize {
+                &self.inner().$rxreg as *const _ as usize
             }
 
             type MemSize = $size;
@@ -83,8 +83,8 @@ macro_rules! peripheral_target_instance {
       $dir:ty $(, $mux:expr)*)) => {
         unsafe impl TargetAddress<$dir> for $peripheral {
             #[inline(always)]
-            fn address(&self) -> u32 {
-                &self.inner().$register as *const _ as u32
+            fn address(&self) -> usize {
+                &self.inner().$register as *const _ as usize
             }
 
             type MemSize = $size;
@@ -101,8 +101,8 @@ macro_rules! peripheral_target_instance {
       $dir:ty $(, $mux:expr)*)) => {
         unsafe impl TargetAddress<$dir> for $peripheral {
             #[inline(always)]
-            fn address(&self) -> u32 {
-                &self.$channel.$register as *const _ as u32
+            fn address(&self) -> usize {
+                &self.$channel.$register as *const _ as usize
             }
 
             type MemSize = $size;

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -490,7 +490,7 @@ where
                 // between reading the CT bit and poisoning the inactive address, this
                 // write will fail and lead to a transfer error (TEIF) and disable
                 // the stream.
-                // If DMA wins the race by the time we write the new valid addressi
+                // If DMA wins the race by the time we write the new valid address
                 // (below), it gets a bus error and errors/stops.
                 unsafe {
                     self.stream.set_memory_address(inactive, 0xffff_ffffusize);

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -32,7 +32,7 @@ mod macros;
 #[cfg(not(feature = "rm0455"))] // Remove when fixed upstream
 pub mod dma; // DMA1 and DMA2
 
-// pub mod bdma;
+pub mod bdma;
 
 pub mod traits;
 use traits::{

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -24,7 +24,7 @@ use core::{
     ptr,
     sync::atomic::{compiler_fence, Ordering},
 };
-use embedded_dma::WriteBuffer;
+use embedded_dma::StaticWriteBuffer;
 
 #[macro_use]
 mod macros;
@@ -286,8 +286,7 @@ where
     STREAM: Stream,
     PERIPHERAL: TargetAddress<DIR>,
     DIR: Direction,
-    BUF: WriteBuffer<Word = <PERIPHERAL as TargetAddress<DIR>>::MemSize>
-        + 'static,
+    BUF: StaticWriteBuffer<Word = <PERIPHERAL as TargetAddress<DIR>>::MemSize>,
 {
     stream: STREAM,
     peripheral: PERIPHERAL,
@@ -305,8 +304,7 @@ where
     CONFIG: DoubleBufferedConfig,
     DIR: Direction,
     PERIPHERAL: TargetAddress<DIR>,
-    BUF: WriteBuffer<Word = <PERIPHERAL as TargetAddress<DIR>>::MemSize>
-        + 'static,
+    BUF: StaticWriteBuffer<Word = <PERIPHERAL as TargetAddress<DIR>>::MemSize>,
 {
     /// Applies all fields in DmaConfig.
     fn apply_config(&mut self, config: CONFIG) {
@@ -782,8 +780,7 @@ where
     STREAM: Stream,
     PERIPHERAL: TargetAddress<DIR>,
     DIR: Direction,
-    BUF: WriteBuffer<Word = <PERIPHERAL as TargetAddress<DIR>>::MemSize>
-        + 'static,
+    BUF: StaticWriteBuffer<Word = <PERIPHERAL as TargetAddress<DIR>>::MemSize>,
 {
     fn drop(&mut self) {
         self.stream.disable();

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -160,9 +160,9 @@ impl From<u8> for FifoLevel {
 /// Which DMA buffer is in use.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CurrentBuffer {
-    /// The first buffer (m0ar) is in use.
+    /// The first buffer (m0ar).
     Buffer0 = 0,
-    /// The second buffer (m1ar) is in use.
+    /// The second buffer (m1ar).
     Buffer1 = 1,
 }
 

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -102,13 +102,13 @@ pub trait Stream: Sealed {
 /// Trait for Double-Buffered DMA streams
 pub trait DoubleBufferedStream: Stream + Sealed {
     /// Set the peripheral address (par) for the DMA stream.
-    unsafe fn set_peripheral_address(&mut self, value: u32);
+    unsafe fn set_peripheral_address(&mut self, value: usize);
 
     /// Set the memory address (m0ar) for the DMA stream.
-    unsafe fn set_memory_address(&mut self, buffer: CurrentBuffer, value: u32);
+    unsafe fn set_memory_address(&mut self, buffer: CurrentBuffer, value: usize);
 
     /// Get the memory address (m0ar) for the DMA stream.
-    fn get_memory_address(&self, buffer: CurrentBuffer) -> u32;
+    fn get_memory_address(&self, buffer: CurrentBuffer) -> usize;
 
     /// Enable/disable memory increment (minc) for the DMA stream.
     fn set_memory_increment(&mut self, increment: bool);
@@ -210,7 +210,7 @@ pub unsafe trait TargetAddress<D: Direction> {
     type MemSize;
 
     /// The address to be used by the DMA stream
-    fn address(&self) -> u32;
+    fn address(&self) -> usize;
 
     /// An optional associated request line
     const REQUEST_LINE: Option<u8> = None;

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -161,8 +161,11 @@ pub trait DoubleBufferedStream: Stream + Sealed {
     /// Enable/disable the double buffer (dbm) of the DMA stream.
     fn set_double_buffer(&mut self, double_buffer: bool);
 
-    /// Get which buffer is currently in use by the DMA.
-    fn current_buffer() -> CurrentBuffer;
+    /// Set the current buffer.
+    fn set_current_buffer(buffer: CurrentBuffer);
+
+    /// Get which buffer is currently in use by the DMA when in double buffer mode.
+    fn get_current_buffer() -> Option<CurrentBuffer>;
 }
 
 /// Trait for Master DMA streams

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -105,7 +105,11 @@ pub trait DoubleBufferedStream: Stream + Sealed {
     unsafe fn set_peripheral_address(&mut self, value: usize);
 
     /// Set the memory address (m0ar) for the DMA stream.
-    unsafe fn set_memory_address(&mut self, buffer: CurrentBuffer, value: usize);
+    unsafe fn set_memory_address(
+        &mut self,
+        buffer: CurrentBuffer,
+        value: usize,
+    );
 
     /// Get the memory address (m0ar) for the DMA stream.
     fn get_memory_address(&self, buffer: CurrentBuffer) -> usize;
@@ -161,11 +165,11 @@ pub trait DoubleBufferedStream: Stream + Sealed {
     /// Enable/disable the double buffer (dbm) of the DMA stream.
     fn set_double_buffer(&mut self, double_buffer: bool);
 
-    /// Set the current buffer.
-    fn set_current_buffer(buffer: CurrentBuffer);
-
     /// Get which buffer is currently in use by the DMA when in double buffer mode.
-    fn get_current_buffer() -> Option<CurrentBuffer>;
+    fn get_current_buffer() -> CurrentBuffer;
+
+    /// Get which buffer is currently not in use by the DMA when in double buffer mode.
+    fn get_inactive_buffer() -> Option<CurrentBuffer>;
 }
 
 /// Trait for Master DMA streams

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -104,14 +104,14 @@ pub trait DoubleBufferedStream: Stream + Sealed {
     /// Set the peripheral address (par) for the DMA stream.
     unsafe fn set_peripheral_address(&mut self, value: usize);
 
-    /// Set the memory address (m0ar) for the DMA stream.
+    /// Set the memory address (m0ar or m1ar) for the DMA stream.
     unsafe fn set_memory_address(
         &mut self,
         buffer: CurrentBuffer,
         value: usize,
     );
 
-    /// Get the memory address (m0ar) for the DMA stream.
+    /// Get the memory address (m0ar or m1ar) for the DMA stream.
     fn get_memory_address(&self, buffer: CurrentBuffer) -> usize;
 
     /// Enable/disable memory increment (minc) for the DMA stream.

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -105,16 +105,10 @@ pub trait DoubleBufferedStream: Stream + Sealed {
     unsafe fn set_peripheral_address(&mut self, value: u32);
 
     /// Set the memory address (m0ar) for the DMA stream.
-    unsafe fn set_memory_address(&mut self, value: u32);
+    unsafe fn set_memory_address(&mut self, buffer: CurrentBuffer, value: u32);
 
     /// Get the memory address (m0ar) for the DMA stream.
-    fn get_memory_address(&self) -> u32;
-
-    /// Set the double buffer address (m1ar) for the DMA stream.
-    unsafe fn set_memory_double_buffer_address(&mut self, value: u32);
-
-    /// Get the double buffer address (m1ar) for the DMA stream.
-    fn get_memory_double_buffer_address(&self) -> u32;
+    fn get_memory_address(&self, buffer: CurrentBuffer) -> u32;
 
     /// Enable/disable memory increment (minc) for the DMA stream.
     fn set_memory_increment(&mut self, increment: bool);
@@ -138,7 +132,7 @@ pub trait DoubleBufferedStream: Stream + Sealed {
     ///     * 0 -> byte
     ///     * 1 -> half word
     ///     * 2 -> word
-    ///     * 3 -> double workd
+    ///     * 3 -> double word
     unsafe fn set_memory_size(&mut self, size: u8);
 
     /// Set the peripheral memory size (psize) for the DMA stream.


### PR DESCRIPTION
This PR (into the `dma` branch) rewrites the `next_transfer()` and `next_transfer_with()` implementations.

* `CurrentBuffer` enums renamed to be more accurate and peripheral-matching.
* Added a few stream methods to expose the dbm/ct bits in joint semantics (also faster).
* Using `usize` for the addresses instead of `u32`.
* The non-double buffer and the double buffer code paths are unified.
* It poisons the inactive buffer address to convert silent corruption into DMA/bus errors (@adamgreig 's idea).
* With that, I'd consider `next_transfer_with()` `safe`. It's not DMA overrun safe in general but it is safe from any concurrent buffer access by user and DMA since the buffer the user has access to is always out of reach of the DMA (by poisoning or implicit disable). Certainly safe in the sense that there is nothing that the user can do to make it safer or less safe.
* Overrun errors due to due to DMA hitting the poison or writing to the active address will not go unnoticed (user needs to clear, handle, and restart).
* Errors due to `next_transfer{,_with}` being invoked late (DMA wrap around) can still go unnoticed. I don't think there is anything we can do about it since the peripheral will happily wrap around unattended (AFAWK). But they now are guaranteed to not lead to corruption within a buffer.
* `next_transfer()` just calls `next_transfer_with()` with triple buffering (one active, one inactive, and one user).
* `fence()` added.

Pending:

* [x] This is untested on hardware.
* [x] `BDMA` is not done.
* [ ] Returning a/the buffer on error might make sense.

@thalesfragoso @richardeoin @ryan-summers comments appreciated.