### PR TITLE
Add initial support for MDMA

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,3 +190,7 @@ required-features = ["rm0433"]
 [[example]]
 name = "spi-dma-rtic"
 required-features = ["rm0433","rt"]
+
+
+[patch.crates-io]
+stm32h7 = { git = "https://github.com/stm32-rs/stm32-rs-nightlies" }

--- a/examples/mdma.rs
+++ b/examples/mdma.rs
@@ -74,7 +74,7 @@ fn main() -> ! {
     let streams = StreamsTuple::new(dp.MDMA, ccdr.peripheral.MDMA);
 
     let config = MdmaConfig::default()
-        // increment by one element per transfer
+        // increment by one element per element
         .destination_increment(MdmaIncrement::Increment)
         .source_increment(MdmaIncrement::Increment);
 
@@ -89,7 +89,7 @@ fn main() -> ! {
 
     // Block of 800 bytes, MDMA checks other streams every 128 bytes
     assert_eq!(transfer.get_block_bytes(), 800);
-    assert_eq!(transfer.get_transfer_bytes(), 128);
+    assert_eq!(transfer.get_buffer_bytes(), 128);
 
     // Start block
     transfer.start(|_| {});

--- a/examples/mdma.rs
+++ b/examples/mdma.rs
@@ -13,7 +13,7 @@ mod utilities;
 use stm32h7xx_hal::{pac, prelude::*};
 
 use stm32h7xx_hal::dma::{
-    mdma::{MdmaConfig, MdmaIncrement, StreamsTuple},
+    mdma::{MdmaConfig, MdmaIncrement, MdmaSize, StreamsTuple},
     traits::Direction,
     MemoryToMemory, Transfer,
 };
@@ -63,6 +63,10 @@ fn main() -> ! {
         unsafe { mem::transmute(buf) }
     };
 
+    //
+    // Example 1: Memory to TCM
+    //
+
     // Target buffer on the stack
     let mut target_buffer: [u32; 20] = [0; 20];
 
@@ -89,13 +93,94 @@ fn main() -> ! {
     while !transfer.get_transfer_complete_flag() {}
 
     // Decompose the stream to get the source buffer back
-    let (_stream, _mem2mem, _target, source_buffer_opt) = transfer.free();
-    let _source_buffer = source_buffer_opt.unwrap();
+    let (stream, _mem2mem, _target, source_buffer_opt) = transfer.free();
+    let source_buffer = source_buffer_opt.unwrap();
 
-    // Comparison check
     assert_eq!(target_buffer, [0x11223344; 20]);
 
-    info!("Memory to TCM DMA completed successfully");
+    info!("Example 1: Memory to TCM DMA completed successfully");
+
+    //
+    // Example 2: Memory to TCM with endianess and offset
+    //
+
+    // Reset source buffer
+    *source_buffer = [0xAABBCCDD; 20];
+
+    let config = MdmaConfig::default()
+        .source_increment(MdmaIncrement::Increment)
+        .destination_increment(MdmaIncrement::IncrementWithOffset(
+            MdmaSize::DoubleWord,
+        ))
+        .half_word_endianness_exchange(true);
+
+    let mut transfer: Transfer<_, _, MemoryToMemory<u32>, _> =
+        Transfer::init_master(
+            stream,
+            MemoryToMemory::new(),
+            unsafe { mem::transmute(&mut target_buffer) }, // Dest: TCM (stack)
+            Some(source_buffer),                           // Source: AXISRAM
+            config,
+        );
+
+    transfer.start(|_| {});
+
+    // Wait for transfer to complete
+    while !transfer.get_transfer_complete_flag() {}
+
+    assert_eq!(
+        target_buffer,
+        [
+            0xCCDDAABB, 0x11223344, 0xCCDDAABB, 0x11223344, 0xCCDDAABB,
+            0x11223344, 0xCCDDAABB, 0x11223344, 0xCCDDAABB, 0x11223344,
+            0xCCDDAABB, 0x11223344, 0xCCDDAABB, 0x11223344, 0xCCDDAABB,
+            0x11223344, 0xCCDDAABB, 0x11223344, 0xCCDDAABB, 0x11223344,
+        ]
+    );
+
+    info!(
+        "Example 2: Memory to TCM DMA with endianess and offset completed successfully"
+    );
+
+    //
+    // Example 3: TCM to TCM with offset
+    //
+
+    let mut source_buffer_tcm = [1u8, 2, 3, 4];
+    // unsafe: we must ensure source_buffer_tcm lives long enough
+    let source_buffer: &'static mut [u8] =
+        unsafe { mem::transmute(&mut source_buffer_tcm[..]) };
+    let mut target_buffer = [0u8; 17];
+
+    let config = MdmaConfig::default().destination_increment(
+        MdmaIncrement::IncrementWithOffset(MdmaSize::DoubleWord),
+    );
+
+    let mut transfer: Transfer<_, _, MemoryToMemory<u8>, _> =
+        Transfer::init_master(
+            streams.1,
+            MemoryToMemory::new(),
+            unsafe { mem::transmute(&mut target_buffer[..]) }, // Dest: TCM (stack)
+            Some(source_buffer), // Source: TCM (stack)
+            config,
+        );
+
+    // Transfer length is limited to the minimum number of bytes that are valid
+    // for both buffers
+    assert_eq!(transfer.get_transfer_bytes(), 3);
+
+    transfer.start(|_| {});
+
+    // Wait for transfer to complete
+    while !transfer.get_transfer_complete_flag() {}
+
+    assert_eq!(source_buffer_tcm, [1, 2, 3, 4]);
+    assert_eq!(
+        target_buffer,
+        [1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3]
+    );
+
+    info!("Example 3: TCM to TCM DMA with offset completed successfully");
 
     loop {}
 }

--- a/examples/mdma.rs
+++ b/examples/mdma.rs
@@ -1,0 +1,101 @@
+//! Example of Memory to Memory Transfer with the Master DMA (MDMA)
+
+#![allow(clippy::transmute_ptr_to_ptr)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use core::{mem, mem::MaybeUninit};
+
+use cortex_m_rt::entry;
+#[macro_use]
+mod utilities;
+use stm32h7xx_hal::{pac, prelude::*};
+
+use stm32h7xx_hal::dma::{
+    mdma::{MdmaConfig, MdmaIncrement, StreamsTuple},
+    traits::Direction,
+    MemoryToMemory, Transfer,
+};
+
+use log::info;
+
+// The MDMA can interact with SRAM banks as well as the TCM. For this example,
+// we place the source in the AXI SRAM.
+//
+// The runtime does not initialise AXI SRAM banks.
+#[link_section = ".axisram.buffers"]
+static mut SOURCE_BUFFER: MaybeUninit<[u32; 20]> = MaybeUninit::uninit();
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = example_power!(pwr).freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc
+        .sys_ck(100.mhz())
+        .hclk(50.mhz())
+        .freeze(pwrcfg, &dp.SYSCFG);
+
+    info!("");
+    info!("stm32h7xx-hal example - Memory to TCM with Master DMA");
+    info!("");
+
+    // Initialise the source buffer without taking any references to
+    // uninitialisated memory
+    let source_buffer: &'static mut [u32; 20] = {
+        let buf: &mut [MaybeUninit<u32>; 20] =
+            unsafe { mem::transmute(&mut SOURCE_BUFFER) };
+
+        for value in buf.iter_mut() {
+            unsafe {
+                value.as_mut_ptr().write(0x11223344u32);
+            }
+        }
+        unsafe { mem::transmute(buf) }
+    };
+
+    // Target buffer on the stack
+    let mut target_buffer: [u32; 20] = [0; 20];
+
+    // Setup DMA
+    let streams = StreamsTuple::new(dp.MDMA, ccdr.peripheral.MDMA);
+
+    let config = MdmaConfig::default()
+        // increment by one element per transfer
+        .destination_increment(MdmaIncrement::Increment)
+        .source_increment(MdmaIncrement::Increment);
+
+    let mut transfer: Transfer<_, _, MemoryToMemory<u32>, _> =
+        Transfer::init_master(
+            streams.0,
+            MemoryToMemory::new(),
+            unsafe { mem::transmute(&mut target_buffer) }, // Dest: TCM (stack)
+            Some(source_buffer),                           // Source: AXISRAM
+            config,
+        );
+
+    transfer.start(|_| {});
+
+    // Wait for transfer to complete
+    while !transfer.get_transfer_complete_flag() {}
+
+    // Decompose the stream to get the source buffer back
+    let (_stream, _mem2mem, _target, source_buffer_opt) = transfer.free();
+    let _source_buffer = source_buffer_opt.unwrap();
+
+    // Comparison check
+    assert_eq!(target_buffer, [0x11223344; 20]);
+
+    info!("Memory to TCM DMA completed successfully");
+
+    loop {}
+}

