### PR TITLE
implement fmt::Write for Serial<USART>

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -911,3 +911,13 @@ where
         Ok(())
     }
 }
+
+impl<USART> fmt::Write for Serial<USART>
+where
+    Serial<USART>: serial::Write<u8>,
+{
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let _ = s.as_bytes().iter().map(|c| block!(self.write(*c))).last();
+        Ok(())
+    }
+}


### PR DESCRIPTION
This enables using the `write!` and `writeln!` macros on the full serial
struct. Previously, you would have to `.split()` the full serial struct
and extract the `Tx<USART>` component. (Which remains possible.)