### PR TITLE
Use register reads to delay peripheral interrupt clearing

### DIFF
--- a/src/dma/bdma.rs
+++ b/src/dma/bdma.rs
@@ -283,13 +283,8 @@ macro_rules! bdma_stream {
                                     .$teif().set_bit() //Clear transfer error interrupt flag
                                     .$gif().set_bit() //Clear global interrupt flag
                     );
-                    while {
-                        let r = dma.$isr.read();
-                        r.$tcisr().bit_is_set() ||
-                        r.$htisr().bit_is_set() ||
-                        r.$teisr().bit_is_set() ||
-                        r.$gisr().bit_is_set()
-                    } {}
+                    let _ = dma.$isr.read();
+                    let _ = dma.$isr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -298,7 +293,8 @@ macro_rules! bdma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$tcif().set_bit());
-                    while dma.$isr.read().$tcisr().bit_is_set() {}
+                    let _ = dma.$isr.read();
+                    let _ = dma.$isr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -307,7 +303,8 @@ macro_rules! bdma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$teif().set_bit());
-                    while dma.$isr.read().$teisr().bit_is_set() {}
+                    let _ = dma.$isr.read();
+                    let _ = dma.$isr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -374,12 +371,8 @@ macro_rules! bdma_stream {
                         .tcie().clear_bit()
                         .teie().clear_bit()
                         .htie().clear_bit());
-                    while {
-                        let r = dmacr.read();
-                        r.tcie().bit_is_set() ||
-                        r.teie().bit_is_set() ||
-                        r.htie().bit_is_set()
-                    } {}
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -412,9 +405,8 @@ macro_rules! bdma_stream {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dmacr = &unsafe { &*I::ptr() }.ch[Self::NUMBER].cr;
                     dmacr.modify(|_, w| w.tcie().bit(transfer_complete_interrupt));
-                    if !transfer_complete_interrupt {
-                        while dmacr.read().tcie().bit_is_set() {}
-                    }
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -422,9 +414,8 @@ macro_rules! bdma_stream {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dmacr = &unsafe { &*I::ptr() }.ch[Self::NUMBER].cr;
                     dmacr.modify(|_, w| w.teie().bit(transfer_error_interrupt));
-                    if !transfer_error_interrupt {
-                        while dmacr.read().teie().bit_is_set() {}
-                    }
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
                 }
             }
 
@@ -434,9 +425,8 @@ macro_rules! bdma_stream {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dmacr = &unsafe { &*I::ptr() }.ch[Self::NUMBER].cr;
                     dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
-                    if !half_transfer_interrupt {
-                        while dmacr.read().htie().bit_is_set() {}
-                    }
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -452,7 +442,8 @@ macro_rules! bdma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$htif().set_bit());
-                    while dma.$isr.read().$htisr().bit_is_set() {}
+                    let _ = dma.$isr.read();
+                    let _ = dma.$isr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -595,7 +586,8 @@ macro_rules! bdma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$htif().set_bit());
-                    while dma.$isr.read().$htisr().bit_is_set() {}
+                    let _ = dma.$isr.read();
+                    let _ = dma.$isr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -610,9 +602,8 @@ macro_rules! bdma_stream {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dmacr = &unsafe { &*I::ptr() }.ch[Self::NUMBER].cr;
                     dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
-                    if !half_transfer_interrupt {
-                        while dmacr.read().htie().bit_is_set() {}
-                    }
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
                 }
             }
         )+

--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -365,14 +365,8 @@ macro_rules! dma_stream {
                                     .$dmeif().set_bit() //Clear direct mode error interrupt flag
                                     .$feif().set_bit() //Clear fifo error interrupt flag
                     );