--- a/src/dma/mdma.rs
+++ b/src/dma/mdma.rs
@@ -1,0 +1,708 @@
+//! Master DMA
+//!
+//!
+
+use super::{
+    config,
+    traits::sealed::{Bits, Sealed},
+    traits::*,
+    MemoryToPeripheral, PeripheralToMemory,
+};
+
+use core::marker::PhantomData;
+use core::mem;
+
+use crate::{
+    i2c::I2c,
+    pac::{self, MDMA},
+    rcc::{rec, rec::ResetEnable},
+};
+
+use core::ops::Deref;
+
+impl Sealed for MDMA {}
+
+/// Type aliases for register blocks
+pub type MDMARegisterBlock = pac::mdma::RegisterBlock;
+pub type DMAMUXRegisterBlock = pac::dmamux2::RegisterBlock;
+
+/// Trait that represents an instance of a MDMA peripheral
+pub trait Instance: Deref<Target = MDMARegisterBlock> + Sealed {
+    type Rec: ResetEnable;
+
+    /// Gives a pointer to the RegisterBlock.
+    fn ptr() -> *const MDMARegisterBlock;
+}
+
+impl Instance for MDMA {
+    type Rec = rec::Mdma;
+
+    #[inline(always)]
+    fn ptr() -> *const MDMARegisterBlock {
+        MDMA::ptr()
+    }
+}
+
+/// MDMA Source/Destination sizes
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub enum MdmaSize {
+    /// Byte (8-bit)
+    Byte = 0,
+    /// Half-word (16-bit)
+    HalfWord = 1,
+    /// Word (32-bit)
+    Word = 2,
+    /// Double-word (64-bit)
+    DoubleWord = 3,
+}
+impl MdmaSize {
+    /// Returns MdmaSize from the size of a type. Undefined if
+    /// embedded_dma::Word is implemented for types not 1, 2, 4 or 8 bytes long.
+    pub fn from_type<T: Sized>() -> Self {
+        match mem::size_of::<T>() {
+            1 => MdmaSize::Byte,
+            2 => MdmaSize::HalfWord,
+            4 => MdmaSize::Word,
+            8 => MdmaSize::DoubleWord,
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// MDMA increment mode
+#[derive(Debug, Clone, Copy)]
+pub enum MdmaIncrement {
+    Fixed,
+    /// Increment by one source/destination element each transfer
+    Increment,
+    /// Decrement by one source/destination element each transfer
+    Decrement,
+    /// Increment by the given offset each transfer. The offset must be larger
+    /// or equal to the source/destination element size, otherwise the stream
+    /// initialisation will panic
+    IncrementWithOffset(MdmaSize),
+    /// Decrement by the given offset each transfer. The offset must be larger
+    /// or equal to the source/destination element size, otherwise the stream
+    /// initialisation will panic
+    DecrementWithOffset(MdmaSize),
+}
+impl Default for MdmaIncrement {
+    fn default() -> Self {
+        MdmaIncrement::Increment
+    }
+}
+
+/// MDMA interrupts
+#[derive(Debug, Clone, Copy)]
+pub struct MdmaInterrupts {
+    transfer_complete: bool,
+    transfer_error: bool,
+    block_transfer_complete: bool,
+    block_repeat_transfer_complete: bool,
+    channel_transfer_complete: bool,
+}
+
+/// Contains the complete set of configuration for a DMA stream.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MdmaConfig {
+    pub(crate) priority: config::Priority,
+    pub(crate) destination_increment: MdmaIncrement,
+    pub(crate) source_increment: MdmaIncrement,
+    pub(crate) transfer_complete_interrupt: bool,
+    pub(crate) transfer_error_interrupt: bool,
+    pub(crate) block_transfer_complete_interrupt: bool,
+    pub(crate) block_repeat_transfer_complete_interrupt: bool,
+    pub(crate) channel_transfer_complete_interrupt: bool,
+}
+
+impl MdmaConfig {
+    /// Set the priority
+    #[inline(always)]
+    pub fn priority(mut self, priority: config::Priority) -> Self {
+        self.priority = priority;
+        self
+    }
+    /// Set the destination_increment
+    #[inline(always)]
+    pub fn destination_increment(
+        mut self,
+        destination_increment: MdmaIncrement,
+    ) -> Self {
+        self.destination_increment = destination_increment;
+        self
+    }
+    /// Set the source_increment
+    #[inline(always)]
+    pub fn source_increment(mut self, source_increment: MdmaIncrement) -> Self {
+        self.source_increment = source_increment;
+        self
+    }
+    /// Set the transfer_complete_interrupt
+    #[inline(always)]
+    pub fn transfer_complete_interrupt(
+        mut self,
+        transfer_complete_interrupt: bool,
+    ) -> Self {
+        self.transfer_complete_interrupt = transfer_complete_interrupt;
+        self
+    }
+    /// Set the transfer_error_interrupt
+    #[inline(always)]
+    pub fn transfer_error_interrupt(
+        mut self,
+        transfer_error_interrupt: bool,
+    ) -> Self {
+        self.transfer_error_interrupt = transfer_error_interrupt;
+        self
+    }
+    /// Set the block_transfer_complete_interrupt
+    #[inline(always)]
+    pub fn block_transfer_complete_interrupt(
+        mut self,
+        block_transfer_complete_interrupt: bool,
+    ) -> Self {
+        self.block_transfer_complete_interrupt =
+            block_transfer_complete_interrupt;
+        self
+    }
+    /// Set the block_repeat_transfer_complete_interrupt
+    #[inline(always)]
+    pub fn block_repeat_transfer_complete_interrupt(
+        mut self,
+        block_repeat_transfer_complete_interrupt: bool,
+    ) -> Self {
+        self.block_repeat_transfer_complete_interrupt =
+            block_repeat_transfer_complete_interrupt;
+        self
+    }
+    /// Set the channel_transfer_complete_interrupt
+    #[inline(always)]
+    pub fn channel_transfer_complete_interrupt(
+        mut self,
+        channel_transfer_complete_interrupt: bool,
+    ) -> Self {
+        self.channel_transfer_complete_interrupt =
+            channel_transfer_complete_interrupt;
+        self
+    }
+}
+
+/// Stream 0 on MDMA
+pub struct Stream0<DMA> {
+    _dma: PhantomData<DMA>,
+}
+/// Stream 1 on MDMA
+pub struct Stream1<DMA> {
+    _dma: PhantomData<DMA>,
+}
+/// Stream 2 on MDMA
+pub struct Stream2<DMA> {
+    _dma: PhantomData<DMA>,
+}
+/// Stream 3 on MDMA
+pub struct Stream3<DMA> {
+    _dma: PhantomData<DMA>,
+}
+/// Stream 4 on MDMA
+pub struct Stream4<DMA> {
+    _dma: PhantomData<DMA>,
+}
+/// Stream 5 on MDMA
+pub struct Stream5<DMA> {
+    _dma: PhantomData<DMA>,
+}
+/// Stream 6 on MDMA
+pub struct Stream6<DMA> {
+    _dma: PhantomData<DMA>,
+}
+/// Stream 7 on MDMA
+pub struct Stream7<DMA> {
+    _dma: PhantomData<DMA>,
+}
+
+impl<DMA> Sealed for Stream0<DMA> {}
+impl<DMA> Sealed for Stream1<DMA> {}
+impl<DMA> Sealed for Stream2<DMA> {}
+impl<DMA> Sealed for Stream3<DMA> {}
+impl<DMA> Sealed for Stream4<DMA> {}
+impl<DMA> Sealed for Stream5<DMA> {}
+impl<DMA> Sealed for Stream6<DMA> {}
+impl<DMA> Sealed for Stream7<DMA> {}
+
+/// Alias for a tuple with all DMA streams.
+pub struct StreamsTuple<T>(
+    pub Stream0<T>,
+    pub Stream1<T>,
+    pub Stream2<T>,
+    pub Stream3<T>,
+    pub Stream4<T>,
+    pub Stream5<T>,
+    pub Stream6<T>,
+    pub Stream7<T>,
+);
+
+impl<I: Instance> StreamsTuple<I> {
+    /// Splits the DMA peripheral into streams.
+    pub fn new(_regs: I, prec: I::Rec) -> Self {
+        prec.enable().reset();
+        Self(
+            Stream0 { _dma: PhantomData },
+            Stream1 { _dma: PhantomData },
+            Stream2 { _dma: PhantomData },
+            Stream3 { _dma: PhantomData },
+            Stream4 { _dma: PhantomData },
+            Stream5 { _dma: PhantomData },
+            Stream6 { _dma: PhantomData },
+            Stream7 { _dma: PhantomData },
+        )
+    }
+}
+
+// Macro that creates a struct representing a stream on the MDMA controller
+//
+// The implementation does the heavy lifting of mapping to the right fields on
+// the stream
+macro_rules! mdma_stream {
+    ($(($name:ident, $channel:ident, $number:expr,
+        $ifcr:ident, $tcif:ident, $htif:ident, $teif:ident, $gif:ident,
+        $isr:ident, $tcisr:ident, $htisr:ident)
+    ),+$(,)*) => {
+        $(
+            impl<I: Instance> Stream for $name<I> {
+
+                const NUMBER: usize = $number;
+                type Config = MdmaConfig;
+                type Interrupts = MdmaInterrupts;
+
+                fn apply_config(&mut self, config: MdmaConfig) {
+                    self.set_priority(config.priority);
+
+                    // We do not set DINCOS/SINCOS here
+                    self.set_destination_increment(config.destination_increment);
+                    self
+                        .set_source_increment(config.source_increment);
+
+                    self.set_transfer_complete_interrupt_enable(
+                        config.transfer_complete_interrupt
+                    );
+                    self.set_transfer_error_interrupt_enable(
+                        config.transfer_error_interrupt
+                    );
+                    self.set_block_transfer_complete_interrupt_enable(
+                        config.block_transfer_complete_interrupt
+                    );
+                    self.set_block_repeat_transfer_complete_interrupt_enable(
+                        config.block_repeat_transfer_complete_interrupt
+                    );
+                    self.set_channel_transfer_complete_interrupt_enable(
+                        config.channel_transfer_complete_interrupt
+                    );
+                }
+
+                #[inline(always)]
+                fn clear_interrupts(&mut self) {
+                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                    // that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.ifcr.write(|w| w
+                        .cltcif().set_bit() //Clear transfer complete interrupt flag
+                        .cteif().set_bit() //Clear transfer error interrupt flag
+
+                        .cbtif().set_bit() //Clear block transfer complete flag
+                        .cbrtif().set_bit() //Clear block repeat transfer complete flag
+                        .cctcif().set_bit() //Clear channel transfer complete flag
+                    );
+                }
+
+                #[inline(always)]
+                fn clear_transfer_error_interrupt(&mut self) {
+                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                    // that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.ifcr.write(|w| w.cteif().set_bit());
+                }
+
+                #[inline(always)]
+                fn clear_transfer_complete_interrupt(&mut self) {
+                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                    // that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.ifcr.write(|w| w.cltcif().set_bit());
+                }
+
+                #[inline(always)]
+                fn get_transfer_complete_flag() -> bool {
+                    //NOTE(unsafe) Atomic read with no side effects
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.isr.read().tcif().bit_is_set()
+                }
+
+                #[inline(always)]
+                unsafe fn enable(&mut self) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = &*I::ptr();
+                    mdma.$channel.cr.modify(|_, w| w.en().set_bit());
+
+                    // If this channel is configured as software triggered, then
+                    // we also active the request
+                    if mdma.$channel.tcr.read().swrm().bit_is_set() {
+                        mdma.$channel.cr.modify(|_, w| w.swrq().set_bit());
+                    }
+                }
+
+                #[inline(always)]
+                fn is_enabled() -> bool {
+                    //NOTE(unsafe) Atomic read with no side effects
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.cr.read().en().bit_is_set()
+                }
+
+                fn disable(&mut self) {
+                    if Self::is_enabled() {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma = unsafe { &*I::ptr() };
+
+                        // Aborting an on-going transfer might cause interrupts to fire, disable
+                        // them
+                        let interrupts = Self::get_interrupts_enable();
+                        self.disable_interrupts();
+
+                        dma.$channel.cr.modify(|_, w| w.en().clear_bit());
+                        while Self::is_enabled() {}
+
+                        self.clear_interrupts();
+                        self.enable_interrupts(interrupts);
+                    }
+                }
+
+                #[inline(always)]
+                fn set_request_line(&mut self, _request_line: u8) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+
+                    // TODO: Request lines
+                }
+
+                #[inline(always)]
+                fn set_priority(&mut self, priority: config::Priority) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.cr.modify(|_, w| unsafe {
+                        w.pl().bits(priority.bits())
+                    });
+                }
+
+                #[inline(always)]
+                fn disable_interrupts(&mut self) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.cr.modify(|_, w| w
+                                                   .tcie().clear_bit()
+                                                   .teie().clear_bit()
+                                                   .btie().clear_bit()
+                                                   .brtie().clear_bit()
+                                                   .ctcie().clear_bit()
+                    );
+                }
+
+                #[inline(always)]
+                fn enable_interrupts(&mut self, interrupt: Self::Interrupts) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.cr.modify(|_, w| w
+                                                   .tcie().bit(interrupt.transfer_complete)
+                                                   .teie().bit(interrupt.transfer_error)
+                                                   .btie().bit(interrupt.block_transfer_complete)
+                                                   .brtie().bit(interrupt.block_repeat_transfer_complete)
+                                                   .ctcie().bit(interrupt.channel_transfer_complete)
+                    );
+                }
+
+                #[inline(always)]
+                fn get_interrupts_enable() -> Self::Interrupts {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma = unsafe { &*I::ptr() };
+                    let cr = dma.$channel.cr.read();
+
+                    MdmaInterrupts {
+                        transfer_complete: cr.tcie().bit_is_set(),
+                        transfer_error: cr.teie().bit_is_set(),
+                        block_transfer_complete: cr.btie().bit_is_set(),
+                        block_repeat_transfer_complete: cr.brtie().bit_is_set(),
+                        channel_transfer_complete: cr.teie().bit_is_set(),
+                    }
+                }
+
+                #[inline(always)]
+                fn set_transfer_complete_interrupt_enable(&mut self, transfer_complete_interrupt: bool) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.cr.modify(|_, w| w.tcie().bit(transfer_complete_interrupt));
+                }
+
+                #[inline(always)]
+                fn set_transfer_error_interrupt_enable(&mut self, transfer_error_interrupt: bool) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.cr.modify(|_, w| w.teie().bit(transfer_error_interrupt));
+                }
+            }
+
+            impl<I: Instance> MasterStream for $name<I> {
+                #[inline(always)]
+                unsafe fn set_source_address(&mut self, value: usize) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = &*I::ptr();
+                    mdma.$channel.sar.write(|w| w.sar().bits(value as u32));
+                    mdma.$channel.tbr.modify(|_,w| w.sbus().bit(
+                        Self::is_ahb_port(value)
+                    ));
+                }
+
+                #[inline(always)]
+                unsafe fn set_destination_address(&mut self, value: usize) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = &*I::ptr();
+                    mdma.$channel.dar.write(|w| w.dar().bits(value as u32));
+                    mdma.$channel.tbr.modify(|_,w| w.dbus().bit(
+                        Self::is_ahb_port(value)
+                    ));
+                }
+
+                #[inline(always)]
+                fn set_software_triggered(&mut self, sw_triggered: bool) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.tcr.modify(|_, w| w.swrm().bit(sw_triggered));
+                }
+
+                #[inline(always)]
+                fn set_transfer_bytes(&mut self, value: u8) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.tcr.modify(|_, w| unsafe { w.tlen().bits(value - 1) });
+                    mdma.$channel.bndtr.modify(|_, w| unsafe { w.bndt().bits(value as u32) });
+                }
+
+                /// Apply the configation structure to this
+                /// stream. SINCOS/DINCOS are set based on the source_size /
+                /// destination_size if not specified by the config structure.
+                #[inline(always)]
+                fn apply_config_with_size(&mut self,
+                                              config: <Self as Stream>::Config,
+                                              source_size: MdmaSize,
+                                              destination_size: MdmaSize) {
+                    self.apply_config(config);
+
+                    //NOTE(unsafe) We only set the offset if it is larger or
+                    // equal to the source/destination size
+                    unsafe {
+                        self.set_source_offset(match config.source_increment {
+                            MdmaIncrement::IncrementWithOffset(source_offset) |
+                            MdmaIncrement::DecrementWithOffset(source_offset) => {
+                                assert!(source_offset >= source_size);
+
+                                // TODO: If source/destination is AHB and DBURST
+                                // =/ 000, destination address must be aligned
+                                // with DINCOS size, else the result is
+                                // unpredictable.
+
+                                source_offset
+                            },
+                            _ => source_size
+                        });
+                        self.set_destination_offset(match config.destination_increment {
+                            MdmaIncrement::IncrementWithOffset(destination_offset) |
+                            MdmaIncrement::DecrementWithOffset(destination_offset) => {
+                                assert!(destination_offset >= destination_size);
+
+                                destination_offset
+                            },
+                            _ => destination_size
+                        });
+                    }
+                }
+
+                #[inline(always)]
+                unsafe fn set_source_size(&mut self, size: MdmaSize) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = &*I::ptr();
+                    mdma.$channel.tcr.modify(|_, w| w.ssize().bits(size as u8));
+                }
+
+                #[inline(always)]
+                unsafe fn set_source_offset(&mut self, offset: MdmaSize) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = &*I::ptr();
+                    mdma.$channel.tcr.modify(|_, w| w.sincos().bits(offset as u8));
+                }
+
+                #[inline(always)]
+                unsafe fn set_destination_size(&mut self, size: MdmaSize) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = &*I::ptr();
+                    mdma.$channel.tcr.modify(|_, w| w.dsize().bits(size as u8));
+                }
+
+                #[inline(always)]
+                unsafe fn set_destination_offset(&mut self, offset: MdmaSize) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = &*I::ptr();
+                    mdma.$channel.tcr.modify(|_, w| w.dincos().bits(offset as u8));
+                }
+            }
+
+            impl<I: Instance> $name<I> {
+                /// Returns true if the MDMA master must access `address` via
+                /// the 32-bit AHB slave port on the Cortex-M7 crossbar, rather
+                /// than the AXI matrix.
+                ///
+                /// This corresponds to the D0TCM, D1TCM and ITCM regions. These
+                /// regions are not relocatable.
+                #[inline(always)]
+                pub fn is_ahb_port(address: usize) -> bool {
+                    // On these parts is it possible to re-locate AXI SRAM to
+                    // the Cortex-M7 crossbar bus. TODO: investigate how to
+                    // handle this.
+                    #[cfg(feature = "rm0468")]
+                    panic!("MDMA not implemented for RM0468 parts yet!");
+
+                    // 64kB ITCM
+                    let is_itcm: bool = address < 0x0001_0000;
+                    // 128kB DTCM
+                    let is_dtcm: bool = (address >= 0x2000_0000 && address < 0x2002_0000);
+
+                    is_itcm || is_dtcm
+                }
+
+                #[inline(always)]
+                pub fn clear_block_transfer_complete_interrupt(&mut self) {
+                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                    // that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.ifcr.write(|w| w.cbtif().set_bit());
+                }
+
+                #[inline(always)]
+                pub fn get_block_transfer_complete_flag() -> bool {
+                    //NOTE(unsafe) Atomic read with no side effects
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.isr.read().btif().bit_is_set()
+                }
+
+                #[inline(always)]
+                pub fn clear_block_repeat_transfer_complete_interrupt(&mut self) {
+                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                    // that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.ifcr.write(|w| w.cbrtif().set_bit());
+                }
+
+                #[inline(always)]
+                pub fn get_block_repeat_transfer_complete_flag() -> bool {
+                    //NOTE(unsafe) Atomic read with no side effects
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.isr.read().brtif().bit_is_set()
+                }
+
+                #[inline(always)]
+                pub fn clear_channel_transfer_complete_interrupt(&mut self) {
+                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                    // that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.ifcr.write(|w| w.cctcif().set_bit());
+                }
+
+                #[inline(always)]
+                pub fn get_channel_transfer_complete_flag() -> bool {
+                    //NOTE(unsafe) Atomic read with no side effects
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.isr.read().ctcif().bit_is_set()
+                }
+
+                #[inline(always)]
+                pub fn set_block_transfer_complete_interrupt_enable(
+                    &mut self, block_transfer_complete_interrupt: bool)
+                {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.cr.modify(|_, w| w.btie().bit(block_transfer_complete_interrupt));
+                }
+
+                #[inline(always)]
+                pub fn set_block_repeat_transfer_complete_interrupt_enable(
+                    &mut self, block_repeat_transfer_complete_interrupt: bool)
+                {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.cr.modify(|_, w| w.brtie().bit(block_repeat_transfer_complete_interrupt));
+                }
+
+                #[inline(always)]
+                pub fn set_channel_transfer_complete_interrupt_enable(
+                    &mut self, channel_transfer_complete_interrupt: bool)
+                {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.cr.modify(|_, w| w.ctcie().bit(channel_transfer_complete_interrupt));
+                }
+
+                #[inline(always)]
+                pub fn set_destination_increment(&mut self, increment: MdmaIncrement) {
+                    use MdmaIncrement::*;
+
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.tcr.modify(|_, w| unsafe {
+                        w.dinc().bits(match increment {
+                            Fixed => 0b00,
+                            Increment | IncrementWithOffset(_) => 0b10,
+                            Decrement | DecrementWithOffset(_) => 0b11,
+                        })
+                    });
+                }
+
+                #[inline(always)]
+                pub fn set_source_increment(&mut self, increment: MdmaIncrement) {
+                    use MdmaIncrement::*;
+
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.tcr.modify(|_, w| unsafe {
+                        w.sinc().bits(match increment {
+                            Fixed => 0b00,
+                            Increment | IncrementWithOffset(_) => 0b10,
+                            Decrement | DecrementWithOffset(_) => 0b11,
+                        })
+                    });
+                }
+            }
+        )+
+    };
+}
+
+mdma_stream!(
+    // Note: the field names start from one, unlike the RM where they start from
+    // zero. May need updating if it gets fixed upstream.
+    (Stream0, ch0, 0, ifcr, ctcif1, chtif1, cteif1, cgif1, isr, tcif1, htif1),
+    (Stream1, ch1, 1, ifcr, ctcif2, chtif2, cteif2, cgif2, isr, tcif2, htif2),
+    (Stream2, ch2, 2, ifcr, ctcif3, chtif3, cteif3, cgif3, isr, tcif3, htif3),
+    (Stream3, ch3, 3, ifcr, ctcif4, chtif4, cteif4, cgif4, isr, tcif4, htif4),
+    (Stream4, ch4, 4, ifcr, ctcif5, chtif5, cteif5, cgif5, isr, tcif5, htif5),
+    (Stream5, ch5, 5, ifcr, ctcif6, chtif6, cteif6, cgif6, isr, tcif6, htif6),
+    (Stream6, ch6, 6, ifcr, ctcif7, chtif7, cteif7, cgif7, isr, tcif7, htif7),
+    (Stream7, ch7, 7, ifcr, ctcif8, chtif8, cteif8, cgif8, isr, tcif8, htif8),
+);
+
+/// Type alias for the DMA Request Multiplexer
+pub type DMAReq = pac::dmamux2::ccr::DMAREQ_ID_A;
+
+type P2M = PeripheralToMemory;
+type M2P = MemoryToPeripheral;
+
+// peripheral_target_address!((
+//     QSPI: pac::QUADSPI,
+//     rdr,
+//     u8,
+//     P2M,
+//     DMAReq::USART1_RX_DMA
+// ),);

