### PR TITLE
Use CamelCase for gpio::Edge enum variants

### DIFF
--- a/examples/exti_interrupt.rs
+++ b/examples/exti_interrupt.rs
@@ -56,13 +56,13 @@ fn main() -> ! {
     let gpioe = dp.GPIOE.split(ccdr.peripheral.GPIOE);
     let mut button1 = gpioe.pe3.into_pull_up_input();
     button1.make_interrupt_source(&mut syscfg);
-    button1.trigger_on_edge(&mut exti, Edge::RISING);
+    button1.trigger_on_edge(&mut exti, Edge::Rising);
     button1.enable_interrupt(&mut exti);
 
     let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
     let mut button2 = gpioc.pc5.into_pull_up_input();
     button2.make_interrupt_source(&mut syscfg);
-    button2.trigger_on_edge(&mut exti, Edge::RISING);
+    button2.trigger_on_edge(&mut exti, Edge::Rising);
     button2.enable_interrupt(&mut exti);
 
     let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);

--- a/examples/rtic.rs
+++ b/examples/rtic.rs
@@ -42,7 +42,7 @@ const APP: () = {
         // Button
         let mut button = gpioc.pc13.into_floating_input();
         button.make_interrupt_source(&mut ctx.device.SYSCFG);
-        button.trigger_on_edge(&mut ctx.device.EXTI, Edge::RISING);
+        button.trigger_on_edge(&mut ctx.device.EXTI, Edge::Rising);
         button.enable_interrupt(&mut ctx.device.EXTI);
 
         init::LateResources {

--- a/examples/rtic_low_power.rs
+++ b/examples/rtic_low_power.rs
@@ -102,7 +102,7 @@ const APP: () = {
         let mut exti = ctx.device.EXTI;
         let mut wakeup = gpioc.pc13.into_floating_input();
         wakeup.make_interrupt_source(&mut syscfg);
-        wakeup.trigger_on_edge(&mut exti, Edge::RISING);
+        wakeup.trigger_on_edge(&mut exti, Edge::Rising);
         wakeup.enable_interrupt(&mut exti);
 
         // LEDs

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -89,9 +89,9 @@ pub enum Speed {
 /// GPIO Edge selection
 #[derive(Copy, Clone, PartialEq)]
 pub enum Edge {
-    RISING,
-    FALLING,
-    RISING_FALLING,
+    Rising,
+    Falling,
+    RisingFalling,
 }
 
 /// Alternate function 0 (type state)
@@ -299,15 +299,15 @@ macro_rules! gpio {
                 /// Generate interrupt on rising edge, falling edge or both
                 fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: Edge) {
                     match edge {
-                        Edge::RISING => {
+                        Edge::Rising => {
                             exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                         },
-                        Edge::FALLING => {
+                        Edge::Falling => {
                             exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                         },
-                        Edge::RISING_FALLING => {
+                        Edge::RisingFalling => {
                             exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                         }
@@ -746,15 +746,15 @@ macro_rules! gpio {
                     /// Generate interrupt on rising edge, falling edge or both
                     fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: Edge) {
                         match edge {
-                            Edge::RISING => {
+                            Edge::Rising => {
                                 exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                             },
-                            Edge::FALLING => {
+                            Edge::Falling => {
                                 exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                             },
-                            Edge::RISING_FALLING => {
+                            Edge::RisingFalling => {
                                 exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                             }


### PR DESCRIPTION
ref: [l4xx](https://github.com/stm32-rs/stm32l4xx-hal/pull/187), [f1xx](https://github.com/stm32-rs/stm32f1xx-hal/pull/303), [f4xx](https://github.com/stm32-rs/stm32f4xx-hal/pull/250), [f7xx](https://github.com/stm32-rs/stm32f7xx-hal/pull/111)
