### PR TITLE
Extended SPI with more hardware CS features

### DIFF
--- a/examples/spi_hardware_cs.rs
+++ b/examples/spi_hardware_cs.rs
@@ -60,17 +60,17 @@ fn main() -> ! {
         (sck, miso, mosi, hcs),
         // Create a config with the hardware chip select given
         spi::Config::new(spi::MODE_0)
-                // Put 1 us idle time between every word sent. (the max is 15 spi peripheral ticks)
-                .inter_word_delay(0.000001) 
-                // Specify that we use the hardware cs
-                .hardware_cs(spi::HardwareCS {
-                    // See the docs of the HardwareCSMode to see what the different modes do
-                    mode: spi::HardwareCSMode::EndlessTransaction,
-                    // Put 1 us between the CS being asserted and the first clock
-                    assertion_delay: 0.000001,
-                    // Our CS should be high when not active and low when asserted
-                    polarity: spi::Polarity::IdleHigh,
-                }),
+            // Put 1 us idle time between every word sent. (the max is 15 spi peripheral ticks)
+            .inter_word_delay(0.000001)
+            // Specify that we use the hardware cs
+            .hardware_cs(spi::HardwareCS {
+                // See the docs of the HardwareCSMode to see what the different modes do
+                mode: spi::HardwareCSMode::EndlessTransaction,
+                // Put 1 us between the CS being asserted and the first clock
+                assertion_delay: 0.000001,
+                // Our CS should be high when not active and low when asserted
+                polarity: spi::Polarity::IdleHigh,
+            }),
         3.mhz(),
         ccdr.peripheral.SPI1,
         &ccdr.clocks,

--- a/examples/spi_hardware_cs.rs
+++ b/examples/spi_hardware_cs.rs
@@ -1,0 +1,93 @@
+//! This example shows off how the hardware chip select is implemented in the HAL.
+//!
+//! There are 4 modes:
+//! - Disabled (default)
+//! - EndlessTransaction
+//! - WordTransaction
+//! - FrameTransaction
+//!
+//! For more docs, see https://docs.rs/stm32h7xx-hal/latest/stm32h7xx_hal/spi/index.html
+//!
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::entry;
+#[macro_use]
+mod utilities;
+use stm32h7xx_hal::{pac, prelude::*, spi};
+
+use log::info;
+
+use nb::block;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = example_power!(pwr).freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc
+        .sys_ck(96.mhz())
+        .pll1_q_ck(48.mhz())
+        .freeze(pwrcfg, &dp.SYSCFG);
+
+    // Acquire the GPIOA peripheral. This also enables the clock for
+    // GPIOA in the RCC register.
+    let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
+
+    let sck = gpioa.pa5.into_alternate_af5();
+    let miso = gpioa.pa6.into_alternate_af5();
+    let mosi = gpioa.pa7.into_alternate_af5();
+    // Because we want to use the hardware chip select, we need to provide that too
+    let hcs = gpioa.pa4.into_alternate_af5();
+
+    info!("");
+    info!("stm32h7xx-hal example - SPI");
+    info!("");
+
+    // Initialise the SPI peripheral.
+    let mut spi = dp.SPI1.spi(
+        // Give ownership of the pins
+        (sck, miso, mosi, hcs),
+        // Create a config with the hardware chip select given
+        spi::Config::new(spi::MODE_0)
+                // Put 1 us idle time between every word sent. (the max is 15 spi peripheral ticks)
+                .inter_word_delay(0.000001) 
+                // Specify that we use the hardware cs
+                .hardware_cs(spi::HardwareCS {
+                    // See the docs of the HardwareCSMode to see what the different modes do
+                    mode: spi::HardwareCSMode::EndlessTransaction,
+                    // Put 1 us between the CS being asserted and the first clock
+                    assertion_delay: 0.000001,
+                    // Our CS should be high when not active and low when asserted
+                    polarity: spi::Polarity::IdleHigh,
+                }),
+        3.mhz(),
+        ccdr.peripheral.SPI1,
+        &ccdr.clocks,
+    );
+
+    // Write fixed data.
+    // The CS will automatically be pulled low before the data is sent.
+    // Because the SPI is in EndlessTransaction mode, the CS will never be de-asserted.
+    spi.write(&[0x11u8, 0x22, 0x33]).unwrap();
+
+    // The CS can be de-asserted manually, though
+    spi.end_transaction().unwrap();
+
+    // Echo what is received on the SPI
+    let mut received = 0;
+    loop {
+        block!(spi.send(received)).ok();
+        received = block!(spi.read()).unwrap();
+    }
+}

