### PR TITLE
Add new/new_unchecked methods for USB structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* **Breaking**: Add new/new_unchecked methods for USB structures, remove pin
+  types from structure
+* Add support for USB1_ULPI #184
 * Updates `cortex-m` to v0.7.1. `cortex-m` v0.6.5+ [are forward compatible with
   v0.7.0+][cm6-changelog] except for CBP, ITM, MPU, NVIC, SCB. If you have
   problems, run `cargo update` to try to switch to `cortex-m` v0.7 in other

--- a/examples/usb_passthrough.rs
+++ b/examples/usb_passthrough.rs
@@ -39,24 +39,25 @@ fn main() -> ! {
     let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
     let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
 
-    let usb1 = USB1 {
-        usb_global: dp.OTG1_HS_GLOBAL,
-        usb_device: dp.OTG1_HS_DEVICE,
-        usb_pwrclk: dp.OTG1_HS_PWRCLK,
-        pin_dm: gpiob.pb14.into_alternate_af12(),
-        pin_dp: gpiob.pb15.into_alternate_af12(),
-        prec: ccdr.peripheral.USB1OTG,
-        hclk: ccdr.clocks.hclk(),
-    };
-    let usb2 = USB2 {
-        usb_global: dp.OTG2_HS_GLOBAL,
-        usb_device: dp.OTG2_HS_DEVICE,
-        usb_pwrclk: dp.OTG2_HS_PWRCLK,
-        pin_dm: gpioa.pa11.into_alternate_af10(),
-        pin_dp: gpioa.pa12.into_alternate_af10(),
-        prec: ccdr.peripheral.USB2OTG,
-        hclk: ccdr.clocks.hclk(),
-    };
+    let usb1 = USB1::new(
+        dp.OTG1_HS_GLOBAL,
+        dp.OTG1_HS_DEVICE,
+        dp.OTG1_HS_PWRCLK,
+        gpiob.pb14.into_alternate_af12(),
+        gpiob.pb15.into_alternate_af12(),
+        ccdr.peripheral.USB1OTG,
+        ccdr.clocks.hclk(),
+    );
+
+    let usb2 = USB2::new(
+        dp.OTG2_HS_GLOBAL,
+        dp.OTG2_HS_DEVICE,
+        dp.OTG2_HS_PWRCLK,
+        gpioa.pa11.into_alternate_af10(),
+        gpioa.pa12.into_alternate_af10(),
+        ccdr.peripheral.USB2OTG,
+        ccdr.clocks.hclk(),
+    );
 
     // Port 1
     let usb1_bus = UsbBus::new(usb1, unsafe { &mut EP_MEMORY_1 });

--- a/examples/usb_passthrough.rs
+++ b/examples/usb_passthrough.rs
@@ -46,7 +46,7 @@ fn main() -> ! {
         gpiob.pb14.into_alternate_af12(),
         gpiob.pb15.into_alternate_af12(),
         ccdr.peripheral.USB1OTG,
-        ccdr.clocks.hclk(),
+        &ccdr.clocks,
     );
 
     let usb2 = USB2::new(
@@ -56,7 +56,7 @@ fn main() -> ! {
         gpioa.pa11.into_alternate_af10(),
         gpioa.pa12.into_alternate_af10(),
         ccdr.peripheral.USB2OTG,
-        ccdr.clocks.hclk(),
+        &ccdr.clocks,
     );
 
     // Port 1

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -53,15 +53,15 @@ fn main() -> ! {
         )
     };
 
-    let usb = USB1 {
-        usb_global: dp.OTG1_HS_GLOBAL,
-        usb_device: dp.OTG1_HS_DEVICE,
-        usb_pwrclk: dp.OTG1_HS_PWRCLK,
+    let usb = USB1::new(
+        dp.OTG1_HS_GLOBAL,
+        dp.OTG1_HS_DEVICE,
+        dp.OTG1_HS_PWRCLK,
         pin_dm,
         pin_dp,
-        prec: ccdr.peripheral.USB1OTG,
-        hclk: ccdr.clocks.hclk(),
-    };
+        ccdr.peripheral.USB1OTG,
+        ccdr.clocks.hclk(),
+    );
 
     let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });
 

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -60,7 +60,7 @@ fn main() -> ! {
         pin_dm,
         pin_dp,
         ccdr.peripheral.USB1OTG,
-        ccdr.clocks.hclk(),
+        &ccdr.clocks,
     );
 
     let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });

