### PR TITLE
Add link to BSP's for NUCLEO-H743ZI and Daisy Seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ functionality.
 Board | Manufacturer | BSP / Examples?
 ---|---|---
 [NUCLEO-H743ZI](https://www.st.com/en/evaluation-tools/nucleo-h743zi.html) | ST | [Examples](https://github.com/astraw/nucleo-h743zi)
+[NUCLEO-H745ZI-Q](https://www.st.com/en/evaluation-tools/nucleo-h745zi-q.html) | ST | [BSP](https://github.com/antoinevg/nucleo-h745zi)
 [STM32H743I-EVAL](https://www.st.com/en/evaluation-tools/stm32h743i-eval.html) | ST |
 [STM32H747I-EVAL](https://www.st.com/en/evaluation-tools/stm32h747i-eval.html) | ST |
 [STM32H747I-DISCO](https://www.st.com/en/evaluation-tools/stm32h747i-disco.html) | ST |
-[Daisy Seed](https://www.electro-smith.com/daisy/daisy) | Electrosmith |
+[Daisy Seed](https://www.electro-smith.com/daisy/daisy) | Electrosmith | [BSP](https://github.com/antoinevg/daisy_bsp)
 [Portenta H7](https://store.arduino.cc/portenta-h7) ⚠️ | Arduino |
 [OpenH743I-C](https://www.waveshare.com/openh743i-c-standard.htm) | Waveshare |
 [Toasty](https://www.tindie.com/products/webtronics/toasty-480mhz-stm32-usb-development-board/) | Webtronics |


### PR DESCRIPTION
This pull request updates the README.md file to add links to board support packages for the NUCLEO-H745ZI and Daisy Seed boards.