### PR TITLE
Updating smoltcp on DMA branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [0.8.0] 2020-10-26
+## [v0.8.0] 2020-10-26
 
 * **Breaking**: Ethernet PHY configuration feature flags removed. The user must
   now instantiate an instance of the PHY type in order to configure the PHY.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,24 @@
 
 ## [Unreleased]
 
-* **Breaking**: Ethernet PHY configuration feature flags removed. The user must now instantiate an instance of the PHY type in order to configure the PHY.
+## [0.8.0] 2020-10-26
+
+* **Breaking**: Ethernet PHY configuration feature flags removed. The user must
+  now instantiate an instance of the PHY type in order to configure the PHY.
 * pac: Upgrade to stm32-rs v0.12.0
+* devices: Add support for 7B3, 7B0, 7A3
+* Add USB support
+* Add I2S support
+* Add RTC support
+* Add LPTIM support
+* Add DMA support, but the current API is depreciated and will be replaced
 * timer: add tick_timer and set_tick_freq to configure the timer's counter frequency [#144](https://github.com/stm32-rs/stm32h7xx-hal/pull/144)
 * Add RTC support [#143](https://github.com/stm32-rs/stm32h7xx-hal/pull/143)
 * pwr: add PowerConfiguration to ensure VoltageScale isn't modified from pwr.freeze() to rcc.freeze() [#141](https://github.com/stm32-rs/stm32h7xx-hal/pull/141)
 * impl Copy, Clone, PartialEq for enums [#139](https://github.com/stm32-rs/stm32h7xx-hal/pull/139)
 * ethernet: automatically configure MDC clock based on hclk
+* time: add types for microseconds and nanoseconds
+* rec: add `low_power` methods for configuring peripherals
 
 ## [v0.7.1] 2020-09-04
 
@@ -88,7 +99,8 @@
 * Upgrade to stm32-rs v0.9.0 (including svd2rust v0.16)
 * Started Changelog
 
-[Unreleased]: https://github.com/stm32-rs/stm32h7xx-hal/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/stm32-rs/stm32h7xx-hal/compare/v0.8.0...HEAD
+[v0.8.0]: https://github.com/stm32-rs/stm32h7xx-hal/compare/v0.7.1...v0.8.0
 [v0.7.1]: https://github.com/stm32-rs/stm32h7xx-hal/compare/v0.7.0...v0.7.1
 [v0.7.0]: https://github.com/stm32-rs/stm32h7xx-hal/compare/v0.6.0...v0.7.0
 [v0.6.0]: https://github.com/stm32-rs/stm32h7xx-hal/compare/v0.5.0...v0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stm32h7xx-hal"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Andrew Straw <strawman@astraw.com>",
            "Richard Meadows <richard@richard.fish>",
            "Henrik Böving <hargonix@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ target device feature must be specified in the `Cargo.toml` file:
 [dependencies]
 cortex-m = "0.6.2"
 cortex-m-rt = "0.6.12"
-stm32h7xx-hal = {version = "0.7.1", features = ["stm32h743v","rt"]}
+stm32h7xx-hal = {version = "0.8.0", features = ["stm32h743v","rt"]}
 ```
 
 If you are unfamiliar with embedded development using Rust, there are

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,49 @@
+## Releasing guide
+
+Create a new branch
+
+```
+git fetch upstream
+git checkout upstream/master
+git checkout -b v0.2.0
+```
+
+* Update version in README
+* Update version in Cargo.toml
+* Update CHANGELOG
+* Update index in top-level documentation (lib.rs)
+* Check that all feature flags mentioned there also appear under
+  `[package.metadata.docs.rs]` in Cargo.toml
+
+```
+git commit -am 'v0.2.0'
+```
+
+Push the new branch
+
+```
+git push --set-upstream upstream v0.2.0
+```
+
+Create a PR and check CI passes.
+
+Merge into master, you can do this from the command line:
+
+```
+git push --set-upstream upstream v0.2.0:master
+```
+
+Create and push a tag
+
+```
+git tag -a 'v0.2.0' -m 'v0.2.0'
+git push upstream refs/tags/v0.2.0
+```
+
+Checkout in a clean tree and publish
+
+```
+cd [clean tree]
+git pull upstream
+cargo publish --features stm32h743,rt
+```


### PR DESCRIPTION
This PR merges `master` back into `dma` so that we can get the smoltcp updates into `dma` as well.

As an aside, it seems to me like we should probably merge `dma` in to master - I'm fairly sure a lot of people are essentially treating `dma` _as_ `master` to get access to DMA transfers right now. Curious to hear thoughts here