--- a/src/usb_hs.rs
+++ b/src/usb_hs.rs
@@ -25,15 +25,53 @@ use crate::time::Hertz;
 pub use synopsys_usb_otg::UsbBus;
 use synopsys_usb_otg::UsbPeripheral;
 
-#[cfg(not(feature = "rm0455"))]
 pub struct USB1 {
     pub usb_global: stm32::OTG1_HS_GLOBAL,
     pub usb_device: stm32::OTG1_HS_DEVICE,
     pub usb_pwrclk: stm32::OTG1_HS_PWRCLK,
-    pub pin_dm: PB14<Alternate<AF12>>,
-    pub pin_dp: PB15<Alternate<AF12>>,
     pub prec: rcc::rec::Usb1Otg,
     pub hclk: Hertz,
+}
+impl USB1 {
+    #[cfg(not(feature = "rm0455"))]
+    pub fn new(
+        usb_global: stm32::OTG1_HS_GLOBAL,
+        usb_device: stm32::OTG1_HS_DEVICE,
+        usb_pwrclk: stm32::OTG1_HS_PWRCLK,
+        _pin_dm: PB14<Alternate<AF12>>,
+        _pin_dp: PB15<Alternate<AF12>>,
+        prec: rcc::rec::Usb1Otg,
+        hclk: Hertz,
+    ) -> Self {
+        Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, hclk)
+    }
+    #[cfg(feature = "rm0455")]
+    pub fn new(
+        usb_global: stm32::OTG1_HS_GLOBAL,
+        usb_device: stm32::OTG1_HS_DEVICE,
+        usb_pwrclk: stm32::OTG1_HS_PWRCLK,
+        _pin_dm: PA11<Alternate<AF10>>,
+        _pin_dp: PA12<Alternate<AF10>>,
+        prec: rcc::rec::Usb1Otg,
+        hclk: Hertz,
+    ) -> Self {
+        Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, hclk)
+    }
+    pub fn new_unchecked(
+        usb_global: stm32::OTG1_HS_GLOBAL,
+        usb_device: stm32::OTG1_HS_DEVICE,
+        usb_pwrclk: stm32::OTG1_HS_PWRCLK,
+        prec: rcc::rec::Usb1Otg,
+        hclk: Hertz,
+    ) -> Self {
+        USB1 {
+            usb_global,
+            usb_device,
+            usb_pwrclk,
+            prec,
+            hclk,
+        }
+    }
 }
 
 #[cfg(not(feature = "rm0455"))]
@@ -41,21 +79,37 @@ pub struct USB2 {
     pub usb_global: stm32::OTG2_HS_GLOBAL,
     pub usb_device: stm32::OTG2_HS_DEVICE,
     pub usb_pwrclk: stm32::OTG2_HS_PWRCLK,
-    pub pin_dm: PA11<Alternate<AF10>>,
-    pub pin_dp: PA12<Alternate<AF10>>,
     pub prec: rcc::rec::Usb2Otg,
     pub hclk: Hertz,
 }