-                    while {
-                        let r = dma.$isr.read();
-                        r.$tcisr().bit_is_set() ||
-                        r.$htisr().bit_is_set() ||
-                        r.$teisr().bit_is_set() ||
-                        r.$dmeisr().bit_is_set() ||
-                        r.$feisr().bit_is_set()
-                    } {}
+                    let _ = dma.$isr.read();
+                    let _ = dma.$isr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -381,7 +375,8 @@ macro_rules! dma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$tcif().set_bit());
-                    while dma.$isr.read().$tcisr().bit_is_set() {}
+                    let _ = dma.$isr.read();
+                    let _ = dma.$isr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -390,7 +385,8 @@ macro_rules! dma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$teif().set_bit());
-                    while dma.$isr.read().$teisr().bit_is_set() {}
+                    let _ = dma.$isr.read();
+                    let _ = dma.$isr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -460,14 +456,8 @@ macro_rules! dma_stream {
                         .dmeie().clear_bit());
                     let dmafcr = &unsafe { &*I::ptr() }.st[Self::NUMBER].fcr;
                     dmafcr.modify(|_, w| w.feie().clear_bit());
-                    while {
-                        let r = dmacr.read();
-                        r.tcie().bit_is_set() ||
-                        r.teie().bit_is_set() ||
-                        r.htie().bit_is_set() ||
-                        r.dmeie().bit_is_set()
-                    } {}
-                    while dmafcr.read().feie().bit_is_set() {}
+                    let _ = dmafcr.read();
+                    let _ = dmafcr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -504,9 +494,8 @@ macro_rules! dma_stream {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dmacr = &unsafe { &*I::ptr() }.st[Self::NUMBER].cr;
                     dmacr.modify(|_, w| w.tcie().bit(transfer_complete_interrupt));
-                    if !transfer_complete_interrupt {
-                        while dmacr.read().tcie().bit_is_set() {}
-                    }
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -514,9 +503,8 @@ macro_rules! dma_stream {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dmacr = &unsafe { &*I::ptr() }.st[Self::NUMBER].cr;
                     dmacr.modify(|_, w| w.teie().bit(transfer_error_interrupt));
-                    if !transfer_error_interrupt {
-                        while dmacr.read().teie().bit_is_set() {}
-                    }
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
                 }
 
             }
@@ -527,9 +515,8 @@ macro_rules! dma_stream {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dmacr = &unsafe { &*I::ptr() }.st[Self::NUMBER].cr;
                     dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
-                    if !half_transfer_interrupt {
-                        while dmacr.read().htie().bit_is_set() {}
-                    }
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -545,7 +532,8 @@ macro_rules! dma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$htif().set_bit());
-                    while dma.$isr.read().$htisr().bit_is_set() {}
+                    let _ = dma.$isr.read();
+                    let _ = dma.$isr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -725,7 +713,8 @@ macro_rules! dma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$dmeif().set_bit());
-                    while dma.$isr.read().$dmeisr().bit_is_set() {}
+                    let _ = dma.$isr.read();
+                    let _ = dma.$isr.read(); // Delay 2 peripheral clocks
                 }
                 #[inline(always)]
                 pub fn clear_fifo_error_interrupt(&mut self) {
@@ -733,7 +722,8 @@ macro_rules! dma_stream {
                     // that belongs to the StreamX
                     let dma = unsafe { &*I::ptr() };
                     dma.$ifcr.write(|w| w.$feif().set_bit());
-                    while dma.$isr.read().$feisr().bit_is_set() {}
+                    let _ = dma.$isr.read();
+                    let _ = dma.$isr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -741,9 +731,8 @@ macro_rules! dma_stream {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dmacr = &unsafe { &*I::ptr() }.st[Self::NUMBER].cr;
                     dmacr.modify(|_, w| w.dmeie().bit(direct_mode_error_interrupt));
-                    if !direct_mode_error_interrupt {
-                        while dmacr.read().dmeie().bit_is_set() {}
-                    }
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
                 }
 
                 #[inline(always)]
@@ -751,9 +740,8 @@ macro_rules! dma_stream {
                     //NOTE(unsafe) We only access the registers that belongs to the StreamX
                     let dmafcr = &unsafe { &*I::ptr() }.st[Self::NUMBER].fcr;
                     dmafcr.modify(|_, w| w.feie().bit(fifo_error_interrupt));
-                    if !fifo_error_interrupt {
-                        while dmafcr.read().feie().bit_is_set() {}
-                    }
+                    let _ = dmafcr.read();
+                    let _ = dmafcr.read(); // Delay 2 peripheral clocks
                 }
             }
         )+

