### PR TITLE
[DMA] Next transfer returns number of remaining data

### DIFF
--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -467,8 +467,11 @@ where
 
     /// Changes the buffer and restarts or continues a double buffer
     /// transfer. This must be called immediately after a transfer complete
-    /// event. Returns the old buffer together with its `CurrentBuffer`. If an
-    /// error occurs, this method will return the new buffer with the error.
+    /// event. Returns (old_buffer, `CurrentBuffer`, remaining), where
+    /// `old_buffer` is the old buffer, `CurrentBuffer` indicates which buffer
+    /// the data represents, and `remaining` indicates the number of remaining
+    /// data in the transfer. If an error occurs, this method will return the
+    /// new buffer with the error.
     ///
     /// This method will clear the transfer complete flag on entry, it will also
     /// clear it again if an overrun occurs during its execution. Moreover, if
@@ -656,6 +659,10 @@ where
     /// error will be returned if this method is called before the end of a
     /// transfer while double buffering and the closure won't be executed.
     ///
+    /// The closure accepts the current buffer, the `CurrentBuffer` indicating
+    /// which buffer is provided, and a `remaining` parameter indicating the
+    /// number of transfers not completed in the DMA transfer.
+    ///
     /// # Panics
     ///
     /// This method will panic when double buffering and one or both of the
@@ -677,7 +684,7 @@ where
         f: F,
     ) -> Result<T, DMAError<()>>
     where
-        F: FnOnce(BUF, CurrentBuffer) -> (BUF, T),
+        F: FnOnce(BUF, CurrentBuffer, usize) -> (BUF, T),
     {
         if self.double_buf.is_some()
             && DIR::direction() != DmaDirection::MemoryToMemory
@@ -694,7 +701,7 @@ where
             } else {
                 self.double_buf.take().unwrap()
             };
-            let r = f(db, !current_buffer);
+            let r = f(db, !current_buffer, 0);
             let mut new_buf = r.0;
             let (new_buf_ptr, new_buf_len) = new_buf.write_buffer();
 
@@ -754,9 +761,11 @@ where
         // "No re-ordering of reads and writes across this point is allowed"
         compiler_fence(Ordering::SeqCst);
 
+        let remaining_data = STREAM::get_number_of_transfers();
+
         // Can never fail, we never let the Transfer without a buffer
         let old_buf = self.buf.take().unwrap();
-        let r = f(old_buf, CurrentBuffer::FirstBuffer);
+        let r = f(old_buf, CurrentBuffer::FirstBuffer, remaining_data as usize);
         let mut new_buf = r.0;
 
         let (buf_ptr, buf_len) = new_buf.write_buffer();


### PR DESCRIPTION
This PR updates the DMA `next_transfer` to return the number of data that was not transferred. This is necessary for applications that are cancelled prematurely (e.g. in scatter-gather implementations where we gather as many data as possible in a fixed amount of time).