--- a/examples/spi_send_frames.rs
+++ b/examples/spi_send_frames.rs
@@ -1,0 +1,103 @@
+//! This example shows off the FrameTransaction mode of hardware chip select functionality.
+//!
+//! For more docs, see https://docs.rs/stm32h7xx-hal/latest/stm32h7xx_hal/spi/index.html
+//!
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::entry;
+#[macro_use]
+mod utilities;
+use spi::Spi;
+use stm32h7xx_hal::{pac, prelude::*, spi};
+use core::num::NonZeroU16;
+
+use log::info;
+
+use nb::block;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = example_power!(pwr).freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc
+        .sys_ck(96.mhz())
+        .pll1_q_ck(48.mhz())
+        .freeze(pwrcfg, &dp.SYSCFG);
+
+    // Acquire the GPIOA peripheral. This also enables the clock for
+    // GPIOA in the RCC register.
+    let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
+
+    let sck = gpioa.pa5.into_alternate_af5();
+    let miso = gpioa.pa6.into_alternate_af5();
+    let mosi = gpioa.pa7.into_alternate_af5();
+    // Because we want to use the hardware chip select, we need to provide that too
+    let hcs = gpioa.pa4.into_alternate_af5();
+
+    info!("");
+    info!("stm32h7xx-hal example - SPI");
+    info!("");
+
+    // Initialise the SPI peripheral.
+    let mut spi: Spi<_, _, u8> = dp.SPI1.spi(
+        // Give ownership of the pins
+        (sck, miso, mosi, hcs),
+        // Create a config with the hardware chip select given
+        spi::Config::new(spi::MODE_0)
+                // Put 1 us idle time between every word sent
+                .inter_word_delay(0.000001) 
+                // Specify that we use the hardware cs
+                .hardware_cs(spi::HardwareCS {
+                    // See the docs of the HardwareCSMode to see what the different modes do
+                    mode: spi::HardwareCSMode::FrameTransaction,
+                    // Put 1 us between the CS being asserted and the first clock
+                    assertion_delay: 0.000001,
+                    // Our CS should be high when not active and low when asserted
+                    polarity: spi::Polarity::IdleHigh,
+                }),
+        3.mhz(),
+        ccdr.peripheral.SPI1,
+        &ccdr.clocks,
+    );
+
+    // We want to send a frame of three bytes.
+    // This means that the CS should be asserted, three words should be sent and the CS should be de-asserted.
+    // To do this, it takes a bit more management.
+
+    // Prepare sending the frame
+    spi.setup_transaction(NonZeroU16::new(3).unwrap()).unwrap();
+
+    // Write fixed data.
+    // The CS will automatically be pulled low before the data is sent and de-assert after the sending is done.
+    for word in &[0x11u8, 0x22, 0x33] {
+        block!(spi.send(*word)).unwrap();
+    }
+
+    // The way that the silicon works, we also need to clean up some flags.
+    // If we don't, then the SPI will silently swallow any data you want to send.
+    // So in this example that would have meant that if we also called send with a fourth byte,
+    // that byte would've simply not been sent
+    spi.end_transaction().unwrap();
+
+
+    // When in this mode, the blocking embedded-hal interface already does this for us.
+    // For example if we want to send two separate frames of different lengths, we can do this:
+    spi.write(&[0, 1, 2]).unwrap();
+    spi.write(&[0, 1, 2, 3, 4, 5, 6]).unwrap();
+
+    loop {
+        cortex_m::asm::nop();
+    }
+}

--- a/examples/spi_send_frames.rs
+++ b/examples/spi_send_frames.rs
@@ -10,9 +10,9 @@
 use cortex_m_rt::entry;
 #[macro_use]
 mod utilities;
+use core::num::NonZeroU16;
 use spi::Spi;
 use stm32h7xx_hal::{pac, prelude::*, spi};
-use core::num::NonZeroU16;
 
 use log::info;
 