--- a/src/ethernet/eth.rs
+++ b/src/ethernet/eth.rs
@@ -805,10 +805,8 @@ pub unsafe fn interrupt_handler() {
     eth_dma
         .dmacsr
         .write(|w| w.nis().set_bit().ri().set_bit().ti().set_bit());
-    while {
-        let r = eth_dma.dmacsr.read();
-        r.nis().bit_is_set() || r.ri().bit_is_set() || r.ti().bit_is_set()
-    } {}
+    let _ = eth_dma.dmacsr.read();
+    let _ = eth_dma.dmacsr.read(); // Delay 2 peripheral clocks
 }
 
 pub unsafe fn enable_interrupt() {

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -218,25 +218,20 @@ impl ExtiExt for EXTI {
                 0..=31 => {
                     reg_for_cpu!(self, imr1)
                         .modify(|r, w| w.bits(r.bits() & !(1 << line)));
-                    while reg_for_cpu!(self, imr1).read().bits() & (1 << line)
-                        != 0
-                    {}
+                    let _ = reg_for_cpu!(self, imr1).read();
+                    let _ = reg_for_cpu!(self, imr1).read(); // Delay 2 peripheral clocks
                 }
                 32..=44 | 46..=63 => {
                     reg_for_cpu!(self, imr2)
                         .modify(|r, w| w.bits(r.bits() & !(1 << (line - 32))));
-                    while reg_for_cpu!(self, imr2).read().bits()
-                        & (1 << (line - 32))
-                        != 0
-                    {}
+                    let _ = reg_for_cpu!(self, imr2).read();
+                    let _ = reg_for_cpu!(self, imr2).read(); // Delay 2 peripheral clocks
                 }
                 64..=80 | 82 | 84..=88 => {
                     reg_for_cpu!(self, imr3)
                         .modify(|r, w| w.bits(r.bits() & !(1 << (line - 64))));
-                    while reg_for_cpu!(self, imr3).read().bits()
-                        & (1 << (line - 64))
-                        != 0
-                    {}
+                    let _ = reg_for_cpu!(self, imr3).read();
+                    let _ = reg_for_cpu!(self, imr3).read(); // Delay 2 peripheral clocks
                 }
                 _ => {}
             }
@@ -273,23 +268,18 @@ impl ExtiExt for EXTI {
             match line {
                 0..=19 | 20 | 21 => {
                     reg_for_cpu!(self, pr1).write(|w| w.bits(1 << line));
-                    while reg_for_cpu!(self, pr1).read().bits() & (1 << line)
-                        != 0
-                    {}
+                    let _ = reg_for_cpu!(self, pr1).read();
+                    let _ = reg_for_cpu!(self, pr1).read(); // Delay 2 peripheral clocks
                 }
                 49 | 51 => {
                     reg_for_cpu!(self, pr2).write(|w| w.bits(1 << (line - 32)));
-                    while reg_for_cpu!(self, pr2).read().bits()
-                        & (1 << (line - 32))
-                        != 0
-                    {}
+                    let _ = reg_for_cpu!(self, pr2).read();
+                    let _ = reg_for_cpu!(self, pr2).read(); // Delay 2 peripheral clocks
                 }
                 82 | 84 | 85 | 86 => {
                     reg_for_cpu!(self, pr3).write(|w| w.bits(1 << (line - 64)));
-                    while reg_for_cpu!(self, pr3).read().bits()
-                        & (1 << (line - 64))
-                        != 0
-                    {}
+                    let _ = reg_for_cpu!(self, pr3).read();
+                    let _ = reg_for_cpu!(self, pr3).read(); // Delay 2 peripheral clocks
                 }
                 _ => {}
             }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -349,7 +349,8 @@ macro_rules! gpio {
                         let pr1 = &(*EXTI::ptr()).c2pr1;
 
                         pr1.write(|w| w.bits(1 << self.i));
-                        while pr1.read().bits() & (1 << self.i) != 0 {}
+                        let _ = pr1.read();
+                        let _ = pr1.read(); // Delay 2 peripheral clocks
                     }
                 }
             }
@@ -796,8 +797,9 @@ macro_rules! gpio {
                             let pr1 = &(*(EXTI::ptr())).c2pr1;
 
                             pr1.write(|w| w.bits(1 << $i));
-                            while pr1.read().bits() & (1 << $i) != 0 {}
-                        };
+                            let _ = pr1.read();
+                            let _ = pr1.read(); // Delay 2 peripheral clocks
+                        }
                     }
                 }
             )+

