### PR TITLE
Add barriers to interrupt clearing functions

### DIFF
--- a/src/dma/bdma.rs
+++ b/src/dma/bdma.rs
@@ -246,10 +246,11 @@ impl<I: Instance> StreamsTuple<I> {
 //
 // The implementation does the heavy lifting of mapping to the right fields on
 // the stream
+// (Stream0, 0, ifcr, ctcif1, chtif1, cteif1, cgif1, isr, tcif1, htif1),
 macro_rules! bdma_stream {
     ($(($name:ident, $number:expr,
         $ifcr:ident, $tcif:ident, $htif:ident, $teif:ident, $gif:ident,
-        $isr:ident, $tcisr:ident, $htisr:ident)
+        $isr:ident, $tcisr:ident, $htisr:ident, $teisr:ident, $gisr:ident)
     ),+$(,)*) => {
         $(
             impl<I: Instance> Stream for $name<I> {
@@ -283,6 +284,13 @@ macro_rules! bdma_stream {
                                     .$teif().set_bit() //Clear transfer error interrupt flag
                                     .$gif().set_bit() //Clear global interrupt flag
                     );
+                    while {
+                        let r = dma.$isr.read();
+                        r.$tcisr().bit_is_set() ||
+                        r.$htisr().bit_is_set() ||
+                        r.$teisr().bit_is_set() ||
+                        r.$gisr().bit_is_set()
+                    } {}
                 }
 
                 #[inline(always)]
@@ -291,6 +299,7 @@ macro_rules! bdma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$tcif().set_bit());
+                    while dma.$isr.read().$tcisr().bit_is_set() {}
                 }
 
                 #[inline(always)]
@@ -299,6 +308,7 @@ macro_rules! bdma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$teif().set_bit());
+                    while dma.$isr.read().$teisr().bit_is_set() {}
                 }
 
                 #[inline(always)]
@@ -359,13 +369,19 @@ macro_rules! bdma_stream {
 
                 #[inline(always)]
                 fn disable_interrupts(&mut self) {
+                    // TODO: Prevent calling when channel is enabled
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ch[Self::NUMBER].cr.modify(|_, w| w
-                                                   .tcie().clear_bit()
-                                                   .teie().clear_bit()
-                                                   .htie().clear_bit()
-                    );
+                    let dmacr = &unsafe { &*I::ptr() }.ch[Self::NUMBER].cr;
+                    dmacr.modify(|_, w| w
+                        .tcie().clear_bit()
+                        .teie().clear_bit()
+                        .htie().clear_bit());
+                    while {
+                        let r = dmacr.read();
+                        r.tcie().bit_is_set() ||
+                        r.teie().bit_is_set() ||
+                        r.htie().bit_is_set()
+                    } {}
                 }
 
                 #[inline(always)]
@@ -396,15 +412,21 @@ macro_rules! bdma_stream {
                 #[inline(always)]
                 fn set_transfer_complete_interrupt_enable(&mut self, transfer_complete_interrupt: bool) {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ch[Self::NUMBER].cr.modify(|_, w| w.tcie().bit(transfer_complete_interrupt));
+                    let dmacr = &unsafe { &*I::ptr() }.ch[Self::NUMBER].cr;
+                    dmacr.modify(|_, w| w.tcie().bit(transfer_complete_interrupt));
+                    if !transfer_complete_interrupt {
+                        while dmacr.read().tcie().bit_is_set() {}
+                    }
                 }
 
                 #[inline(always)]
                 fn set_transfer_error_interrupt_enable(&mut self, transfer_error_interrupt: bool) {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ch[Self::NUMBER].cr.modify(|_, w| w.teie().bit(transfer_error_interrupt));
+                    let dmacr = &unsafe { &*I::ptr() }.ch[Self::NUMBER].cr;
+                    dmacr.modify(|_, w| w.teie().bit(transfer_error_interrupt));
+                    if !transfer_error_interrupt {
+                        while dmacr.read().teie().bit_is_set() {}
+                    }
                 }
             }
 
@@ -412,8 +434,11 @@ macro_rules! bdma_stream {
                 #[inline(always)]
                 fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ch[Self::NUMBER].cr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
+                    let dmacr = &unsafe { &*I::ptr() }.ch[Self::NUMBER].cr;
+                    dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
+                    if !half_transfer_interrupt {
+                        while dmacr.read().htie().bit_is_set() {}
+                    }
                 }
 
                 #[inline(always)]
@@ -429,6 +454,7 @@ macro_rules! bdma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$htif().set_bit());
+                    while dma.$isr.read().$htisr().bit_is_set() {}
                 }
 
                 #[inline(always)]
