### PR TITLE
Implement DMA for constant source buffers

### DIFF
--- a/examples/dma.rs
+++ b/examples/dma.rs
@@ -81,13 +81,14 @@ fn main() -> ! {
         .peripheral_increment(true) // source mem
         .fifo_enable(true);
 
-    let mut transfer: Transfer<_, _, MemoryToMemory<u32>, _> = Transfer::init(
-        streams.4,
-        MemoryToMemory::new(),
-        unsafe { mem::transmute(&mut TARGET_BUFFER) }, // Uninitialised memory
-        Some(source_buffer),
-        config,
-    );
+    let mut transfer: Transfer<_, _, MemoryToMemory<u32>, _, _> =
+        Transfer::init(
+            streams.4,
+            MemoryToMemory::new(),
+            unsafe { mem::transmute(&mut TARGET_BUFFER) }, // Uninitialised memory
+            Some(source_buffer),
+            config,
+        );
 
     transfer.start(|_| {});
 

--- a/examples/i2c4_bdma.rs
+++ b/examples/i2c4_bdma.rs
@@ -90,7 +90,7 @@ fn main() -> ! {
     let config = BdmaConfig::default().memory_increment(true);
 
     // We need to specify the direction with a type annotation
-    let mut transfer: Transfer<_, _, PeripheralToMemory, _> = Transfer::init(
+    let mut transfer: Transfer<_, _, PeripheralToMemory, _, _> = Transfer::init(
         streams.0,
         i2c,
         unsafe { &mut BUFFER }, // uninitialised memory

--- a/examples/sai_dma_passthru.rs
+++ b/examples/sai_dma_passthru.rs
@@ -96,7 +96,7 @@ fn main() -> ! {
         .peripheral_increment(false)
         .circular_buffer(true)
         .fifo_enable(false);
-    let mut dma1_str0: dma::Transfer<_, _, dma::MemoryToPeripheral, _> =
+    let mut dma1_str0: dma::Transfer<_, _, dma::MemoryToPeripheral, _, _> =
         dma::Transfer::init(
             dma1_streams.0,
             unsafe { pac::Peripherals::steal().SAI1 },
@@ -111,7 +111,7 @@ fn main() -> ! {
     let dma_config = dma_config
         .transfer_complete_interrupt(true)
         .half_transfer_interrupt(true);
-    let mut dma1_str1: dma::Transfer<_, _, dma::PeripheralToMemory, _> =
+    let mut dma1_str1: dma::Transfer<_, _, dma::PeripheralToMemory, _, _> =
         dma::Transfer::init(
             dma1_streams.1,
             unsafe { pac::Peripherals::steal().SAI1 },
@@ -177,6 +177,7 @@ fn main() -> ! {
         stm32::SAI1,
         dma::PeripheralToMemory,
         &'static mut [u32; 128],
+        dma::DBTransfer,
     >;
 
     static mut TRANSFER_DMA1_STR1: Option<TransferDma1Str1> = None;

--- a/examples/spi-dma-rtic.rs
+++ b/examples/spi-dma-rtic.rs
@@ -37,6 +37,7 @@ const APP: () = {
             hal::spi::Spi<hal::stm32::SPI2, hal::spi::Disabled, u8>,
             hal::dma::MemoryToPeripheral,
             &'static mut [u8; BUFFER_SIZE],
+            hal::dma::DBTransfer,
         >,
         cs: hal::gpio::gpiob::PB12<hal::gpio::Output<hal::gpio::PushPull>>,
     }
@@ -123,6 +124,7 @@ const APP: () = {
             _,
             _,
             hal::dma::MemoryToPeripheral,
+            _,
             _,
         > = hal::dma::Transfer::init(streams.1, spi, buffer, None, config);
 

--- a/examples/spi-dma-rtic.rs
+++ b/examples/spi-dma-rtic.rs
@@ -3,6 +3,7 @@
 //!
 //! This example demonstrates using DMA to write data over a TX-only SPI interface.
 #![deny(warnings)]
+#![allow(clippy::type_complexity)]
 #![no_main]
 #![no_std]
 

--- a/examples/spi-dma.rs
+++ b/examples/spi-dma.rs
@@ -115,7 +115,7 @@ fn main() -> ! {
 
     let config = DmaConfig::default().memory_increment(true);
 
-    let mut transfer: Transfer<_, _, MemoryToPeripheral, _> =
+    let mut transfer: Transfer<_, _, MemoryToPeripheral, _, _> =
         Transfer::init(streams.0, spi, &mut short_buffer[..], None, config);
 
     transfer.start(|spi| {

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -24,7 +24,7 @@ use core::{
     ptr,
     sync::atomic::{fence, Ordering},
 };
-use embedded_dma::StaticWriteBuffer;
+use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
 
 #[macro_use]
 mod macros;
@@ -264,330 +264,369 @@ pub mod config {
     }
 }
 
+/// Marker type for a transfer with a mutable source and backed by a
+/// `DoubleBufferedStream`
+pub struct DBTransfer;
+/// Marker type for a transfer with a constant source and backed by a
+/// `DoubleBufferedStream`
+pub struct ConstDBTransfer;
+/// Marker type for a transfer with a mutable source and backed by a
+/// `MasterStream`
+pub struct MasterTransfer;
+/// Marker type for a transfer with a constant source and backed by a
+/// `MasterStream`
+pub struct ConstMasterTransfer;
+
 /// DMA Transfer.
-pub struct Transfer<STREAM, PERIPHERAL, DIR, BUF>
+pub struct Transfer<STREAM, PERIPHERAL, DIR, BUF, TXFRT>
 where
     STREAM: Stream,
     PERIPHERAL: TargetAddress<DIR>,
     DIR: Direction,
-    BUF: StaticWriteBuffer<Word = <PERIPHERAL as TargetAddress<DIR>>::MemSize>,
 {
     stream: STREAM,
     peripheral: PERIPHERAL,
     _direction: PhantomData<DIR>,
+    _transfer_type: PhantomData<TXFRT>,
     buf: [Option<BUF>; 2],
     // Used when double buffering
     transfer_length: u16,
 }
 
-impl<STREAM, CONFIG, PERIPHERAL, DIR, BUF>
-    Transfer<STREAM, PERIPHERAL, DIR, BUF>
-where
-    STREAM: DoubleBufferedStream + Stream<Config = CONFIG>,
-    CONFIG: DoubleBufferedConfig,
-    DIR: Direction,
-    PERIPHERAL: TargetAddress<DIR>,
-    BUF: StaticWriteBuffer<Word = <PERIPHERAL as TargetAddress<DIR>>::MemSize>,
-{
-    /// Applies all fields in DmaConfig.
-    fn apply_config(&mut self, config: CONFIG) {
-        let msize =
-            mem::size_of::<<PERIPHERAL as TargetAddress<DIR>>::MemSize>() / 2;
+macro_rules! db_transfer_def {
+    ($Marker:ty, $init:ident, $Buffer:tt, $rw_buffer:ident $(, $mut:tt)*;
+     $($constraint:stmt)*) => {
+        impl<STREAM, CONFIG, PERIPHERAL, DIR, BUF>
+            Transfer<STREAM, PERIPHERAL, DIR, BUF, $Marker>
+        where
+            STREAM: DoubleBufferedStream + Stream<Config = CONFIG>,
+            CONFIG: DoubleBufferedConfig,
+            DIR: Direction,
+            PERIPHERAL: TargetAddress<DIR>,
+            BUF: $Buffer<Word = <PERIPHERAL as TargetAddress<DIR>>::MemSize>,
+        {
+            /// Applies all fields in DmaConfig.
+            fn apply_config(&mut self, config: CONFIG) {
+                let msize = mem::size_of::<
+                    <PERIPHERAL as TargetAddress<DIR>>::MemSize,
+                >() / 2;
 
-        self.stream.clear_interrupts();
+                self.stream.clear_interrupts();
 
-        // NOTE(unsafe) These values are correct because of the invariants of TargetAddress
-        unsafe {
-            self.stream.set_memory_size(msize as u8);
-            self.stream.set_peripheral_size(msize as u8);
-        }
+                // NOTE(unsafe) These values are correct because of the
+                // invariants of TargetAddress
+                unsafe {
+                    self.stream.set_memory_size(msize as u8);
+                    self.stream.set_peripheral_size(msize as u8);
+                }
 
-        self.stream.apply_config(config);
-    }
-
-    /// Configures the DMA source and destination and applies supplied
-    /// configuration. In a memory to memory transfer, the `double_buf` argument
-    /// is the source of the data. If double buffering is enabled, the number of
-    /// transfers will be the minimum length of `memory` and `double_buf`.
-    ///
-    /// # Panics
-    ///
-    /// * When the FIFO is disabled or double buffering is enabled in
-    ///   `DmaConfig` while initializing a memory to memory transfer.
-    /// * When double buffering is enabled but the `double_buf` argument is
-    ///   `None`.
-    /// * When the transfer length is greater than (2^16 - 1)
-    pub fn init(
-        mut stream: STREAM,
-        peripheral: PERIPHERAL,
-        mut memory: BUF,
-        mut double_buf: Option<BUF>,
-        config: CONFIG,
-    ) -> Self {
-        stream.disable();
-
-        // Set peripheral to memory mode
-        stream.set_direction(DIR::direction());
-
-        // Enable bufferable transfers
-        #[cfg(not(feature = "rm0455"))]
-        if PERIPHERAL::TRBUFF {
-            stream.set_trbuff(true);
-        }
-
-        // NOTE(unsafe) We now own this buffer and we won't call any &mut
-        // methods on it until the end of the DMA transfer
-        let (buf_ptr, buf_len) = unsafe { memory.write_buffer() };
-
-        // Set the memory address
-        //
-        // # Safety
-        //
-        // Must be a valid memory address
-        unsafe {
-            stream.set_memory_address(CurrentBuffer::Buffer0, buf_ptr as usize);
-        }
-
-        let is_mem2mem = DIR::direction() == DmaDirection::MemoryToMemory;
-        if is_mem2mem {
-            // Fifo must be enabled for memory to memory
-            if !config.is_fifo_enabled() {
-                panic!("Fifo disabled.");
-            } else if config.is_double_buffered() {
-                panic!("Double buffering enabled.");
+                self.stream.apply_config(config);
             }
-        } else {
-            // Set the peripheral address
-            //
-            // # Safety
-            //
-            // Must be a valid peripheral address
-            unsafe {
-                stream.set_peripheral_address(peripheral.address());
-            }
-        }
 
-        let db_len = if let Some(ref mut db) = double_buf {
-            // NOTE(unsafe) We now own this buffer and we won't call any &mut
-            // methods on it until the end of the DMA transfer
+            /// Configures the DMA source and destination and applies supplied
+            /// configuration. In a memory to memory transfer, the `double_buf` argument
+            /// is the source of the data. If double buffering is enabled, the number of
+            /// transfers will be the minimum length of `memory` and `double_buf`.
+            ///
+            /// # Panics
+            ///
+            /// * When the FIFO is disabled or double buffering is enabled in
+            ///   `DmaConfig` while initializing a memory to memory transfer.
+            /// * When double buffering is enabled but the `double_buf` argument is
+            ///   `None`.
+            /// * When the transfer length is greater than (2^16 - 1)
+            pub fn $init(
+                mut stream: STREAM,
+                peripheral: PERIPHERAL,
+                $($mut)* memory: BUF,
+                mut double_buf: Option<BUF>,
+                config: CONFIG,
+            ) -> Self {
+                stream.disable();
 
-            let (db_ptr, db_len) = unsafe { db.write_buffer() };
-            unsafe {
-                if is_mem2mem {
-                    // Double buffer is the source in mem2mem mode
-                    stream.set_peripheral_address(db_ptr as usize);
-                } else {
+                // Used in the case that we can constant `memory`
+                $($constraint)*
+
+                // Set peripheral to memory mode
+                stream.set_direction(DIR::direction());
+
+                // Enable bufferable transfers
+                #[cfg(not(feature = "rm0455"))]
+                if PERIPHERAL::TRBUFF {
+                    stream.set_trbuff(true);
+                }
+
+                // NOTE(unsafe) We now own this buffer and we won't call any &mut
+                // methods on it until the end of the DMA transfer
+                let (buf_ptr, buf_len) = unsafe { memory.$rw_buffer() };
+
+                // Set the memory address
+                //
+                // # Safety
+                //
+                // Must be a valid memory address
+                unsafe {
                     stream.set_memory_address(
-                        CurrentBuffer::Buffer1,
-                        db_ptr as usize,
+                        CurrentBuffer::Buffer0,
+                        buf_ptr as usize,
                     );
                 }
-            }
-            Some(db_len)
-        } else {
-            if config.is_double_buffered() {
-                // Error if we expected a double buffer but none was specified
-                panic!("No second buffer.");
-            }
-            None
-        };
 
-        let n_transfers = if let Some(db) = db_len {
-            buf_len.min(db)
-        } else {
-            buf_len
-        };
-        assert!(
-            n_transfers <= 65535,
-            "Hardware does not support more than 65535 transfers"
-        );
-        let n_transfers = n_transfers as u16;
-        stream.set_number_of_transfers(n_transfers);
-
-        // Set the DMAMUX request line if needed
-        if let Some(request_line) = PERIPHERAL::REQUEST_LINE {
-            stream.set_request_line(request_line);
-        }
-
-        let mut transfer = Self {
-            stream,
-            peripheral,
-            _direction: PhantomData,
-            buf: [Some(memory), double_buf],
-            transfer_length: n_transfers,
-        };
-        transfer.apply_config(config);
-
-        transfer
-    }
-
-    /// Changes the buffer and restarts or continues a transfer.
-    /// The closure is called with the old completed buffer as arguments and
-    /// must return `(BUF, T)` where `BUF` is the new buffer
-    /// to be used.
-    ///
-    /// In normal mode (not double buffer mode):
-    /// * This method restarts the transfer.
-    /// * This method can be called before the end of an ongoing transfer.
-    ///   In that case, the current transfer will be canceled and a new one
-    ///   will be started.
-    ///
-    /// In double buffer mode:
-    /// * This method continues a running transfer and exchanges the inactive
-    ///   buffer with the closure.
-    /// * This must be called immediately after a transfer complete
-    ///   event to ensure no repeated transfers into/out of the same buffer.
-    /// * A `NotReady` error will be returned if this method is called
-    ///   before a transfer is completed and the closure won't be executed.
-    /// * A `SmallBuffer` error will be returned if the size of the buffer
-    ///   returned by the closure does not match the current transfer size.
-    /// * The DMA may overrun and access the poison address causing a bus error
-    ///   and disabling of the stream if any of following conditions happen:
-    ///   * `SmallBuffer` error
-    ///   * The closure `f` takes too long to return
-    /// * If the buffer address poisoning itself fails because the DMA has overrun,
-    ///   the closure will still be called and the buffer address is updated but
-    ///   the DMA stream will error (TEIF) and disable itself.
-    ///
-    /// A `remaining` parameter is also passed to the closure. This indicates
-    /// the number of transfers not completed in the previous DMA transfer.
-    pub fn next_transfer_with<F, T>(&mut self, func: F) -> Result<T, DMAError>
-    where
-        F: FnOnce(BUF, CurrentBuffer, usize) -> (BUF, T),
-    {
-        let (single_buffer, inactive) = match STREAM::get_inactive_buffer() {
-            None => {
-                // Single buffer mode
-                self.stream.disable();
-                (true, CurrentBuffer::Buffer0)
-            }
-            Some(inactive) => {
-                // Double buffer mode
-                if !STREAM::get_transfer_complete_flag() {
-                    // DMA has not released a buffer
-                    return Err(DMAError::NotReady);
+                let is_mem2mem =
+                    DIR::direction() == DmaDirection::MemoryToMemory;
+                if is_mem2mem {
+                    // Fifo must be enabled for memory to memory
+                    if !config.is_fifo_enabled() {
+                        panic!("Fifo disabled.");
+                    } else if config.is_double_buffered() {
+                        panic!("Double buffering enabled.");
+                    }
+                } else {
+                    // Set the peripheral address
+                    //
+                    // # Safety
+                    //
+                    // Must be a valid peripheral address
+                    unsafe {
+                        stream.set_peripheral_address(peripheral.address());
+                    }
                 }
-                // Poison the peripheral's inactive memory address to get a memory
-                // error instead of potentially silent corruption.
-                // If DMA wins the race (overrun) to the inactive buffer
-                // between reading the CT bit and poisoning the inactive address, this
-                // write will fail and lead to a transfer error (TEIF) and disable
-                // the stream.
-                // If DMA wins the race by the time we write the new valid address
-                // (below), it gets a bus error and errors/stops.
+
+                let db_len = if let Some(ref mut db) = double_buf {
+                    // NOTE(unsafe) We now own this buffer and we won't call any &mut
+                    // methods on it until the end of the DMA transfer
+
+                    let (db_ptr, db_len) = unsafe { db.$rw_buffer() };
+                    unsafe {
+                        if is_mem2mem {
+                            // Double buffer is the source in mem2mem mode
+                            stream.set_peripheral_address(db_ptr as usize);
+                        } else {
+                            stream.set_memory_address(
+                                CurrentBuffer::Buffer1,
+                                db_ptr as usize,
+                            );
+                        }
+                    }
+                    Some(db_len)
+                } else {
+                    if config.is_double_buffered() {
+                        // Error if we expected a double buffer but none was specified
+                        panic!("No second buffer.");
+                    }
+                    None
+                };
+
+                let n_transfers = if let Some(db) = db_len {
+                    buf_len.min(db)
+                } else {
+                    buf_len
+                };
+                assert!(
+                    n_transfers <= 65535,
+                    "Hardware does not support more than 65535 transfers"
+                );
+                let n_transfers = n_transfers as u16;
+                stream.set_number_of_transfers(n_transfers);
+
+                // Set the DMAMUX request line if needed
+                if let Some(request_line) = PERIPHERAL::REQUEST_LINE {
+                    stream.set_request_line(request_line);
+                }
+
+                let mut transfer = Self {
+                    stream,
+                    peripheral,
+                    _direction: PhantomData,
+                    _transfer_type: PhantomData,
+                    buf: [Some(memory), double_buf],
+                    transfer_length: n_transfers,
+                };
+                transfer.apply_config(config);
+
+                transfer
+            }
+
+            /// Changes the buffer and restarts or continues a transfer.
+            /// The closure is called with the old completed buffer as arguments and
+            /// must return `(BUF, T)` where `BUF` is the new buffer
+            /// to be used.
+            ///
+            /// In normal mode (not double buffer mode):
+            /// * This method restarts the transfer.
+            /// * This method can be called before the end of an ongoing transfer.
+            ///   In that case, the current transfer will be canceled and a new one
+            ///   will be started.
+            ///
+            /// In double buffer mode:
+            /// * This method continues a running transfer and exchanges the inactive
+            ///   buffer with the closure.
+            /// * This must be called immediately after a transfer complete
+            ///   event to ensure no repeated transfers into/out of the same buffer.
+            /// * A `NotReady` error will be returned if this method is called
+            ///   before a transfer is completed and the closure won't be executed.
+            /// * A `SmallBuffer` error will be returned if the size of the buffer
+            ///   returned by the closure does not match the current transfer size.
+            /// * The DMA may overrun and access the poison address causing a bus error
+            ///   and disabling of the stream if any of following conditions happen:
+            ///   * `SmallBuffer` error
+            ///   * The closure `f` takes too long to return
+            /// * If the buffer address poisoning itself fails because the DMA has overrun,
+            ///   the closure will still be called and the buffer address is updated but
+            ///   the DMA stream will error (TEIF) and disable itself.
+            ///
+            /// A `remaining` parameter is also passed to the closure. This indicates
+            /// the number of transfers not completed in the previous DMA transfer.
+            pub fn next_transfer_with<F, T>(
+                &mut self,
+                func: F,
+            ) -> Result<T, DMAError>
+            where
+                F: FnOnce(BUF, CurrentBuffer, usize) -> (BUF, T),
+            {
+                let (single_buffer, inactive) =
+                    match STREAM::get_inactive_buffer() {
+                        None => {
+                            // Single buffer mode
+                            self.stream.disable();
+                            (true, CurrentBuffer::Buffer0)
+                        }
+                        Some(inactive) => {
+                            // Double buffer mode
+                            if !STREAM::get_transfer_complete_flag() {
+                                // DMA has not released a buffer
+                                return Err(DMAError::NotReady);
+                            }
+                            // Poison the peripheral's inactive memory address to get a memory
+                            // error instead of potentially silent corruption.
+                            // If DMA wins the race (overrun) to the inactive buffer
+                            // between reading the CT bit and poisoning the inactive address, this
+                            // write will fail and lead to a transfer error (TEIF) and disable
+                            // the stream.
+                            // If DMA wins the race by the time we write the new valid address
+                            // (below), it gets a bus error and errors/stops.
+                            unsafe {
+                                self.stream.set_memory_address(
+                                    inactive,
+                                    0xffff_ffffusize,
+                                );
+                            }
+                            (false, inactive)
+                        }
+                    };
+
+                // Protect the instruction sequence of preceding DMA disable/inactivity
+                // verification/poisoning and subsequent (old completed) buffer content
+                // access.
+                // Cortex-M7: Also protect the corresponding data access sequence.
+                // NOTE: The data cache also needs to be flushed (if enabled).
+                fence(Ordering::SeqCst);
+
+                // Check how many data in the transfer are remaining.
+                let remaining_data = STREAM::get_number_of_transfers();
+
+                // This buffer is inactive now and can be accessed.
+                // NOTE(panic): We always hold ownership in lieu of the DMA peripheral.
+                let buf = self.buf[inactive as usize].take().unwrap();
+
+                let ($($mut)* buf, result) =
+                    func(buf, inactive, remaining_data as usize);
+
+                // NOTE(unsafe) We now own this buffer and we won't access it
+                // until the end of the DMA transfer.
+                let (buf_ptr, buf_len) = unsafe { buf.$rw_buffer() };
+
+                // Keep ownership of the active buffer in lieu of the DMA peripheral.
+                self.buf[inactive as usize].replace(buf);
+
+                // Protect the instruction sequence of preceding (new) buffer content access
+                // and subsequent DMA enable/address update. See the matching fence() above.
+                fence(Ordering::SeqCst);
+
+                if single_buffer {
+                    // Set length before the writing the new valid address.
+                    self.stream.set_number_of_transfers(buf_len as u16);
+                } else if buf_len != usize::from(self.transfer_length) {
+                    // We can't change the transfer length while double buffering
+                    return Err(DMAError::SmallBuffer);
+                }
+
+                // NOTE(double buffer mode):
+                // Up to here, if the DMA starts accessing the poisoned inactive buffer (overrun)
+                // this will lead to a bus error and disable DMA.
+                // This write can not fail since the DMA is not accessing the corresponding buffer
+                // yet or has hit the poison address and errored disabling itself.
                 unsafe {
-                    self.stream.set_memory_address(inactive, 0xffff_ffffusize);
+                    self.stream.set_memory_address(inactive, buf_ptr as usize);
                 }
-                (false, inactive)
+
+                // Acknowledge the TCIF.
+                self.stream.clear_transfer_complete_interrupt();
+
+                if single_buffer {
+                    unsafe {
+                        self.stream.enable();
+                    }
+                }
+
+                Ok(result)
             }
-        };
 
-        // Protect the instruction sequence of preceding DMA disable/inactivity
-        // verification/poisoning and subsequent (old completed) buffer content
-        // access.
-        // Cortex-M7: Also protect the corresponding data access sequence.
-        // NOTE: The data cache also needs to be flushed (if enabled).
-        fence(Ordering::SeqCst);
+            /// Changes the buffer and restarts or continues a double buffer
+            /// transfer. This must be called immediately after a transfer complete
+            /// event. Returns the old buffer together with its `CurrentBuffer`. If an
+            /// error occurs, this method will return the old or new buffer with the error.
+            ///
+            /// This method will clear the transfer complete flag. Moreover, if
+            /// an overrun occurs, the stream will be disabled and the transfer error
+            /// flag will be set. This method can be called before the end of an ongoing
+            /// transfer only if not using double buffering, in that case, the current
+            /// transfer will be canceled and a new one will be started. A `NotReady`
+            /// error together with the new buffer will be returned if this method is called
+            /// before the end of a transfer while double buffering. A `SmallBuffer` error
+            /// together with the old buffer will be returned if the new buffer size does not
+            /// match the ongoing transfer size.
+            pub fn next_transfer(
+                &mut self,
+                new_buf: BUF,
+            ) -> Result<(BUF, CurrentBuffer, usize), DMAError> {
+                let mut buf = new_buf;
+                let mut last_remaining = 0usize;
 
-        // Check how many data in the transfer are remaining.
-        let remaining_data = STREAM::get_number_of_transfers();
+                let current =
+                    self.next_transfer_with(|mut old, current, remaining| {
+                        core::mem::swap(&mut old, &mut buf);
+                        last_remaining = remaining;
+                        (old, current)
+                    })?;
+                // TODO: return buf on Err
+                Ok((buf, current, last_remaining))
+            }
 
-        // This buffer is inactive now and can be accessed.
-        // NOTE(panic): We always hold ownership in lieu of the DMA peripheral.
-        let buf = self.buf[inactive as usize].take().unwrap();
+            /// Clear half transfer interrupt (htif) for the DMA stream.
+            #[inline(always)]
+            pub fn clear_half_transfer_interrupt(&mut self) {
+                self.stream.clear_half_transfer_interrupt();
+            }
 
-        let (mut buf, result) = func(buf, inactive, remaining_data as usize);
-
-        // NOTE(unsafe) We now own this buffer and we won't access it
-        // until the end of the DMA transfer.
-        let (buf_ptr, buf_len) = unsafe { buf.write_buffer() };
-
-        // Keep ownership of the active buffer in lieu of the DMA peripheral.
-        self.buf[inactive as usize].replace(buf);
-
-        // Protect the instruction sequence of preceding (new) buffer content access
-        // and subsequent DMA enable/address update. See the matching fence() above.
-        fence(Ordering::SeqCst);
-
-        if single_buffer {
-            // Set length before the writing the new valid address.
-            self.stream.set_number_of_transfers(buf_len as u16);
-        } else if buf_len != usize::from(self.transfer_length) {
-            // We can't change the transfer length while double buffering
-            return Err(DMAError::SmallBuffer);
-        }
-
-        // NOTE(double buffer mode):
-        // Up to here, if the DMA starts accessing the poisoned inactive buffer (overrun)
-        // this will lead to a bus error and disable DMA.
-        // This write can not fail since the DMA is not accessing the corresponding buffer
-        // yet or has hit the poison address and errored disabling itself.
-        unsafe {
-            self.stream.set_memory_address(inactive, buf_ptr as usize);
-        }
-
-        // Acknowledge the TCIF.
-        self.stream.clear_transfer_complete_interrupt();
-
-        if single_buffer {
-            unsafe {
-                self.stream.enable();
+            #[inline(always)]
+            pub fn get_half_transfer_flag(&self) -> bool {
+                STREAM::get_half_transfer_flag()
             }
         }
-
-        Ok(result)
-    }
-
-    /// Changes the buffer and restarts or continues a double buffer
-    /// transfer. This must be called immediately after a transfer complete
-    /// event. Returns the old buffer together with its `CurrentBuffer`. If an
-    /// error occurs, this method will return the old or new buffer with the error.
-    ///
-    /// This method will clear the transfer complete flag. Moreover, if
-    /// an overrun occurs, the stream will be disabled and the transfer error
-    /// flag will be set. This method can be called before the end of an ongoing
-    /// transfer only if not using double buffering, in that case, the current
-    /// transfer will be canceled and a new one will be started. A `NotReady`
-    /// error together with the new buffer will be returned if this method is called
-    /// before the end of a transfer while double buffering. A `SmallBuffer` error
-    /// together with the old buffer will be returned if the new buffer size does not
-    /// match the ongoing transfer size.
-    pub fn next_transfer(
-        &mut self,
-        new_buf: BUF,
-    ) -> Result<(BUF, CurrentBuffer, usize), DMAError> {
-        let mut buf = new_buf;
-        let mut last_remaining = 0usize;
-
-        let current =
-            self.next_transfer_with(|mut old, current, remaining| {
-                core::mem::swap(&mut old, &mut buf);
-                last_remaining = remaining;
-                (old, current)
-            })?;
-        // TODO: return buf on Err
-        Ok((buf, current, last_remaining))
-    }
-
-    /// Clear half transfer interrupt (htif) for the DMA stream.
-    #[inline(always)]
-    pub fn clear_half_transfer_interrupt(&mut self) {
-        self.stream.clear_half_transfer_interrupt();
-    }
-
-    #[inline(always)]
-    pub fn get_half_transfer_flag(&self) -> bool {
-        STREAM::get_half_transfer_flag()
-    }
+    };
 }
 
-impl<STREAM, CONFIG, PERIPHERAL, DIR, BUF>
-    Transfer<STREAM, PERIPHERAL, DIR, BUF>
+db_transfer_def!(DBTransfer, init, StaticWriteBuffer, write_buffer, mut;);
+db_transfer_def!(ConstDBTransfer, init_const, StaticReadBuffer, read_buffer;
+                 assert!(DIR::direction() != DmaDirection::PeripheralToMemory));
+
+impl<STREAM, CONFIG, PERIPHERAL, DIR, BUF, TXFRT>
+    Transfer<STREAM, PERIPHERAL, DIR, BUF, TXFRT>
 where
     STREAM: Stream<Config = CONFIG>,
     DIR: Direction,
     PERIPHERAL: TargetAddress<DIR>,
-    BUF: StaticWriteBuffer<Word = <PERIPHERAL as TargetAddress<DIR>>::MemSize>,
 {
     /// Starts the transfer, the closure will be executed right after enabling
     /// the stream.
@@ -670,13 +709,12 @@ where
     }
 }
 
-impl<STREAM, PERIPHERAL, DIR, BUF> Drop
-    for Transfer<STREAM, PERIPHERAL, DIR, BUF>
+impl<STREAM, PERIPHERAL, DIR, BUF, TXFRT> Drop
+    for Transfer<STREAM, PERIPHERAL, DIR, BUF, TXFRT>
 where
     STREAM: Stream,
     PERIPHERAL: TargetAddress<DIR>,
     DIR: Direction,
-    BUF: StaticWriteBuffer<Word = <PERIPHERAL as TargetAddress<DIR>>::MemSize>,
 {
     fn drop(&mut self) {
         self.stream.disable();


### PR DESCRIPTION
The lack of support for constant source buffers was first raised by @ryan-summers here https://github.com/stm32-rs/stm32h7xx-hal/pull/153#discussion_r515865869

This solution adds a 5th generic type parameter to `Transfer`, and uses this to implement `Transfer` for two different type constraints on `BUF`.

The additional generic type parameter will also be useful for MDMA support, which will also need its own versions of `init`, `next_transfer`, `next_transfer_with` and so on.

The downside is the additional complexity of another type parameter.