-
-#[cfg(feature = "rm0455")]
-pub struct USB1 {
-    pub usb_global: stm32::OTG1_HS_GLOBAL,
-    pub usb_device: stm32::OTG1_HS_DEVICE,
-    pub usb_pwrclk: stm32::OTG1_HS_PWRCLK,
-    pub pin_dm: PA11<Alternate<AF10>>,
-    pub pin_dp: PA12<Alternate<AF10>>,
-    pub prec: rcc::rec::Usb1Otg,
-    pub hclk: Hertz,
+#[cfg(not(feature = "rm0455"))]
+impl USB2 {
+    pub fn new(
+        usb_global: stm32::OTG2_HS_GLOBAL,
+        usb_device: stm32::OTG2_HS_DEVICE,
+        usb_pwrclk: stm32::OTG2_HS_PWRCLK,
+        _pin_dm: PA11<Alternate<AF10>>,
+        _pin_dp: PA12<Alternate<AF10>>,
+        prec: rcc::rec::Usb2Otg,
+        hclk: Hertz,
+    ) -> Self {
+        Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, hclk)
+    }
+    pub fn new_unchecked(
+        usb_global: stm32::OTG2_HS_GLOBAL,
+        usb_device: stm32::OTG2_HS_DEVICE,
+        usb_pwrclk: stm32::OTG2_HS_PWRCLK,
+        prec: rcc::rec::Usb2Otg,
+        hclk: Hertz,
+    ) -> Self {
+        USB2 {
+            usb_global,
+            usb_device,
+            usb_pwrclk,
+            prec,
+            hclk,
+        }
+    }
 }
 
 macro_rules! usb_peripheral {
@@ -115,18 +169,6 @@ pub struct USB1_ULPI {
     pub usb_pwrclk: stm32::OTG1_HS_PWRCLK,
     pub prec: rcc::rec::Usb1Otg,
     pub hclk: Hertz,
-    pub ulpi_clk: PA5<Alternate<AF10>>,
-    pub ulpi_dir: Usb1UlpiDirPin,
-    pub ulpi_nxt: Usb1UlpiNxtPin,
-    pub ulpi_stp: PC0<Alternate<AF10>>,
-    pub ulpi_d0: PA3<Alternate<AF10>>,
-    pub ulpi_d1: PB0<Alternate<AF10>>,
-    pub ulpi_d2: PB1<Alternate<AF10>>,
-    pub ulpi_d3: PB10<Alternate<AF10>>,
-    pub ulpi_d4: PB11<Alternate<AF10>>,
-    pub ulpi_d5: PB12<Alternate<AF10>>,
-    pub ulpi_d6: PB13<Alternate<AF10>>,
-    pub ulpi_d7: PB5<Alternate<AF10>>,
 }
 
 pub enum Usb1UlpiDirPin {
@@ -160,6 +202,45 @@ impl From<PH4<Alternate<AF10>>> for Usb1UlpiNxtPin {
 impl From<PC3<Alternate<AF10>>> for Usb1UlpiNxtPin {
     fn from(v: PC3<Alternate<AF10>>) -> Self {
         Usb1UlpiNxtPin::PC3(v)
+    }
+}
+
+impl USB1_ULPI {
+    pub fn new(
+        usb_global: stm32::OTG1_HS_GLOBAL,
+        usb_device: stm32::OTG1_HS_DEVICE,
+        usb_pwrclk: stm32::OTG1_HS_PWRCLK,
+        _ulpi_clk: PA5<Alternate<AF10>>,
+        _ulpi_dir: impl Into<Usb1UlpiDirPin>,
+        _ulpi_nxt: impl Into<Usb1UlpiNxtPin>,
+        _ulpi_stp: PC0<Alternate<AF10>>,
+        _ulpi_d0: PA3<Alternate<AF10>>,
+        _ulpi_d1: PB0<Alternate<AF10>>,
+        _ulpi_d2: PB1<Alternate<AF10>>,
+        _ulpi_d3: PB10<Alternate<AF10>>,
+        _ulpi_d4: PB11<Alternate<AF10>>,
+        _ulpi_d5: PB12<Alternate<AF10>>,
+        _ulpi_d6: PB13<Alternate<AF10>>,
+        _ulpi_d7: PB5<Alternate<AF10>>,
+        prec: rcc::rec::Usb1Otg,
+        hclk: Hertz,
+    ) -> Self {
+        Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, hclk)
+    }
+    pub fn new_unchecked(
+        usb_global: stm32::OTG1_HS_GLOBAL,
+        usb_device: stm32::OTG1_HS_DEVICE,
+        usb_pwrclk: stm32::OTG1_HS_PWRCLK,
+        prec: rcc::rec::Usb1Otg,
+        hclk: Hertz,
+    ) -> Self {
+        USB1_ULPI {
+            usb_global,
+            usb_device,
+            usb_pwrclk,
+            prec,
+            hclk,
+        }
     }
 }
 

--- a/src/usb_hs.rs
+++ b/src/usb_hs.rs
@@ -41,9 +41,9 @@ impl USB1 {
         _pin_dm: PB14<Alternate<AF12>>,
         _pin_dp: PB15<Alternate<AF12>>,
         prec: rcc::rec::Usb1Otg,
-        hclk: Hertz,
+        clocks: &rcc::CoreClocks,
     ) -> Self {
-        Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, hclk)
+        Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, clocks)
     }
     #[cfg(feature = "rm0455")]
     pub fn new(
@@ -53,23 +53,23 @@ impl USB1 {
         _pin_dm: PA11<Alternate<AF10>>,
         _pin_dp: PA12<Alternate<AF10>>,
         prec: rcc::rec::Usb1Otg,
-        hclk: Hertz,
+        clocks: &rcc::CoreClocks,
     ) -> Self {
-        Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, hclk)
+        Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, clocks)
     }
     pub fn new_unchecked(
         usb_global: stm32::OTG1_HS_GLOBAL,
         usb_device: stm32::OTG1_HS_DEVICE,
         usb_pwrclk: stm32::OTG1_HS_PWRCLK,
         prec: rcc::rec::Usb1Otg,
-        hclk: Hertz,
+        clocks: &rcc::CoreClocks,
     ) -> Self {
         USB1 {
             usb_global,
             usb_device,
             usb_pwrclk,
             prec,
-            hclk,
+            hclk: clocks.hclk(),
         }
     }
 }