--- a/src/dma/mdma.rs
+++ b/src/dma/mdma.rs
@@ -518,11 +518,17 @@ macro_rules! mdma_stream {
                 }
 
                 #[inline(always)]
+                fn set_trigger_mode(&mut self, trigger_mode: u8) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.tcr.modify(|_, w| unsafe { w.trgm().bits(trigger_mode) });
+                }
+
+                #[inline(always)]
                 unsafe fn set_transfer_bytes(&mut self, value: u8) {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let mdma = &*I::ptr();
                     mdma.$channel.tcr.modify(|_, w| w.tlen().bits(value - 1));
-                    mdma.$channel.bndtr.modify(|_, w| w.bndt().bits(value as u32));
                 }
 
                 #[inline(always)]
@@ -530,6 +536,20 @@ macro_rules! mdma_stream {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let mdma = unsafe { &*I::ptr() };
                     mdma.$channel.tcr.read().tlen().bits() + 1
+                }
+
+                #[inline(always)]
+                unsafe fn set_block_bytes(&mut self, value: u32) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = &*I::ptr();
+                    mdma.$channel.bndtr.modify(|_, w| w.bndt().bits(value));
+                }
+
+                #[inline(always)]
+                fn get_block_bytes() -> u32 {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.bndtr.read().bndt().bits()
                 }
 
                 fn source_destination_size_offset(

--- a/src/dma/mdma.rs
+++ b/src/dma/mdma.rs
@@ -504,10 +504,7 @@ impl<I: Instance> StreamsTuple<I> {
 // The implementation does the heavy lifting of mapping to the right fields on
 // the stream
 macro_rules! mdma_stream {
-    ($(($name:ident, $channel:ident, $number:expr,
-        $ifcr:ident, $tcif:ident, $htif:ident, $teif:ident, $gif:ident,
-        $isr:ident, $tcisr:ident, $htisr:ident)
-    ),+$(,)*) => {
+    ($( ($name:ident, $channel:ident, $number:expr) ),+$(,)*) => {
         $(
             impl<I: Instance> Stream for $name<I> {
 
@@ -1056,16 +1053,14 @@ macro_rules! mdma_stream {
 }
 
 mdma_stream!(
-    // Note: the field names start from one, unlike the RM where they start from
-    // zero. May need updating if it gets fixed upstream.
-    (Stream0, ch0, 0, ifcr, ctcif1, chtif1, cteif1, cgif1, isr, tcif1, htif1),
-    (Stream1, ch1, 1, ifcr, ctcif2, chtif2, cteif2, cgif2, isr, tcif2, htif2),
-    (Stream2, ch2, 2, ifcr, ctcif3, chtif3, cteif3, cgif3, isr, tcif3, htif3),
-    (Stream3, ch3, 3, ifcr, ctcif4, chtif4, cteif4, cgif4, isr, tcif4, htif4),
-    (Stream4, ch4, 4, ifcr, ctcif5, chtif5, cteif5, cgif5, isr, tcif5, htif5),
-    (Stream5, ch5, 5, ifcr, ctcif6, chtif6, cteif6, cgif6, isr, tcif6, htif6),
-    (Stream6, ch6, 6, ifcr, ctcif7, chtif7, cteif7, cgif7, isr, tcif7, htif7),
-    (Stream7, ch7, 7, ifcr, ctcif8, chtif8, cteif8, cgif8, isr, tcif8, htif8),
+    (Stream0, ch0, 0),
+    (Stream1, ch1, 1),
+    (Stream2, ch2, 2),
+    (Stream3, ch3, 3),
+    (Stream4, ch4, 4),
+    (Stream5, ch5, 5),
+    (Stream6, ch6, 6),
+    (Stream7, ch7, 7),
 );
 
 /// Type alias for the DMA Request Multiplexer

--- a/src/dma/mdma.rs
+++ b/src/dma/mdma.rs
@@ -1069,10 +1069,15 @@ pub type DMAReq = pac::dmamux2::ccr::DMAREQ_ID_A;
 type P2M = PeripheralToMemory;
 type M2P = MemoryToPeripheral;
 
-// peripheral_target_address!((
-//     QSPI: pac::QUADSPI,
-//     rdr,
-//     u8,
-//     P2M,
-//     DMAReq::USART1_RX_DMA
-// ),);
+// Access the QSPI data register as a u32 for bus access efficiency. The MDMA
+// itself can be used to pack/unpack to/from u8/u16.
+#[cfg(not(feature = "rm0455"))]
+peripheral_target_address!(
+    (pac::QUADSPI, dr, u32, P2M),
+    (pac::QUADSPI, dr, u32, M2P),
+);
+#[cfg(all(feature = "quadspi", not(feature = "rm0455")))]
+peripheral_target_address!(
+    (INNER: crate::qspi::Qspi, dr, u32, P2M),
+    (INNER: crate::qspi::Qspi, dr, u32, M2P),
+);

--- a/src/dma/mdma.rs
+++ b/src/dma/mdma.rs
@@ -213,6 +213,27 @@ impl Default for MdmaIncrement {
     }
 }
 
+/// MDMA Packing/Alignment mode
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MdmaPackingAlignment {
+    /// Source data is packed/unpacked into the destination data size
+    Packed,
+    /// Source data is extended/truncated into the destination data size. Source
+    /// data smaller than the destination is right-aligned and padded with zeros
+    ExtendTruncate,
+    /// Source data is extended/truncated into the destination data size. Source
+    /// data smaller than the destination is right-aligned and sign-extended.
+    ExtendSignExtend,
+    /// Source data is extended/truncated into the destination data size. Source
+    /// data smaller than the destination is left-aligned and padded with zeros
+    ExtendLeftAligned,
+}
+impl Default for MdmaPackingAlignment {
+    fn default() -> Self {
+        MdmaPackingAlignment::Packed
+    }
+}
+
 /// MDMA trigger mode
 #[derive(Debug, Clone, Copy)]
 pub enum MdmaTrigger {
@@ -250,6 +271,7 @@ pub struct MdmaConfig {
     pub(crate) transfer_request: Option<MdmaTransferRequest>,
     pub(crate) trigger_mode: MdmaTrigger,
     pub(crate) buffer_length: Option<u8>,
+    pub(crate) packing_alignment: MdmaPackingAlignment,
     pub(crate) word_endianness_exchange: bool,
     pub(crate) half_word_endianness_exchange: bool,
     pub(crate) byte_endianness_exchange: bool,
@@ -326,6 +348,13 @@ impl MdmaConfig {
         );
 
         self.buffer_length = Some(bytes);
+        self
+    }
+    /// Set the MDMA packing and alignment. When the source and destination have
+    /// the same storage type, this has no effect
+    #[inline(always)]
+    pub fn packing_alignment(mut self, packing: MdmaPackingAlignment) -> Self {
+        self.packing_alignment = packing;
         self
     }
     /// Set word endianness exchange. Applies when the destination is
@@ -521,6 +550,9 @@ macro_rules! mdma_stream {
                         }
                     }
 
+                    self.set_packing_alignment(
+                        config.packing_alignment
+                    );
                     self.set_word_endianness_exchange(
                         config.word_endianness_exchange
                     );
@@ -878,6 +910,23 @@ macro_rules! mdma_stream {
                     is_itcm || is_dtcm
                 }
 
+                #[inline(always)]
+                pub fn set_packing_alignment(&mut self, pack: MdmaPackingAlignment) {
+                    use MdmaPackingAlignment::*;
+
+                    //NOTE(unsafe) We only access the registers that belongs to
+                    // the StreamX
+                    let mdma = unsafe { &*I::ptr() };
+                    mdma.$channel.tcr.modify(|_,w| unsafe {
+                        w
+                            .pke().bit(pack == Packed)
+                            .pam().bits(match pack {
+                                ExtendSignExtend => 0b01,
+                                ExtendLeftAligned => 0b10,
+                                _ => 0b00,
+                            })
+                    });
+                }
                 #[inline(always)]
                 pub fn set_word_endianness_exchange(&mut self, exchange: bool) {
                     //NOTE(unsafe) We only access the registers that belongs to

--- a/src/dma/mdma.rs
+++ b/src/dma/mdma.rs
@@ -6,6 +6,34 @@
 //! matrix. Unlike DMA1/DMA2, it can access TCM memory regions via the Cortex-M7
 //! AHBS port.
 //!
+//! ## Trigger Modes
+//!
+//! #### Block Trigger (default)
+//!
+//! In this mode, each transfer results in the transfer of up to 65536 bytes of
+//! data. The MDMA checks for other higher priority every 128 bytes, although
+//! the [`buffer_length`](MdmaConfig#method.buffer_length) method can be use to
+//! configure a smaller interval.
+//!
+//! #### Buffer Trigger
+//!
+//! In Buffer mode, each trigger results in the transfer of up to 128 bytes of
+//! data. If a larger transfer was configured, the MDMA stream must be triggered
+//! again to continue the transfer. This behaviour is useful alongside hardware
+//! triggers when transferring to/from peripheral FIFOs.
+//!
+//! In the reference manual, the words Buffer and Transfer are used
+//! interchangeably, for example in the TLEN field. To avoid confusion with
+//! other types of transfers, we use only the word Buffer.
+//!
+//! #### Repeated Block Mode
+//!
+//! TODO
+//!
+//! #### Linked List Mode
+//!
+//! TODO
+//!
 //! ## Stream Transfer Requests
 //!
 //! MDMA stream transfer requests can originate from either hardware or
@@ -166,15 +194,15 @@ impl MdmaSize {
 #[derive(Debug, Clone, Copy)]
 pub enum MdmaIncrement {
     Fixed,
-    /// Increment by one source/destination element each transfer
+    /// Increment by one source/destination element each element
     Increment,
-    /// Decrement by one source/destination element each transfer
+    /// Decrement by one source/destination element each element
     Decrement,
-    /// Increment by the given offset each transfer. The offset must be larger
+    /// Increment by the given offset each element. The offset must be larger
     /// or equal to the source/destination element size, otherwise the stream
     /// initialisation will panic
     IncrementWithOffset(MdmaSize),
-    /// Decrement by the given offset each transfer. The offset must be larger
+    /// Decrement by the given offset each element. The offset must be larger
     /// or equal to the source/destination element size, otherwise the stream
     /// initialisation will panic
     DecrementWithOffset(MdmaSize),
@@ -221,7 +249,7 @@ pub struct MdmaConfig {
     pub(crate) source_increment: MdmaIncrement,
     pub(crate) transfer_request: Option<MdmaTransferRequest>,
     pub(crate) trigger_mode: MdmaTrigger,
-    pub(crate) transfer_length: Option<u8>,
+    pub(crate) buffer_length: Option<u8>,
     pub(crate) word_endianness_exchange: bool,
     pub(crate) half_word_endianness_exchange: bool,
     pub(crate) byte_endianness_exchange: bool,
@@ -277,27 +305,27 @@ impl MdmaConfig {
         self.trigger_mode = trigger;
         self
     }
-    /// Sets the length of each transfer. For the MDMA this is the length of
+    /// Sets the length of each buffer. For the MDMA this is the length of
     /// data to be transferred without checking for requests on other channels.
     ///
     /// Normally the MDMA is configured to trigger a block transfer
-    /// (TRGM=0b01). Each block consists of one of more transfers. If
-    /// `trigger_mode` is set to `Buffer` instead, then each transfer must be
+    /// (TRGM=0b01). Each block consists of one of more buffers. If
+    /// `trigger_mode` is set to `Buffer` instead, then each buffer must be
     /// triggered individually.
     ///
-    /// The transfer length is specified in bytes, and must be a multiple of
+    /// The buffer length is specified in bytes, and must be a multiple of
     /// both the source and destination sizes.
     ///
-    /// If the number of bytes in the block is not a multiple of the transfer
-    /// length, then the final transfer will be shorter than the others.
+    /// If the number of bytes in the block is not a multiple of the buffer
+    /// length, then the final buffer will be shorter than the others.
     #[inline(always)]
-    pub fn transfer_length(mut self, bytes: u8) -> Self {
+    pub fn buffer_length(mut self, bytes: u8) -> Self {
         debug_assert!(
             bytes <= 128,
-            "Hardware only supports transfers up to 128 bytes"
+            "Hardware only supports buffers up to 128 bytes"
         );
 
-        self.transfer_length = Some(bytes);
+        self.buffer_length = Some(bytes);
         self
     }
     /// Set word endianness exchange. Applies when the destination is
@@ -471,25 +499,25 @@ macro_rules! mdma_stream {
                     }
                     self.set_trigger_mode(config.trigger_mode);
 
-                    // Custom transfer length if specified
-                    if let Some(transfer_length) = config.transfer_length {
+                    // Custom buffer length if specified
+                    if let Some(buffer_length) = config.buffer_length {
                         // Up to 128 bytes
-                        assert!(transfer_length <= 128);
-                        // Length of the transfer must be less than the length
+                        assert!(buffer_length <= 128);
+                        // Length of the buffer must be less than the length
                         // of the block
-                        assert!(transfer_length as u32 <= Self::get_block_bytes());
-                        // Length of the transfer must be a multiple of the
+                        assert!(buffer_length as u32 <= Self::get_block_bytes());
+                        // Length of the buffer must be a multiple of the
                         // source size
-                        assert_eq!(transfer_length as usize %
+                        assert_eq!(buffer_length as usize %
                                    Self::get_source_size().n_bytes(), 0);
-                        // Length of the transfer must be a multiple of the
+                        // Length of the buffer must be a multiple of the
                         // destination size
-                        assert_eq!(transfer_length as usize %
+                        assert_eq!(buffer_length as usize %
                                    Self::get_destination_size().n_bytes(), 0);
 
-                        // Replace calculated transfer length
+                        // Replace calculated buffer length
                         unsafe {
-                            self.set_transfer_bytes(transfer_length);
+                            self.set_buffer_bytes(buffer_length);
                         }
                     }
 
@@ -712,14 +740,14 @@ macro_rules! mdma_stream {
                 }
 
                 #[inline(always)]
-                unsafe fn set_transfer_bytes(&mut self, value: u8) {
+                unsafe fn set_buffer_bytes(&mut self, value: u8) {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let mdma = &*I::ptr();
                     mdma.$channel.tcr.modify(|_, w| w.tlen().bits(value - 1));
                 }
 
                 #[inline(always)]
-                fn get_transfer_bytes() -> u8 {
+                fn get_buffer_bytes() -> u8 {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let mdma = unsafe { &*I::ptr() };
                     mdma.$channel.tcr.read().tlen().bits() + 1

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -903,4 +903,15 @@ where
     pub fn get_block_bytes(&self) -> u32 {
         STREAM::get_block_bytes()
     }
+
+    /// Get the buffer transfer complete flag (tcif)
+    #[inline(always)]
+    pub fn get_buffer_transfer_complete_flag(&self) -> bool {
+        STREAM::get_buffer_transfer_complete_flag()
+    }
+    /// Get the block transfer complete (btif)
+    #[inline(always)]
+    pub fn get_block_transfer_complete_flag(&self) -> bool {
+        STREAM::get_block_transfer_complete_flag()
+    }
 }

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -768,14 +768,23 @@ where
 
     /// Configures the DMA source and destination and applies supplied
     /// configuration. In a memory to memory transfer, the `second_buf` argument
-    /// is the source of the data.
+    /// is the source of the data
     ///
     /// # Panics
     ///
     /// * When a memory-memory transfer is specified but the `second_buf`
     /// argument is `None`.
     ///
-    /// * When the transfer length is greater than 128 bytes.
+    /// * When the length is greater than 65536 bytes.
+    ///
+    /// * When `config` specifies a `source_increment` that is smaller than the
+    /// source size.
+    ///
+    /// * When `config` specifies a `destination_increment` that is smaller than
+    /// the destination size.
+    ///
+    /// * When `config` specifies a `transfer_length` that is not a multiple of
+    /// both the source and destination sizes.
     pub fn init_master(
         mut stream: STREAM,
         peripheral: PERIPHERAL,
@@ -837,9 +846,6 @@ where
 
             0
         };
-
-        // This method always configures a block transfer
-        stream.set_trigger_mode(1);
 
         // Set trigger source
         stream.set_software_triggered(is_mem2mem);

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -743,30 +743,47 @@ where
         self.stream.apply_config(config);
     }
 
-    /// Calculates the maximum number of bytes that can be transferred
+    /// Calculates the maximum number of bytes that can be transferred in an
+    /// MDMA block. The length is reffered to the source size
     ///
-    /// s_len: The number of input words of s_size available
-    /// d_len: The number of input words of d_size available
-    fn m_number_of_bytes(config: &CONFIG, s_len: usize, d_len: usize) -> usize {
+    /// * `s_len`: The number of input words of s_size available. `None` if the
+    /// source is a peripheral
+    /// * `d_len`: The number of input words of d_size available. `None` if the
+    /// destination is a peripheral
+    ///
+    /// `s_len` and `d_len` cannot both be peripherals (None)
+    fn m_number_of_bytes(
+        config: &CONFIG,
+        s_len: Option<usize>,
+        d_len: Option<usize>,
+    ) -> usize {
         let ((s_size, d_size), (s_offset, d_offset)) =
             Self::source_destination_size_offset(&config);
 
-        let s_bytes = s_len * s_size.n_bytes();
-        // Include a virtual gap at the end
-        let s_plus_gap = s_bytes + s_offset.n_bytes() - s_size.n_bytes();
-        // Bytes = Number of steps * Element size
-        let s_bytes = (s_plus_gap / s_offset.n_bytes()) * s_size.n_bytes();
+        let len_to_bytes = |len, size: usize, offset: usize| {
+            let bytes = len * size;
+            // Include a virtual gap at the end
+            let plus_gap = bytes + offset - size;
+            // Bytes = Number of elements * SOURCE data size
+            (plus_gap / offset) * s_size.n_bytes()
+        };
 
-        let d_bytes = d_len * d_size.n_bytes();
-        // Include a virtual gap at the end
-        let d_plus_gap = d_bytes + d_offset.n_bytes() - d_size.n_bytes();
-        // Bytes = Number of steps * Element size
-        let d_bytes = (d_plus_gap / d_offset.n_bytes()) * d_size.n_bytes();
+        let s_bytes = s_len
+            .map(|len| len_to_bytes(len, s_size.n_bytes(), s_offset.n_bytes()));
+        let d_bytes = d_len
+            .map(|len| len_to_bytes(len, d_size.n_bytes(), d_offset.n_bytes()));
 
-        cmp::min(s_bytes, d_bytes)
+        // Ignore None - from a memory point of view, we can read infinite bytes
+        // from a peripheral
+        match (s_bytes, d_bytes) {
+            (Some(s), Some(d)) => cmp::min(s, d),
+            (Some(s), None) => s,
+            (None, Some(d)) => d,
+            (None, None) => unreachable!(),
+        }
     }
 
-    /// Configures the DMA source and destination and applies supplied
+    /// Configures the MDMA source and destination and applies supplied
     /// configuration. In a memory to memory transfer, the `second_buf` argument
     /// is the source of the data
     ///
@@ -794,65 +811,61 @@ where
     ) -> Self {
         stream.disable();
 
-        // TODO
-        assert!(
-            DIR::direction() == DmaDirection::PeripheralToMemory
-                || DIR::direction() == DmaDirection::MemoryToMemory,
-            "M2P not yet supported."
-        );
-
         // NOTE(unsafe) We now own this buffer and we won't call any &mut
         // methods on it until the end of the DMA transfer
         let (buf_ptr, buf_len) = unsafe { memory.write_buffer() };
 
-        // Set the memory address
-        //
-        // # Safety
-        //
-        // Must be a valid memory address
-        unsafe {
-            stream.set_destination_address(buf_ptr as usize);
-        }
+        let (source_len, destination_len) = match DIR::direction() {
+            DmaDirection::MemoryToMemory => {
+                // must have 2nd buffer
+                if let Some(ref mut sb) = second_buf {
+                    // NOTE(unsafe) We now own this buffer and we won't call any &mut
+                    // methods on it until the end of the DMA transfer
 
-        let is_mem2mem = DIR::direction() == DmaDirection::MemoryToMemory;
-        let source_len = if is_mem2mem {
-            // must have 2nd buffer
-            if let Some(ref mut sb) = second_buf {
-                // NOTE(unsafe) We now own this buffer and we won't call any &mut
-                // methods on it until the end of the DMA transfer
+                    let (sb_ptr, sb_len) = unsafe { sb.write_buffer() };
 
-                let (sb_ptr, sb_len) = unsafe { sb.write_buffer() };
+                    // second buffer is the source in mem2mem mode
+                    unsafe {
+                        stream.set_source_address(sb_ptr as usize);
+                        stream.set_destination_address(buf_ptr as usize);
+                    }
 
-                // second buffer is the source in mem2mem mode
+                    (Some(sb_len), Some(buf_len))
+                } else {
+                    panic!("must have second buffer");
+                }
+            }
+            DmaDirection::MemoryToPeripheral => {
+                // Set the source/destination address
+                //
+                // # Safety
+                //
+                // Must be a valid source/destination address
                 unsafe {
-                    stream.set_source_address(sb_ptr as usize);
+                    stream.set_source_address(buf_ptr as usize);
+                    stream.set_destination_address(peripheral.address());
                 }
 
-                sb_len
-            } else {
-                panic!("must have second buffer");
+                (Some(buf_len), None)
             }
-        } else {
-            // Must not have a second-buffer
+            DmaDirection::PeripheralToMemory => {
+                // Set the source/destination address
+                //
+                // # Safety
+                //
+                // Must be a valid source/destination address
+                unsafe {
+                    stream.set_source_address(peripheral.address());
+                    stream.set_destination_address(buf_ptr as usize);
+                }
 
-            // Set the peripheral address as the source
-            //
-            // # Safety
-            //
-            // Must be a valid peripheral address
-            unsafe {
-                stream.set_source_address(peripheral.address());
+                (None, Some(buf_len))
             }
-
-            0
         };
-
-        // Set trigger source
-        stream.set_software_triggered(is_mem2mem);
 
         // Set block length
         let block_number_of_bytes =
-            Self::m_number_of_bytes(&config, source_len, buf_len); // s, d
+            Self::m_number_of_bytes(&config, source_len, destination_len);
         assert!(
             block_number_of_bytes <= 65536,
             "Hardware does not support more than 65536 bytes in a single transfer"
@@ -861,6 +874,7 @@ where
         // not a integer multiple of transfer_bytes, the last transfer will be
         // shorter
         let transfer_bytes = cmp::min(128, block_number_of_bytes);
+        // This is overriden if set in `config`
 
         //NOTE(unsafe) Configuration (Number of bytes, size, offset) configured
         // to be within both source and destination buffers
@@ -868,11 +882,6 @@ where
             stream.set_transfer_bytes(transfer_bytes as u8);
             stream.set_block_bytes(block_number_of_bytes as u32);
         }
-
-        // // Set the request line if not software triggered
-        // if let Some(request_line) = PERIPHERAL::REQUEST_LINE {
-        //     stream.set_request_line(request_line);
-        // }
 
         let mut transfer = Self {
             stream,

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -744,7 +744,7 @@ where
     }
 
     /// Calculates the maximum number of bytes that can be transferred in an
-    /// MDMA block. The length is reffered to the source size
+    /// MDMA block. The length is referred to the source size
     ///
     /// * `s_len`: The number of input words of s_size available. `None` if the
     /// source is a peripheral

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -871,15 +871,15 @@ where
             "Hardware does not support more than 65536 bytes in a single transfer"
         );
         // Set transfer length (within the block). If block_number_of_bytes is
-        // not a integer multiple of transfer_bytes, the last transfer will be
+        // not a integer multiple of buffer_bytes, the last buffer will be
         // shorter
-        let transfer_bytes = cmp::min(128, block_number_of_bytes);
+        let buffer_bytes = cmp::min(128, block_number_of_bytes);
         // This is overriden if set in `config`
 
         //NOTE(unsafe) Configuration (Number of bytes, size, offset) configured
         // to be within both source and destination buffers
         unsafe {
-            stream.set_transfer_bytes(transfer_bytes as u8);
+            stream.set_buffer_bytes(buffer_bytes as u8);
             stream.set_block_bytes(block_number_of_bytes as u32);
         }
 
@@ -896,8 +896,8 @@ where
     }
 
     #[inline(always)]
-    pub fn get_transfer_bytes(&self) -> u8 {
-        STREAM::get_transfer_bytes()
+    pub fn get_buffer_bytes(&self) -> u8 {
+        STREAM::get_buffer_bytes()
     }
     #[inline(always)]
     pub fn get_block_bytes(&self) -> u32 {

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -184,15 +184,26 @@ pub trait MasterStream: Stream + Sealed {
     /// Set the trigger source as software (true) or hardware (false)
     fn set_software_triggered(&mut self, sw_triggered: bool);
 
+    /// Set the trigger mode: buffer (0), block (1), repeated block (2),
+    /// linked-list (3)
+    fn set_trigger_mode(&mut self, trigger_mode: u8);
+
     /// Set the number of bytes in each transfer. This is the number of bytes
     /// that are transferred on this stream before checking for MDMA requests on
-    /// other channels.
+    /// other channels
     unsafe fn set_transfer_bytes(&mut self, value: u8);
 
     /// Get the number of bytes in each transfer. This is the number of bytes
     /// that are transferred on this stream before checking for MDMA requests on
-    /// other channels.
+    /// other channels
     fn get_transfer_bytes() -> u8;
+
+    /// Set the number of bytes to be transferred in each block
+    unsafe fn set_block_bytes(&mut self, value: u32);
+
+    /// Get the number of bytes remaining in the current block. This decrements
+    /// during the transfer, reaching zero at the end of the block
+    fn get_block_bytes() -> u32;
 
     /// For a given configuration, determine the size and offset for the source
     /// and destination

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -186,7 +186,7 @@ pub trait MasterStream: Stream + Sealed {
 
     /// Set the trigger mode: buffer (0), block (1), repeated block (2),
     /// linked-list (3)
-    fn set_trigger_mode(&mut self, trigger_mode: u8);
+    fn set_trigger_mode(&mut self, trigger_mode: mdma::MdmaTrigger);
 
     /// Set the number of bytes in each transfer. This is the number of bytes
     /// that are transferred on this stream before checking for MDMA requests on
@@ -226,6 +226,9 @@ pub trait MasterStream: Stream + Sealed {
     /// This must have the same alignment of the buffer used in the transfer.
     unsafe fn set_source_size(&mut self, size: mdma::MdmaSize);
 
+    /// Get the source size for the DMA stream.
+    fn get_source_size() -> mdma::MdmaSize;
+
     /// Set the source offset for the DMA stream.
     unsafe fn set_source_offset(&mut self, offset: mdma::MdmaSize);
 
@@ -236,6 +239,9 @@ pub trait MasterStream: Stream + Sealed {
     /// This must have the same alignment of the peripheral data used in the
     /// transfer.
     unsafe fn set_destination_size(&mut self, size: mdma::MdmaSize);
+
+    /// Get the destination size for the DMA stream.
+    fn get_destination_size() -> mdma::MdmaSize;
 
     /// Set the destination offset for the DMA stream.
     unsafe fn set_destination_offset(&mut self, offset: mdma::MdmaSize);

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -191,15 +191,15 @@ pub trait MasterStream: Stream + Sealed {
     /// linked-list (3)
     fn set_trigger_mode(&mut self, trigger_mode: mdma::MdmaTrigger);
 
-    /// Set the number of bytes in each transfer. This is the number of bytes
+    /// Set the number of bytes in each buffer. This is the number of bytes
     /// that are transferred on this stream before checking for MDMA requests on
     /// other channels
-    unsafe fn set_transfer_bytes(&mut self, value: u8);
+    unsafe fn set_buffer_bytes(&mut self, value: u8);
 
-    /// Get the number of bytes in each transfer. This is the number of bytes
+    /// Get the number of bytes in each buffer. This is the number of bytes
     /// that are transferred on this stream before checking for MDMA requests on
     /// other channels
-    fn get_transfer_bytes() -> u8;
+    fn get_buffer_bytes() -> u8;
 
     /// Set the number of bytes to be transferred in each block
     unsafe fn set_block_bytes(&mut self, value: u32);

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -184,6 +184,9 @@ pub trait MasterStream: Stream + Sealed {
     /// Set the trigger source as software (true) or hardware (false)
     fn set_software_triggered(&mut self, sw_triggered: bool);
 
+    /// Set the hardware trigger selection source
+    fn set_trigger_selection(&mut self, trigger: u8);
+
     /// Set the trigger mode: buffer (0), block (1), repeated block (2),
     /// linked-list (3)
     fn set_trigger_mode(&mut self, trigger_mode: mdma::MdmaTrigger);

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -172,11 +172,52 @@ pub trait DoubleBufferedStream: Stream + Sealed {
     fn get_inactive_buffer() -> Option<CurrentBuffer>;
 }
 
-/// Trait for Master DMA streams
-///
-/// TODO
+/// Trait for Master DMA (MDMA) streams
 #[allow(unused)]
-pub trait MasterStream: Stream + Sealed {}
+pub trait MasterStream: Stream + Sealed {
+    /// Set the source for the Master DMA stream
+    unsafe fn set_source_address(&mut self, value: usize);
+
+    /// Set the destination for the Master DMA stream
+    unsafe fn set_destination_address(&mut self, value: usize);
+
+    /// Set the trigger source as software (true) or hardware (false)
+    fn set_software_triggered(&mut self, sw_triggered: bool);
+
+    /// Set the number of bytes to be transferred in a single transfer
+    fn set_transfer_bytes(&mut self, value: u8);
+
+    /// Apply the configation structure to this
+    /// stream. SINCOS/DINCOS are set based on the source_size /
+    /// destination_size if not specified by the config structure.
+    fn apply_config_with_size(
+        &mut self,
+        config: <Self as Stream>::Config,
+        source_size: mdma::MdmaSize,
+        destination_size: mdma::MdmaSize,
+    );
+
+    /// Set the source size (s_size) for the DMA stream.
+    ///
+    /// # Safety
+    ///
+    /// This must have the same alignment of the buffer used in the transfer.
+    unsafe fn set_source_size(&mut self, size: mdma::MdmaSize);
+
+    /// Set the source offset for the DMA stream.
+    unsafe fn set_source_offset(&mut self, offset: mdma::MdmaSize);
+
+    /// Set the destination size (d_size) for the DMA stream.
+    ///
+    /// # Safety
+    ///
+    /// This must have the same alignment of the peripheral data used in the
+    /// transfer.
+    unsafe fn set_destination_size(&mut self, size: mdma::MdmaSize);
+
+    /// Set the destination offset for the DMA stream.
+    unsafe fn set_destination_offset(&mut self, offset: mdma::MdmaSize);
+}
 
 /// Trait for the configuration of Double-Buffered DMA streams
 pub trait DoubleBufferedConfig {

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -184,17 +184,28 @@ pub trait MasterStream: Stream + Sealed {
     /// Set the trigger source as software (true) or hardware (false)
     fn set_software_triggered(&mut self, sw_triggered: bool);
 
-    /// Set the number of bytes to be transferred in a single transfer
-    fn set_transfer_bytes(&mut self, value: u8);
+    /// Set the number of bytes in each transfer. This is the number of bytes
+    /// that are transferred on this stream before checking for MDMA requests on
+    /// other channels.
+    unsafe fn set_transfer_bytes(&mut self, value: u8);
 
-    /// Apply the configation structure to this
-    /// stream. SINCOS/DINCOS are set based on the source_size /
-    /// destination_size if not specified by the config structure.
-    fn apply_config_with_size(
-        &mut self,
-        config: <Self as Stream>::Config,
-        source_size: mdma::MdmaSize,
-        destination_size: mdma::MdmaSize,
+    /// Get the number of bytes in each transfer. This is the number of bytes
+    /// that are transferred on this stream before checking for MDMA requests on
+    /// other channels.
+    fn get_transfer_bytes() -> u8;
+
+    /// For a given configuration, determine the size and offset for the source
+    /// and destination
+    ///
+    /// Returns ((s_size, d_size), (s_offset, d_offset))
+    fn source_destination_size_offset(
+        config: &Self::Config,
+        peripheral_size: mdma::MdmaSize,
+        memory_size: mdma::MdmaSize,
+        direction: DmaDirection,
+    ) -> (
+        (mdma::MdmaSize, mdma::MdmaSize),
+        (mdma::MdmaSize, mdma::MdmaSize),
     );
 
     /// Set the source size (s_size) for the DMA stream.

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -259,7 +259,7 @@ pub trait MasterStream: Stream + Sealed {
     /// Clear buffer transfer complete interrupt (tcif) for the DMA stream.
     fn clear_buffer_transfer_complete_interrupt(&mut self);
 
-    /// Get buffertransfer complete flag.
+    /// Get the buffer transfer complete flag (tcif)
     fn get_buffer_transfer_complete_flag() -> bool;
 
     /// Enable/disable the block transfer complete interrupt (btie) of the DMA
@@ -272,7 +272,7 @@ pub trait MasterStream: Stream + Sealed {
     /// Clear block transfer complete interrupt (btif) for the DMA stream.
     fn clear_block_transfer_complete_interrupt(&mut self);
 
-    /// Get block transfer complete flag.
+    /// Get the block transfer complete (btif)
     fn get_block_transfer_complete_flag() -> bool;
 
     /// Enable/disable the block repeat transfer complete interrupt (brtie) of the
@@ -285,7 +285,7 @@ pub trait MasterStream: Stream + Sealed {
     /// Clear block repeat transfer complete interrupt (brtif) for the DMA stream.
     fn clear_block_repeat_transfer_complete_interrupt(&mut self);
 
-    /// Get block repeat transfer complete flag.
+    /// Get the block repeat transfer complete flag (brtif)
     fn get_block_repeat_transfer_complete_flag() -> bool;
 }
 

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -248,6 +248,45 @@ pub trait MasterStream: Stream + Sealed {
 
     /// Set the destination offset for the DMA stream.
     unsafe fn set_destination_offset(&mut self, offset: mdma::MdmaSize);
+
+    /// Enable/disable the buffer transfer complete interrupt (tcie) of the
+    /// DMA stream.
+    fn set_buffer_transfer_complete_interrupt_enable(
+        &mut self,
+        buffer_transfer_complete_interrupt: bool,
+    );
+
+    /// Clear buffer transfer complete interrupt (tcif) for the DMA stream.
+    fn clear_buffer_transfer_complete_interrupt(&mut self);
+
+    /// Get buffertransfer complete flag.
+    fn get_buffer_transfer_complete_flag() -> bool;
+
+    /// Enable/disable the block transfer complete interrupt (btie) of the DMA
+    /// stream.
+    fn set_block_transfer_complete_interrupt_enable(
+        &mut self,
+        transfer_complete_interrupt: bool,
+    );
+
+    /// Clear block transfer complete interrupt (btif) for the DMA stream.
+    fn clear_block_transfer_complete_interrupt(&mut self);
+
+    /// Get block transfer complete flag.
+    fn get_block_transfer_complete_flag() -> bool;
+
+    /// Enable/disable the block repeat transfer complete interrupt (brtie) of the
+    /// DMA stream.
+    fn set_block_repeat_transfer_complete_interrupt_enable(
+        &mut self,
+        transfer_complete_interrupt: bool,
+    );
+
+    /// Clear block repeat transfer complete interrupt (brtif) for the DMA stream.
+    fn clear_block_repeat_transfer_complete_interrupt(&mut self);
+
+    /// Get block repeat transfer complete flag.
+    fn get_block_repeat_transfer_complete_flag() -> bool;
 }
 
 /// Trait for the configuration of Double-Buffered DMA streams


### PR DESCRIPTION
TODO:

- [x] Support for memory-memory transfers
- [x] Example of memory-memory transfers - [examples/mdma.rs](https://github.com/richardeoin/stm32h7xx-hal/blob/dma-mdma1/examples/mdma.rs)
- [x] Support for memory-peripheral transfers
- [ ] Example of memory-peripheral transfers
- [ ] Support for configurable AXI burst sizes
- [ ] Support for different source/destination types for memory-memory transfers 