@@ -56,17 +56,17 @@ fn main() -> ! {
         (sck, miso, mosi, hcs),
         // Create a config with the hardware chip select given
         spi::Config::new(spi::MODE_0)
-                // Put 1 us idle time between every word sent
-                .inter_word_delay(0.000001) 
-                // Specify that we use the hardware cs
-                .hardware_cs(spi::HardwareCS {
-                    // See the docs of the HardwareCSMode to see what the different modes do
-                    mode: spi::HardwareCSMode::FrameTransaction,
-                    // Put 1 us between the CS being asserted and the first clock
-                    assertion_delay: 0.000001,
-                    // Our CS should be high when not active and low when asserted
-                    polarity: spi::Polarity::IdleHigh,
-                }),
+            // Put 1 us idle time between every word sent
+            .inter_word_delay(0.000001)
+            // Specify that we use the hardware cs
+            .hardware_cs(spi::HardwareCS {
+                // See the docs of the HardwareCSMode to see what the different modes do
+                mode: spi::HardwareCSMode::FrameTransaction,
+                // Put 1 us between the CS being asserted and the first clock
+                assertion_delay: 0.000001,
+                // Our CS should be high when not active and low when asserted
+                polarity: spi::Polarity::IdleHigh,
+            }),
         3.mhz(),
         ccdr.peripheral.SPI1,
         &ccdr.clocks,
@@ -90,7 +90,6 @@ fn main() -> ! {
     // So in this example that would have meant that if we also called send with a fourth byte,
     // that byte would've simply not been sent
     spi.end_transaction().unwrap();
-
 
     // When in this mode, the blocking embedded-hal interface already does this for us.
     // For example if we want to send two separate frames of different lengths, we can do this:

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -65,7 +65,9 @@ use crate::stm32::rcc::{cdccip1r as ccip1r, srdccipr};
 use crate::stm32::rcc::{d2ccip1r as ccip1r, d3ccipr as srdccipr};
 
 use crate::stm32;
-use crate::stm32::spi1::{cfg1::MBR_A as MBR, cfg2::COMM_A as COMM, cfg2::SSIOP_A as SSIOP};
+use crate::stm32::spi1::{
+    cfg1::MBR_A as MBR, cfg2::COMM_A as COMM, cfg2::SSIOP_A as SSIOP,
+};
 use core::convert::From;
 use core::marker::PhantomData;
 use core::ptr;
@@ -646,7 +648,7 @@ macro_rules! spi {
                     }
 
                     /// Sets up a frame transaction with the given amount of data words.
-                    /// 
+                    ///
                     /// If this is called when the hardware CS mode is not [HardwareCSMode::FrameTransaction],
                     /// then an error is returned with [Error::InvalidCall].
                     ///
@@ -937,7 +939,7 @@ macro_rules! spi {
                         if matches!(self.hardware_cs_mode, HardwareCSMode::FrameTransaction) {
                             const MAX_WORDS: usize = 0xFFFF;
 
-                            // Can we send 
+                            // Can we send
                             if words.len() > MAX_WORDS {
                                 return Err(Error::BufferTooBig { max_size: MAX_WORDS });
                             }
@@ -958,7 +960,7 @@ macro_rules! spi {
                             // Clean up
                             self.end_transaction()?;
                         }
-            
+
                         Ok(words)
                     }
                 }
@@ -977,7 +979,7 @@ macro_rules! spi {
                         if matches!(self.hardware_cs_mode, HardwareCSMode::FrameTransaction) {
                             const MAX_WORDS: usize = 0xFFFF;
 
-                            // Can we send 
+                            // Can we send
                             if words.len() > MAX_WORDS {
                                 return Err(Error::BufferTooBig { max_size: MAX_WORDS });
                             }
@@ -998,7 +1000,7 @@ macro_rules! spi {
                             // Clean up
                             self.end_transaction()?;
                         }
-            
+
                         Ok(())
                     }
                 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -563,20 +563,13 @@ macro_rules! spi {
                                 inter_word_delay += 1;
                             }
 
-                            if assertion_delay > 0xF {
-                                assertion_delay = 0xF;
-                            }
-                            if inter_word_delay > 0xF {
-                                inter_word_delay = 0xF;
-                            }
-
                             // If CS suspends while data is inactive, we also require an
                             // "inter-data" delay.
                             if matches!(config.hardware_cs.mode, HardwareCSMode::WordTransaction) {
                                 inter_word_delay = inter_word_delay.max(1);
                             }
 
-                            (assertion_delay as u8, inter_word_delay as u8)
+                            (assertion_delay.min(0xF) as u8, inter_word_delay.min(0xF) as u8)
                         };
 
                         // The calculated cycle delay may not be more than 4 bits wide for the
@@ -932,11 +925,11 @@ macro_rules! spi {
                         // Are we in frame mode?
                         if matches!(self.hardware_cs_mode, HardwareCSMode::FrameTransaction) {
                             const MAX_BITS: usize = 0xFFFF;
-                            let bits = words.len() * core::mem::size_of::<$TY>();
+                            let bits = words.len() * (core::mem::size_of::<$TY>() * 8);
 
                             // Can we send 
                             if bits > MAX_BITS {
-                                return Err(Error::BufferTooBig { max_size: MAX_BITS / core::mem::size_of::<$TY>() });
+                                return Err(Error::BufferTooBig { max_size: MAX_BITS / (core::mem::size_of::<$TY>() * 8) });
                             }
 
                             // Setup that we're going to send this amount of bits
@@ -973,11 +966,11 @@ macro_rules! spi {
                         // Are we in frame mode?
                         if matches!(self.hardware_cs_mode, HardwareCSMode::FrameTransaction) {
                             const MAX_BITS: usize = 0xFFFF;
-                            let bits = words.len() * core::mem::size_of::<$TY>();
+                            let bits = words.len() * (core::mem::size_of::<$TY>() * 8);
 
                             // Can we send 
                             if bits > MAX_BITS {
-                                return Err(Error::BufferTooBig { max_size: MAX_BITS / core::mem::size_of::<$TY>() });
+                                return Err(Error::BufferTooBig { max_size: MAX_BITS / (core::mem::size_of::<$TY>() * 8) });
                             }
 
                             // Setup that we're going to send this amount of bits


### PR DESCRIPTION
The hardware CS now comes in 4 specific modes that are setup in the config:

- Disabled
- EndlessTransaction
- WordTransaction
- FrameTransaction

New here is the frame transaction where `TSIZE` is used to send frames of a specific length.
There's now also `end_transaction` that is useful for endless and mandatory for frame transactions.

The blocking implementation now checks if we're in frame mode and will send frames when we are.

I don't have a nice dev board, so all testing was with an oscilloscope with the probe manually held to the pins. So I couldn't check everything as good as I'd like, but it should all work from what I could see.