### PR TITLE
Tidy various clippy lints

### DIFF
--- a/examples/adc12.rs
+++ b/examples/adc12.rs
@@ -9,7 +9,6 @@
 #[macro_use]
 mod utilities;
 
-use cortex_m;
 use cortex_m_rt::entry;
 use log::info;
 use stm32h7xx_hal::{adc, delay::Delay, pac, prelude::*};

--- a/examples/ethernet-nucleo-h743zi2.rs
+++ b/examples/ethernet-nucleo-h743zi2.rs
@@ -110,7 +110,7 @@ fn main() -> ! {
             dp.ETHERNET_MTL,
             dp.ETHERNET_DMA,
             &mut DES_RING,
-            mac_addr.clone(),
+            mac_addr,
             ccdr.peripheral.ETH1MAC,
             &ccdr.clocks,
         )

--- a/examples/sdmmc.rs
+++ b/examples/sdmmc.rs
@@ -160,8 +160,8 @@ fn main() -> ! {
     }
 
     // Check the read
-    for j in 0..5120 {
-        assert_eq!(buffer[j], 0x34);
+    for byte in buffer.iter() {
+        assert_eq!(*byte, 0x34);
     }
 
     info!("Done!");

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -208,10 +208,13 @@ macro_rules! adc_internal {
 }
 
 /// Vref internal signal
+#[derive(Default)]
 pub struct Vrefint;
 /// Vbat internal signal
+#[derive(Default)]
 pub struct Vbat;
 /// Internal temperature sensor
+#[derive(Default)]
 pub struct Temperature;
 
 // Not implementing Pxy_C adc pins

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -183,7 +183,7 @@ macro_rules! impl_delay_from_count_down_timer  {
                     self.0.start(looping_delay_hz);
                     while time_left > looping_delay {
                         block!(self.0.wait()).ok();
-                        time_left = time_left - looping_delay;
+                        time_left -= looping_delay;
                     }
 
                     if time_left > 0 {

--- a/src/ethernet/eth.rs
+++ b/src/ethernet/eth.rs
@@ -759,6 +759,8 @@ impl<'a> phy::Device<'a> for EthernetDMA<'_> {
     type RxToken = RxToken<'a>;
     type TxToken = TxToken<'a>;
 
+    // Clippy false positive because DeviceCapabilities is non-exhaustive
+    #[allow(clippy::field_reassign_with_default)]
     fn capabilities(&self) -> DeviceCapabilities {
         let mut caps = DeviceCapabilities::default();
         // ethernet frame type II (6 smac, 6 dmac, 2 ethertype),

--- a/src/ethernet/ksz8081r.rs
+++ b/src/ethernet/ksz8081r.rs
@@ -58,7 +58,7 @@ impl<MAC: StationManagement> KSZ8081R<MAC> {
     }
 
     pub fn link_established(&mut self) -> bool {
-        return self.poll_link();
+        self.poll_link()
     }
 
     pub fn block_until_link(&mut self) {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -49,6 +49,7 @@ pub enum Stop {
 
 /// I2C error
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Bus error
     Bus,
@@ -60,8 +61,6 @@ pub enum Error {
     // Pec, // SMBUS mode only
     // Timeout, // SMBUS mode only
     // Alert, // SMBUS mode only
-    #[doc(hidden)]
-    _Extensible,
 }
 
 /// A trait to represent the SCL Pin of an I2C Port

--- a/src/rcc/pll.rs
+++ b/src/rcc/pll.rs
@@ -101,7 +101,7 @@ macro_rules! vco_setup {
 
          // Calculate resulting reference clock
          let ref_x_ck = $pllsrc / pll_x_m;
-         assert!(ref_x_ck >= 1_000_000 && ref_x_ck <= 2_000_000);
+         assert!((1_000_000..=2_000_000).contains(&ref_x_ck));
 
          // Configure VCO
          $rcc.pllcfgr.modify(|_, w| {
@@ -152,7 +152,7 @@ macro_rules! vco_setup {
 
          // Calculate resulting reference clock
          let ref_x_ck = $pllsrc / pll_x_m;
-         assert!(ref_x_ck >= 2_000_000 && ref_x_ck <= 16_000_000);
+         assert!((2_000_000..=16_000_000).contains(&ref_x_ck));
 
          // Configure VCO
          $rcc.pllcfgr.modify(|_, w| {
@@ -340,10 +340,10 @@ fn calc_ck_div(
 ) -> u32 {
     let mut div = (vco_ck + target_ck - 1) / target_ck;
     // If the divider takes us under the target clock, then increase it
-    if strategy == PllConfigStrategy::FractionalNotLess {
-        if target_ck * div > vco_ck {
-            div -= 1;
-        }
+    if strategy == PllConfigStrategy::FractionalNotLess
+        && target_ck * div > vco_ck
+    {
+        div -= 1;
     }
     div
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -45,6 +45,7 @@ use crate::Never;
 
 /// Serial error
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Framing error
     Framing,
@@ -54,8 +55,6 @@ pub enum Error {
     Overrun,
     /// Parity check error
     Parity,
-    #[doc(hidden)]
-    _Extensible,
 }
 
 /// Interrupt event

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -69,7 +69,6 @@ use crate::stm32::spi1::{cfg1::MBR_A as MBR, cfg2::COMM_A as COMM};
 use core::convert::From;
 use core::marker::PhantomData;
 use core::ptr;
-use nb;
 use stm32h7::Variant::Val;
 
 use crate::stm32::{SPI1, SPI2, SPI3, SPI4, SPI5, SPI6};
@@ -95,6 +94,7 @@ use crate::time::Hertz;
 
 /// SPI error
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Overrun occurred
     Overrun,
@@ -102,8 +102,6 @@ pub enum Error {
     ModeFault,
     /// CRC error
     Crc,
-    #[doc(hidden)]
-    _Extensible,
 }
 
 /// Enabled SPI peripheral (type state)
@@ -165,7 +163,7 @@ impl Config {
     /// * `mode` - The SPI mode to configure.
     pub fn new(mode: Mode) -> Self {
         Config {
-            mode: mode,
+            mode,
             swap_miso_mosi: false,
             cs_delay: 0.0,
             managed_cs: false,
@@ -502,7 +500,7 @@ macro_rules! spi {
                             // before truncation to an integer to ensure that we have at least as
                             // many cycles as required.
                             if config.cs_delay > 0.0_f32 {
-                                delay = delay + 1;
+                                delay += 1;
                             }
 
                             if delay > 0xF {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -19,7 +19,6 @@ use crate::stm32::{
 };
 
 use cast::{u16, u32};
-use nb;
 use void::Void;
 
 #[cfg(feature = "rm0455")]

--- a/src/traits/i2s.rs
+++ b/src/traits/i2s.rs
@@ -1,7 +1,5 @@
 //! I2S - Inter-IC Sound Interface
 
-use nb;
-
 /// Full duplex
 pub trait FullDuplex<Word> {
     /// Error type


### PR DESCRIPTION
Using `#[non_exhaustive]` breaks pre-1.40 support, that's acceptable at this point