--- a/src/sai/i2s.rs
+++ b/src/sai/i2s.rs
@@ -5,7 +5,7 @@
 use core::convert::TryInto;
 
 use crate::rcc::{rec, CoreClocks, ResetEnable};
-use crate::sai::{GetClkSAI, Sai, SaiChannel, ALL_IRQ_FLAGS_BITS, INTERFACE};
+use crate::sai::{GetClkSAI, Sai, SaiChannel, CLEAR_ALL_FLAGS_BITS, INTERFACE};
 use crate::stm32;
 use crate::time::Hertz;
 
@@ -711,7 +711,7 @@ fn i2s_config_channel(
 }
 
 fn enable_ch(audio_ch: &CH) {
-    unsafe { audio_ch.clrfr.write(|w| w.bits(ALL_IRQ_FLAGS_BITS)) };
+    unsafe { audio_ch.clrfr.write(|w| w.bits(CLEAR_ALL_FLAGS_BITS)) };
     audio_ch.cr2.modify(|_, w| w.fflush().flush());
     audio_ch.cr1.modify(|_, w| w.saien().enabled());
 }

--- a/src/sai/mod.rs
+++ b/src/sai/mod.rs
@@ -19,7 +19,7 @@ use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::time::Hertz;
 use stm32h7::Variant::Val;
 
-const ALL_IRQ_FLAGS_BITS: u32 = 0b0111_0111;
+const CLEAR_ALL_FLAGS_BITS: u32 = 0b0111_0111;
 
 mod pdm;
 pub use pdm::SaiPdmExt;
@@ -184,31 +184,15 @@ macro_rules! sai_hal {
                         SaiChannel::ChannelB => &self.rb.chb,
                     };
                     match event {
-                        Event::Overdue => {
-                            ch.im.modify(|_, w| w.ovrudrie().clear_bit());
-                            while ch.im.read().ovrudrie().bit_is_set() {}
-                        }
-                        Event::Muted => {
-                            ch.im.modify(|_, w| w.mutedetie().clear_bit());
-                            while ch.im.read().mutedetie().bit_is_set() {}
-                        }
-                        Event::WrongClock => {
-                            ch.im.modify(|_, w| w.wckcfgie().clear_bit());
-                            while ch.im.read().wckcfgie().bit_is_set() {}
-                        }
-                        Event::Data => {
-                            ch.im.modify(|_, w| w.freqie().clear_bit());
-                            while ch.im.read().freqie().bit_is_set() {}
-                        }
-                        Event::AnticipatedFrameSync => {
-                            ch.im.modify(|_, w| w.afsdetie().clear_bit());
-                            while ch.im.read().afsdetie().bit_is_set() {}
-                        }
-                        Event::LateFrameSync => {
-                            ch.im.modify(|_, w| w.lfsdetie().clear_bit());
-                            while ch.im.read().lfsdetie().bit_is_set() {}
-                        }
+                        Event::Overdue              => ch.im.modify(|_, w| w.ovrudrie().clear_bit()),
+                        Event::Muted                => ch.im.modify(|_, w| w.mutedetie().clear_bit()),
+                        Event::WrongClock           => ch.im.modify(|_, w| w.wckcfgie().clear_bit()),
+                        Event::Data                 => ch.im.modify(|_, w| w.freqie().clear_bit()),
+                        Event::AnticipatedFrameSync => ch.im.modify(|_, w| w.afsdetie().clear_bit()),
+                        Event::LateFrameSync        => ch.im.modify(|_, w| w.lfsdetie().clear_bit()),
                     }
+                    let _ = ch.im.read();
+                    let _ = ch.im.read(); // Delay 2 peripheral clocks
                 }
 
                 /// Clears interrupt flag `event` on the `channel`