@@ -571,6 +597,7 @@ macro_rules! bdma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$htif().set_bit());
+                    while dma.$isr.read().$htisr().bit_is_set() {}
                 }
 
                 #[inline(always)]
@@ -583,8 +610,11 @@ macro_rules! bdma_stream {
                 #[inline(always)]
                 pub fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ch[Self::NUMBER].cr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
+                    let dmacr = &unsafe { &*I::ptr() }.ch[Self::NUMBER].cr;
+                    dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
+                    if !half_transfer_interrupt {
+                        while dmacr.read().htie().bit_is_set() {}
+                    }
                 }
             }
         )+
@@ -594,14 +624,38 @@ macro_rules! bdma_stream {
 bdma_stream!(
     // Note: the field names start from one, unlike the RM where they start from
     // zero. May need updating if it gets fixed upstream.
-    (Stream0, 0, ifcr, ctcif1, chtif1, cteif1, cgif1, isr, tcif1, htif1),
-    (Stream1, 1, ifcr, ctcif2, chtif2, cteif2, cgif2, isr, tcif2, htif2),
-    (Stream2, 2, ifcr, ctcif3, chtif3, cteif3, cgif3, isr, tcif3, htif3),
-    (Stream3, 3, ifcr, ctcif4, chtif4, cteif4, cgif4, isr, tcif4, htif4),
-    (Stream4, 4, ifcr, ctcif5, chtif5, cteif5, cgif5, isr, tcif5, htif5),
-    (Stream5, 5, ifcr, ctcif6, chtif6, cteif6, cgif6, isr, tcif6, htif6),
-    (Stream6, 6, ifcr, ctcif7, chtif7, cteif7, cgif7, isr, tcif7, htif7),
-    (Stream7, 7, ifcr, ctcif8, chtif8, cteif8, cgif8, isr, tcif8, htif8),
+    (
+        Stream0, 0, ifcr, ctcif1, chtif1, cteif1, cgif1, isr, tcif1, htif1,
+        teif1, gif1
+    ),
+    (
+        Stream1, 1, ifcr, ctcif2, chtif2, cteif2, cgif2, isr, tcif2, htif2,
+        teif2, gif2
+    ),
+    (
+        Stream2, 2, ifcr, ctcif3, chtif3, cteif3, cgif3, isr, tcif3, htif3,
+        teif3, gif3
+    ),
+    (
+        Stream3, 3, ifcr, ctcif4, chtif4, cteif4, cgif4, isr, tcif4, htif4,
+        teif4, gif4
+    ),
+    (
+        Stream4, 4, ifcr, ctcif5, chtif5, cteif5, cgif5, isr, tcif5, htif5,
+        teif5, gif5
+    ),
+    (
+        Stream5, 5, ifcr, ctcif6, chtif6, cteif6, cgif6, isr, tcif6, htif6,
+        teif6, gif6
+    ),
+    (
+        Stream6, 6, ifcr, ctcif7, chtif7, cteif7, cgif7, isr, tcif7, htif7,
+        teif7, gif7
+    ),
+    (
+        Stream7, 7, ifcr, ctcif8, chtif8, cteif8, cgif8, isr, tcif8, htif8,
+        teif8, gif8
+    ),
 );
 
 /// Type alias for the DMA Request Multiplexer

--- a/src/dma/bdma.rs
+++ b/src/dma/bdma.rs
@@ -246,7 +246,6 @@ impl<I: Instance> StreamsTuple<I> {
 //
 // The implementation does the heavy lifting of mapping to the right fields on
 // the stream
-// (Stream0, 0, ifcr, ctcif1, chtif1, cteif1, cgif1, isr, tcif1, htif1),
 macro_rules! bdma_stream {
     ($(($name:ident, $number:expr,
         $ifcr:ident, $tcif:ident, $htif:ident, $teif:ident, $gif:ident,
@@ -369,7 +368,6 @@ macro_rules! bdma_stream {
 
                 #[inline(always)]
                 fn disable_interrupts(&mut self) {
-                    // TODO: Prevent calling when channel is enabled
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dmacr = &unsafe { &*I::ptr() }.ch[Self::NUMBER].cr;
                     dmacr.modify(|_, w| w

--- a/src/ethernet/eth.rs
+++ b/src/ethernet/eth.rs
@@ -805,6 +805,10 @@ pub unsafe fn interrupt_handler() {
     eth_dma
         .dmacsr
         .write(|w| w.nis().set_bit().ri().set_bit().ti().set_bit());
+    while {
+        let r = eth_dma.dmacsr.read();
+        r.nis().bit_is_set() || r.ri().bit_is_set() || r.ti().bit_is_set()
+    } {}
 }
 
 pub unsafe fn enable_interrupt() {

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -215,12 +215,29 @@ impl ExtiExt for EXTI {
 
         unsafe {
             match line {
-                0..=31 => reg_for_cpu!(self, imr1)
-                    .modify(|r, w| w.bits(r.bits() & !(1 << line))),
-                32..=44 | 46..=63 => reg_for_cpu!(self, imr2)
-                    .modify(|r, w| w.bits(r.bits() & !(1 << (line - 32)))),
-                64..=80 | 82 | 84..=88 => reg_for_cpu!(self, imr3)
-                    .modify(|r, w| w.bits(r.bits() & !(1 << (line - 64)))),
+                0..=31 => {
+                    reg_for_cpu!(self, imr1)
+                        .modify(|r, w| w.bits(r.bits() & !(1 << line)));
+                    while reg_for_cpu!(self, imr1).read().bits() & (1 << line)
+                        != 0
+                    {}
+                }
+                32..=44 | 46..=63 => {
+                    reg_for_cpu!(self, imr2)
+                        .modify(|r, w| w.bits(r.bits() & !(1 << (line - 32))));
+                    while reg_for_cpu!(self, imr2).read().bits()
+                        & (1 << (line - 32))
+                        != 0
+                    {}
+                }
+                64..=80 | 82 | 84..=88 => {
+                    reg_for_cpu!(self, imr3)
+                        .modify(|r, w| w.bits(r.bits() & !(1 << (line - 64))));
+                    while reg_for_cpu!(self, imr3).read().bits()
+                        & (1 << (line - 64))
+                        != 0
+                    {}
+                }
                 _ => {}
             }
         }
@@ -255,13 +272,24 @@ impl ExtiExt for EXTI {
         unsafe {
             match line {
                 0..=19 | 20 | 21 => {
-                    reg_for_cpu!(self, pr1).write(|w| w.bits(1 << line))
+                    reg_for_cpu!(self, pr1).write(|w| w.bits(1 << line));
+                    while reg_for_cpu!(self, pr1).read().bits() & (1 << line)
+                        != 0
+                    {}
                 }
                 49 | 51 => {
-                    reg_for_cpu!(self, pr2).write(|w| w.bits(1 << (line - 32)))
+                    reg_for_cpu!(self, pr2).write(|w| w.bits(1 << (line - 32)));
+                    while reg_for_cpu!(self, pr2).read().bits()
+                        & (1 << (line - 32))
+                        != 0
+                    {}
                 }
                 82 | 84 | 85 | 86 => {
-                    reg_for_cpu!(self, pr3).write(|w| w.bits(1 << (line - 64)))
+                    reg_for_cpu!(self, pr3).write(|w| w.bits(1 << (line - 64)));
+                    while reg_for_cpu!(self, pr3).read().bits()
+                        & (1 << (line - 64))
+                        != 0
+                    {}
                 }
                 _ => {}
             }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -348,8 +348,8 @@ macro_rules! gpio {
                         #[cfg(all(feature = "rm0399", feature = "cm4"))]
                         let pr1 = &(*EXTI::ptr()).c2pr1;
 
-
-                        pr1.write(|w| w.bits(1 << self.i) );
+                        pr1.write(|w| w.bits(1 << self.i));
+                        while pr1.read().bits() & (1 << self.i) != 0 {}
                     }
                 }
             }
@@ -796,6 +796,7 @@ macro_rules! gpio {
                             let pr1 = &(*(EXTI::ptr())).c2pr1;
 
                             pr1.write(|w| w.bits(1 << $i));
+                            while pr1.read().bits() & (1 << $i) != 0 {}
                         };
                     }
                 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -355,31 +355,59 @@ macro_rules! i2c {
 
                 /// Stop listening for `event`
                 pub fn unlisten(&mut self, event: Event) {
-                    self.i2c.cr1.modify(|_,w| {
-                        match event {
-                            Event::Transmit => w.txie().clear_bit(),
-                            Event::Receive => w.rxie().clear_bit(),
-                            Event::TransferComplete => w.tcie().clear_bit(),
-                            Event::Stop => w.stopie().clear_bit(),
-                            Event::Errors => w.errie().clear_bit(),
-                            Event::NotAcknowledge => w.nackie().clear_bit(),
+                    match event {
+                        Event::Transmit => {
+                            self.i2c.cr1.modify(|_, w| w.txie().clear_bit());
+                            while self.i2c.cr1.read().txie().bit_is_set() {}
                         }
-                    });
+                        Event::Receive => {
+                            self.i2c.cr1.modify(|_, w| w.rxie().clear_bit());
+                            while self.i2c.cr1.read().rxie().bit_is_set() {}
+                        }
+                        Event::TransferComplete => {
+                            self.i2c.cr1.modify(|_, w| w.tcie().clear_bit());
+                            while self.i2c.cr1.read().tcie().bit_is_set() {}
+                        }
+                        Event::Stop => {
+                            self.i2c.cr1.modify(|_, w| w.stopie().clear_bit());
+                            while self.i2c.cr1.read().stopie().bit_is_set() {}
+                        }
+                        Event::Errors => {
+                            self.i2c.cr1.modify(|_, w| w.errie().clear_bit());
+                            while self.i2c.cr1.read().errie().bit_is_set() {}
+                        }
+                        Event::NotAcknowledge => {
+                            self.i2c.cr1.modify(|_, w| w.nackie().clear_bit());
+                            while self.i2c.cr1.read().nackie().bit_is_set() {}
+                        }
+                    }
                 }
 
                 /// Clears interrupt flag for `event`
                 pub fn clear_irq(&mut self, event: Event) {
-                    self.i2c.icr.write(|w| {
-                        match event {
-                            Event::Stop => w.stopcf().set_bit(),
-                            Event::Errors => w
+                    match event {
+                        Event::Stop => {
+                            self.i2c.icr.write(|w| w.stopcf().set_bit());
+                            while self.i2c.isr.read().stopf().bit_is_set() {}
+                        }
+                        Event::Errors => {
+                            self.i2c.icr.write(|w| w
                                 .berrcf().set_bit()
                                 .arlocf().set_bit()
-                                .ovrcf().set_bit(),
-                            Event::NotAcknowledge => w.nackcf().set_bit(),
-                            _ => w
+                                .ovrcf().set_bit());
+                            while {
+                                let r = self.i2c.isr.read();
+                                r.berr().bit_is_set() ||
+                                r.arlo().bit_is_set() ||
+                                r.ovr().bit_is_set()
+                            } {}
                         }
-                    });
+                        Event::NotAcknowledge => {
+                            self.i2c.icr.write(|w| w.nackcf().set_bit());
+                            while self.i2c.isr.read().nackf().bit_is_set() {}
+                        }
+                        _ => {}
+                    }
                 }
 
                 /// Releases the I2C peripheral

--- a/src/qspi.rs
+++ b/src/qspi.rs
@@ -556,11 +556,20 @@ impl Qspi {
 
     /// Disable interrupts for the given `event`
     pub fn unlisten(&mut self, event: Event) {
-        self.rb.cr.modify(|_, w| match event {
-            Event::FIFOThreashold => w.ftie().clear_bit(),
-            Event::Complete => w.tcie().clear_bit(),
-            Event::Error => w.teie().clear_bit(),
-        });
+        match event {
+            Event::FIFOThreashold => {
+                self.rb.cr.modify(|_, w| w.ftie().clear_bit());
+                while self.rb.cr.read().ftie().bit_is_set() {}
+            }
+            Event::Complete => {
+                self.rb.cr.modify(|_, w| w.tcie().clear_bit());
+                while self.rb.cr.read().tcie().bit_is_set() {}
+            }
+            Event::Error => {
+                self.rb.cr.modify(|_, w| w.teie().clear_bit());
+                while self.rb.cr.read().teie().bit_is_set() {}
+            }
+        }
     }
 
     fn get_clock(clocks: &CoreClocks) -> Option<Hertz> {

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -759,27 +759,27 @@ impl Rtc {
         match event {
             Event::LseCss => {
                 rcc.cier.modify(|_, w| w.lsecssie().disabled());
-                exti.listen(ExtiEvent::RTC_OTHER);
+                exti.unlisten(ExtiEvent::RTC_OTHER);
                 exti.rtsr1.modify(|_, w| w.tr18().disabled());
             }
             Event::AlarmA => {
                 self.reg.cr.modify(|_, w| w.alraie().clear_bit());
-                exti.listen(ExtiEvent::RTC_ALARM);
+                exti.unlisten(ExtiEvent::RTC_ALARM);
                 exti.rtsr1.modify(|_, w| w.tr17().disabled());
             }
             Event::AlarmB => {
                 self.reg.cr.modify(|_, w| w.alrbie().clear_bit());
-                exti.listen(ExtiEvent::RTC_ALARM);
+                exti.unlisten(ExtiEvent::RTC_ALARM);
                 exti.rtsr1.modify(|_, w| w.tr17().disabled());
             }
             Event::Wakeup => {
                 self.reg.cr.modify(|_, w| w.wutie().clear_bit());
-                exti.listen(ExtiEvent::RTC_WAKEUP);
+                exti.unlisten(ExtiEvent::RTC_WAKEUP);
                 exti.rtsr1.modify(|_, w| w.tr19().disabled());
             }
             Event::Timestamp => {
                 self.reg.cr.modify(|_, w| w.tsie().clear_bit());
-                exti.listen(ExtiEvent::RTC_OTHER);
+                exti.unlisten(ExtiEvent::RTC_OTHER);
                 exti.rtsr1.modify(|_, w| w.tr18().disabled());
             }
         }

--- a/src/sai/i2s.rs
+++ b/src/sai/i2s.rs
@@ -5,7 +5,7 @@
 use core::convert::TryInto;
 
 use crate::rcc::{rec, CoreClocks, ResetEnable};
-use crate::sai::{GetClkSAI, Sai, SaiChannel, CLEAR_ALL_FLAGS_BITS, INTERFACE};
+use crate::sai::{GetClkSAI, Sai, SaiChannel, ALL_IRQ_FLAGS_BITS, INTERFACE};
 use crate::stm32;
 use crate::time::Hertz;
 
@@ -711,7 +711,7 @@ fn i2s_config_channel(
 }
 
 fn enable_ch(audio_ch: &CH) {
-    unsafe { audio_ch.clrfr.write(|w| w.bits(CLEAR_ALL_FLAGS_BITS)) };
+    unsafe { audio_ch.clrfr.write(|w| w.bits(ALL_IRQ_FLAGS_BITS)) };
     audio_ch.cr2.modify(|_, w| w.fflush().flush());
     audio_ch.cr1.modify(|_, w| w.saien().enabled());
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -519,13 +519,16 @@ macro_rules! usart {
                 pub fn unlisten(&mut self, event: Event) {
                     match event {
                         Event::Rxne => {
-                            self.usart.cr1.modify(|_, w| w.rxneie().disabled())
+                            self.usart.cr1.modify(|_, w| w.rxneie().disabled());
+                            while self.usart.cr1.read().rxneie().is_enabled() {}
                         },
                         Event::Txe => {
-                            self.usart.cr1.modify(|_, w| w.txeie().disabled())
+                            self.usart.cr1.modify(|_, w| w.txeie().disabled());
+                            while self.usart.cr1.read().txeie().is_enabled() {}
                         },
                         Event::Idle => {
-                            self.usart.cr1.modify(|_, w| w.idleie().disabled())
+                            self.usart.cr1.modify(|_, w| w.idleie().disabled());
+                            while self.usart.cr1.read().idleie().is_enabled() {}
                         },
                     }
                 }
@@ -638,7 +641,9 @@ macro_rules! usart {
                 /// Stop listening for `Rxne` event
                 pub fn unlisten(&mut self) {
                     // unsafe: rxneie bit accessed by Rx part only
-                    unsafe { &*$USARTX::ptr() }.cr1.modify(|_, w| w.rxneie().disabled());
+                    let cr1 = &unsafe { &*$USARTX::ptr() }.cr1;
+                    cr1.modify(|_, w| w.rxneie().disabled());
+                    while cr1.read().rxneie().is_enabled() {}
                 }
             }
 
@@ -713,7 +718,9 @@ macro_rules! usart {
                 /// Stop listening for `Txe` event
                 pub fn unlisten(&mut self) {
                     // unsafe: txeie bit accessed by Tx part only
-                    unsafe { &*$USARTX::ptr() }.cr1.modify(|_, w| w.txeie().disabled());
+                    let cr1 = &unsafe { &*$USARTX::ptr() }.cr1;
+                    cr1.modify(|_, w| w.txeie().disabled());
+                    while cr1.read().txeie().is_enabled() {}
                 }
             }
         )+

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -424,7 +424,7 @@ macro_rules! hal {
                 pub fn unlisten(&mut self, event: Event) {
                     match event {
                         Event::TimeOut => {
-                            // Enable update event interrupt
+                            // Disable update event interrupt
                             self.tim.dier.write(|w| w.uie().clear_bit());
                             while self.tim.dier.read().uie().bit_is_set() {}
                         }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -426,6 +426,7 @@ macro_rules! hal {
                         Event::TimeOut => {
                             // Enable update event interrupt
                             self.tim.dier.write(|w| w.uie().clear_bit());
+                            while self.tim.dier.read().uie().bit_is_set() {}
                         }
                     }
                 }
@@ -441,6 +442,7 @@ macro_rules! hal {
                         // Clears timeout event
                         w.uif().clear_bit()
                     });
+                    while self.tim.sr.read().uif().bit_is_set() {}
                 }
 
                 /// Releases the TIM peripheral
@@ -623,6 +625,7 @@ macro_rules! lptim_hal {
                         Event::TimeOut => {
                             // Disable autoreload match interrupt
                             self.tim.ier.modify(|_, w| w.arrmie().clear_bit());
+                            while self.tim.ier.read().arrmie().bit_is_set() {}
                         }
                     }
                 }
@@ -703,6 +706,7 @@ macro_rules! lptim_hal {
                 pub fn clear_irq(&mut self) {
                     // Clear autoreload match event
                     self.tim.icr.write(|w| w.arrmcf().set_bit());
+                    while self.tim.isr.read().arrm().bit_is_set() {}
                 }
 
                 /// Releases the LPTIM peripheral


### PR DESCRIPTION
If you clear an interrupt flag and quickly return from the interrupt, the interrupt will often immediately execute again. There are two possible causes for this:

1. The peripheral bus that executes the interrupt clear operation is clocked slower than the CPU clock, so there are a few instructions that are executed after clearing the IRQ flag but before the write takes effect.

2. The instruction pipeline may be executing future instructions that haven't 'noticed' the changed interrupt flag.

Adding the appropriate barrier instructions ensures that the side effects of the register write occur before the program continues executing.

See ARM Application Note 321.

Fixes #190 