### PR TITLE
Updating smoltcp dependency features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ embedded-display-controller = { version = "^0.1.0", optional = true }
 [dependencies.smoltcp]
 version = "0.7.0"
 default-features = false
-features = ["ethernet", "proto-ipv4"]
+features = ["ethernet", "proto-ipv4", "socket-raw"]
 optional = true
 
 [dependencies.chrono]


### PR DESCRIPTION
This PR fixes #220 by using a valid feature set for the `smoltcp` dependency. The existing feature set was invalid, but worked because of a Cargo bug that caused the `dev-dependencies` feature to unify with the normal features.