@@ -220,44 +204,28 @@ macro_rules! sai_hal {
                         SaiChannel::ChannelB => &self.rb.chb,
                     };
                     match event {
-                        Event::Overdue => {
-                            ch.clrfr.write(|w| w.covrudr().set_bit());
-                            while ch.sr.read().ovrudr().bit_is_set() {}
-                        }
-                        Event::Muted => {
-                            ch.clrfr.write(|w| w.cmutedet().set_bit());
-                            while ch.sr.read().mutedet().bit_is_set() {}
-                        }
-                        Event::WrongClock => {
-                            ch.clrfr.write(|w| w.cwckcfg().set_bit());
-                            while ch.sr.read().wckcfg().bit_is_set() {}
-                        }
-                        Event::Data => {} // Cleared by reading/writing data
-                        Event::AnticipatedFrameSync => {
-                            ch.clrfr.write(|w| w.cafsdet().set_bit());
-                            while ch.sr.read().afsdet().bit_is_set() {}
-                        }
-                        Event::LateFrameSync => {
-                            ch.clrfr.write(|w| w.clfsdet().set_bit());
-                            while ch.sr.read().lfsdet().bit_is_set() {}
-                        }
+                        Event::Overdue              => ch.clrfr.write(|w| w.covrudr().set_bit()),
+                        Event::Muted                => ch.clrfr.write(|w| w.cmutedet().set_bit()),
+                        Event::WrongClock           => ch.clrfr.write(|w| w.cwckcfg().set_bit()),
+                        Event::Data                 => (), // Cleared by reading/writing data
+                        Event::AnticipatedFrameSync => ch.clrfr.write(|w| w.cafsdet().set_bit()),
+                        Event::LateFrameSync        => ch.clrfr.write(|w| w.clfsdet().set_bit()),
                     }
+                    let _ = ch.sr.read();
+                    let _ = ch.sr.read(); // Delay 2 peripheral clocks
                 }
 
                 /// Clears all interrupts on the `channel`
                 pub fn clear_all_irq(&mut self, channel: SaiChannel) {
+                    let ch = match channel {
+                        SaiChannel::ChannelA => &self.rb.cha,
+                        SaiChannel::ChannelB => &self.rb.chb,
+                    };
                     unsafe {
-                        match channel {
-                            SaiChannel::ChannelA => {
-                                self.rb.cha.clrfr.write(|w| w.bits(ALL_IRQ_FLAGS_BITS));
-                                while self.rb.cha.sr.read().bits() & ALL_IRQ_FLAGS_BITS != 0 {}
-                            }
-                            SaiChannel::ChannelB => {
-                                self.rb.chb.clrfr.write(|w| w.bits(ALL_IRQ_FLAGS_BITS));
-                                while self.rb.chb.sr.read().bits() & ALL_IRQ_FLAGS_BITS != 0 {}
-                            }
-                        };
+                        ch.clrfr.write(|w| w.bits(CLEAR_ALL_FLAGS_BITS));
                     }
+                    let _ = ch.sr.read();
+                    let _ = ch.sr.read(); // Delay 2 peripheral clocks
                 }
 
                 /// Mute `channel`, this is checked at the start of each frame

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -519,18 +519,17 @@ macro_rules! usart {
                 pub fn unlisten(&mut self, event: Event) {
                     match event {
                         Event::Rxne => {
-                            self.usart.cr1.modify(|_, w| w.rxneie().disabled());
-                            while self.usart.cr1.read().rxneie().is_enabled() {}
+                            self.usart.cr1.modify(|_, w| w.rxneie().disabled())
                         },
                         Event::Txe => {
-                            self.usart.cr1.modify(|_, w| w.txeie().disabled());
-                            while self.usart.cr1.read().txeie().is_enabled() {}
+                            self.usart.cr1.modify(|_, w| w.txeie().disabled())
                         },
                         Event::Idle => {
-                            self.usart.cr1.modify(|_, w| w.idleie().disabled());
-                            while self.usart.cr1.read().idleie().is_enabled() {}
+                            self.usart.cr1.modify(|_, w| w.idleie().disabled())
                         },
                     }
+                    let _ = self.usart.cr1.read();
+                    let _ = self.usart.cr1.read(); // Delay 2 peripheral clocks
                 }
 
                 /// Return true if the line idle status is set
@@ -643,7 +642,8 @@ macro_rules! usart {
                     // unsafe: rxneie bit accessed by Rx part only
                     let cr1 = &unsafe { &*$USARTX::ptr() }.cr1;
                     cr1.modify(|_, w| w.rxneie().disabled());
-                    while cr1.read().rxneie().is_enabled() {}
+                    let _ = cr1.read();
+                    let _ = cr1.read(); // Delay 2 peripheral clocks
                 }
             }
 
