### PR TITLE
Better calculations for set_timeout_ticks

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -350,7 +350,7 @@ macro_rules! hal {
                 }
 
                 fn set_timeout_ticks(&mut self, ticks: u32) {
-                    let psc = u16((ticks - 1) / (1 << 16)).unwrap();
+                    let psc = u16(ticks / (1 << 16)).unwrap();
                     self.tim.psc.write(|w| w.psc().bits(psc));
 
                     let arr = u16(ticks / u32(psc + 1)).unwrap();

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -363,7 +363,7 @@ macro_rules! hal {
                 /// timer.set_timeout_ticks(100001);
                 /// ```
                 fn set_timeout_ticks(&mut self, ticks: u32) {
-                    let (psc, arr) = calculate_timout_ticks_register_values(ticks);
+                    let (psc, arr) = calculate_timeout_ticks_register_values(ticks);
                     self.tim.psc.write(|w| w.psc().bits(psc));
                     self.tim.arr.write(|w| unsafe { w.bits(u32(arr)) });
                 }
@@ -480,7 +480,7 @@ macro_rules! hal {
 /// Because every tick is now 4x as long, we need to divide `ticks` by 4 to keep the same timeout.
 ///
 /// This function returns the prescaler register value and auto reload register value.
-fn calculate_timout_ticks_register_values(ticks: u32) -> (u16, u16) {
+fn calculate_timeout_ticks_register_values(ticks: u32) -> (u16, u16) {
     // Note (unwrap): Never panics because 32-bit value is shifted right by 16 bits,
     // resulting in a value that always fits in 16 bits.
     let psc = u16(ticks / (1 << 16)).unwrap();
@@ -770,18 +770,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn timout_ticks_register_values() {
-        assert_eq!(calculate_timout_ticks_register_values(0), (0, 0));
-        assert_eq!(calculate_timout_ticks_register_values(50000), (0, 50000));
-        assert_eq!(calculate_timout_ticks_register_values(100000), (1, 50000));
-        assert_eq!(calculate_timout_ticks_register_values(65535), (0, 65535));
-        assert_eq!(calculate_timout_ticks_register_values(65536), (1, 32768));
+    fn timeout_ticks_register_values() {
+        assert_eq!(calculate_timeout_ticks_register_values(0), (0, 0));
+        assert_eq!(calculate_timeout_ticks_register_values(50000), (0, 50000));
+        assert_eq!(calculate_timeout_ticks_register_values(100000), (1, 50000));
+        assert_eq!(calculate_timeout_ticks_register_values(65535), (0, 65535));
+        assert_eq!(calculate_timeout_ticks_register_values(65536), (1, 32768));
         assert_eq!(
-            calculate_timout_ticks_register_values(1000000),
+            calculate_timeout_ticks_register_values(1000000),
             (15, 62500)
         );
         assert_eq!(
-            calculate_timout_ticks_register_values(u32::MAX),
+            calculate_timeout_ticks_register_values(u32::MAX),
             (u16::MAX, u16::MAX)
         );
     }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -353,7 +353,7 @@ macro_rules! hal {
                     let psc = u16(ticks / (1 << 16)).unwrap();
                     self.tim.psc.write(|w| w.psc().bits(psc));
 
-                    let arr = u16(ticks / u32(psc + 1)).unwrap();
+                    let arr = u16(ticks / (u32(psc) + 1)).unwrap();
                     self.tim.arr.write(|w| unsafe { w.bits(u32(arr)) });
                 }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -363,19 +363,8 @@ macro_rules! hal {
                 /// timer.set_timeout_ticks(100001);
                 /// ```
                 fn set_timeout_ticks(&mut self, ticks: u32) {
-                    // We want to have `ticks` amount of timer ticks before it reloads.
-                    // But `ticks` may have a higher value than what the timer can hold directly.
-                    // So we'll use the prescaler to extend the range.
-
-                    // To know how many times we would overflow with a prescaler of 1, we divide `ticks` by 2^16 (the max amount of ticks per overflow).
-                    // If the result is e.g. 3, then we need to increase our range by 4 times to fit all the ticks.
-                    // We can increase the range enough by setting the prescaler to 3 (which will divide the clock freq by 4).
-                    // Because every tick is now 4x as long, we need to divide `ticks` by 4 to keep the same timeout.
-
-                    let psc = u16(ticks / (1 << 16)).unwrap();
+                    let (psc, arr) = calculate_timout_ticks_register_values(ticks);
                     self.tim.psc.write(|w| w.psc().bits(psc));
-
-                    let arr = u16(ticks / (u32(psc) + 1)).unwrap();
                     self.tim.arr.write(|w| unsafe { w.bits(u32(arr)) });
                 }
 
@@ -479,6 +468,25 @@ macro_rules! hal {
             }
         )+
     }
+}
+
+/// We want to have `ticks` amount of timer ticks before it reloads.
+/// But `ticks` may have a higher value than what the timer can hold directly.
+/// So we'll use the prescaler to extend the range.
+///
+/// To know how many times we would overflow with a prescaler of 1, we divide `ticks` by 2^16 (the max amount of ticks per overflow).
+/// If the result is e.g. 3, then we need to increase our range by 4 times to fit all the ticks.
+/// We can increase the range enough by setting the prescaler to 3 (which will divide the clock freq by 4).
+/// Because every tick is now 4x as long, we need to divide `ticks` by 4 to keep the same timeout.
+///
+/// This function returns the prescaler register value and auto reload register value.
+fn calculate_timout_ticks_register_values(ticks: u32) -> (u16, u16) {
+    // Note (unwrap): Never panics because 32-bit value is shifted right by 16 bits,
+    // resulting in a value that always fits in 16 bits.
+    let psc = u16(ticks / (1 << 16)).unwrap();
+    // Note (unwrap): Never panics because the divisor is always such that the result fits in 16 bits.
+    let arr = u16(ticks / (u32(psc) + 1)).unwrap();
+    (psc, arr)
 }
 
 hal! {
@@ -755,4 +763,26 @@ lptim_hal! {
 lptim_hal! {
     LPTIM4: (lptim4, Lptim4, lptim3),
     LPTIM5: (lptim5, Lptim5, lptim3),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timout_ticks_register_values() {
+        assert_eq!(calculate_timout_ticks_register_values(0), (0, 0));
+        assert_eq!(calculate_timout_ticks_register_values(50000), (0, 50000));
+        assert_eq!(calculate_timout_ticks_register_values(100000), (1, 50000));
+        assert_eq!(calculate_timout_ticks_register_values(65535), (0, 65535));
+        assert_eq!(calculate_timout_ticks_register_values(65536), (1, 32768));
+        assert_eq!(
+            calculate_timout_ticks_register_values(1000000),
+            (15, 62500)
+        );
+        assert_eq!(
+            calculate_timout_ticks_register_values(u32::MAX),
+            (u16::MAX, u16::MAX)
+        );
+    }
 }


### PR DESCRIPTION
Ran into an issue where my devices would crash randomly.
I've dug around and found that when the set_timeout_ticks function gets a ticks value of an exact multiple of 2^16, it will overflow.

Also when `ticks > u32::MAX - u16::MAX`, the `+1` would overflow. I think it was tried to do it in 32 bit, but the parentheses were wrong.

This solves those issues. All psc and arr values remain the same with this change, except that there should be no panics anymore and all ticks values are valid.