@@ -91,23 +91,23 @@ impl USB2 {
         _pin_dm: PA11<Alternate<AF10>>,
         _pin_dp: PA12<Alternate<AF10>>,
         prec: rcc::rec::Usb2Otg,
-        hclk: Hertz,
+        clocks: &rcc::CoreClocks,
     ) -> Self {
-        Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, hclk)
+        Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, clocks)
     }
     pub fn new_unchecked(
         usb_global: stm32::OTG2_HS_GLOBAL,
         usb_device: stm32::OTG2_HS_DEVICE,
         usb_pwrclk: stm32::OTG2_HS_PWRCLK,
         prec: rcc::rec::Usb2Otg,
-        hclk: Hertz,
+        clocks: &rcc::CoreClocks,
     ) -> Self {
         USB2 {
             usb_global,
             usb_device,
             usb_pwrclk,
             prec,
-            hclk,
+            hclk: clocks.hclk(),
         }
     }
 }
@@ -223,23 +223,23 @@ impl USB1_ULPI {
         _ulpi_d6: PB13<Alternate<AF10>>,
         _ulpi_d7: PB5<Alternate<AF10>>,
         prec: rcc::rec::Usb1Otg,
-        hclk: Hertz,
+        clocks: &rcc::CoreClocks,
     ) -> Self {
-        Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, hclk)
+        Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, clocks)
     }
     pub fn new_unchecked(
         usb_global: stm32::OTG1_HS_GLOBAL,
         usb_device: stm32::OTG1_HS_DEVICE,
         usb_pwrclk: stm32::OTG1_HS_PWRCLK,
         prec: rcc::rec::Usb1Otg,
-        hclk: Hertz,
+        clocks: &rcc::CoreClocks,
     ) -> Self {
         USB1_ULPI {
             usb_global,
             usb_device,
             usb_pwrclk,
             prec,
-            hclk,
+            hclk: clocks.hclk(),
         }
     }
 }


### PR DESCRIPTION
Breaking change on the USB API, since the structure no longer contains instances of the pin types