@@ -720,7 +720,8 @@ macro_rules! usart {
                     // unsafe: txeie bit accessed by Tx part only
                     let cr1 = &unsafe { &*$USARTX::ptr() }.cr1;
                     cr1.modify(|_, w| w.txeie().disabled());
-                    while cr1.read().txeie().is_enabled() {}
+                    let _ = cr1.read();
+                    let _ = cr1.read(); // Delay 2 peripheral clocks
                 }
             }
         )+

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -654,11 +654,9 @@ macro_rules! spi {
                         match event {
                             Event::Rxp => {
                                 self.spi.ier.modify(|_, w| w.rxpie().masked());
-                                while self.spi.ier.read().rxpie().is_not_masked() {}
                             }
                             Event::Txp => {
                                 self.spi.ier.modify(|_, w| w.txpie().masked());
-                                while self.spi.ier.read().txpie().is_not_masked() {}
                             }
                             Event::Error => {
                                 self.spi.ier.modify(|_, w| {
@@ -670,16 +668,11 @@ macro_rules! spi {
                                         .masked()
                                         .modfie() // Mode fault
                                         .masked()
-                                });
-                                while {
-                                    let r = self.spi.ier.read();
-                                    r.udrie().is_not_masked() ||
-                                    r.ovrie().is_not_masked() ||
-                                    r.crceie().is_not_masked() ||
-                                    r.modfie().is_not_masked()
-                                } {}
+                                })
                             }
                         }
+                        let _ = self.spi.ier.read();
+                        let _ = self.spi.ier.read(); // Delay 2 peripheral clocks
                     }
 
                     /// Return `true` if the TXP flag is set, i.e. new
@@ -712,6 +705,8 @@ macro_rules! spi {
                     /// mode fault has occurred.
                     pub fn clear_modf(&mut self) {
                         self.spi.ifcr.write(|w| w.modfc().clear());
+                        let _ = self.spi.sr.read();
+                        let _ = self.spi.sr.read(); // Delay 2 peripheral clocks
                     }
                 }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -426,7 +426,8 @@ macro_rules! hal {
                         Event::TimeOut => {
                             // Disable update event interrupt
                             self.tim.dier.write(|w| w.uie().clear_bit());
-                            while self.tim.dier.read().uie().bit_is_set() {}
+                            let _ = self.tim.dier.read();
+                            let _ = self.tim.dier.read(); // Delay 2 peripheral clocks
                         }
                     }
                 }
@@ -442,7 +443,8 @@ macro_rules! hal {
                         // Clears timeout event
                         w.uif().clear_bit()
                     });
-                    while self.tim.sr.read().uif().bit_is_set() {}
+                    let _ = self.tim.sr.read();
+                    let _ = self.tim.sr.read(); // Delay 2 peripheral clocks
                 }
 
                 /// Releases the TIM peripheral
@@ -573,8 +575,8 @@ macro_rules! lptim_hal {
                 pub fn reset_counter(&mut self) {
                     // Counter Reset
                     self.tim.cr.write(|w| w.countrst().set_bit().enable().enabled());
-
-                    while self.tim.cr.read().countrst().bit_is_set() {}
+                    let _ = self.tim.cr.read();
+                    let _ = self.tim.cr.read(); // Delay 2 peripheral clocks
                 }
 
                 /// Disables the LPTIM peripheral
@@ -625,7 +627,8 @@ macro_rules! lptim_hal {
                         Event::TimeOut => {
                             // Disable autoreload match interrupt
                             self.tim.ier.modify(|_, w| w.arrmie().clear_bit());
-                            while self.tim.ier.read().arrmie().bit_is_set() {}
+                            let _ = self.tim.ier.read();
+                            let _ = self.tim.ier.read(); // Delay 2 peripheral clocks
                         }
                     }
                 }


### PR DESCRIPTION
If the interrupt pending flag is set quickly multiple times it could be set after the pending flag is cleared but before the clear could be read by the busy wait loop, causing it to loop forever waiting for the pending flag to be cleared again.