### PR TITLE
Initial OCTOSPI and QUADSPI memories support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - stm32h7b0
           - stm32h735
     env:                        # Peripheral Feature flags
-      FLAGS: rt,quadspi,sdmmc,fmc,usb_hs,rtc,ethernet,ltdc,crc
+      FLAGS: rt,xspi,sdmmc,fmc,usb_hs,rtc,ethernet,ltdc,crc
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
           - log-semihost
           - log-rtt
     env:                        # Peripheral Feature flags
-      FLAGS: rt,quadspi,sdmmc,fmc,usb_hs,rtc,ethernet,ltdc,crc
+      FLAGS: rt,xspi,sdmmc,fmc,usb_hs,rtc,ethernet,ltdc,crc
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 * spi: Add more hardware CS features #216
 * timers: Better calculations for `set_timeout_ticks` #208
 
+* **Breaking**: Rename the `quadspi` flag to `xspi`
+
 ## [v0.9.0] 2021-03-12
 
 * Updates `cortex-m` to v0.7.1. `cortex-m` v0.6.5+ [are forward compatible with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,10 @@ name = "qspi"
 required-features = ["xspi", "rm0433"]
 
 [[example]]
+name = "qspi_mdma"
+required-features = ["xspi", "rm0433"]
+
+[[example]]
 name = "octospi"
 required-features = ["xspi", "rm0468"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,8 +148,8 @@ name = "qspi"
 required-features = ["xspi", "rm0433"]
 
 [[example]]
-name = "qspi_mdma"
-required-features = ["quadspi", "rm0433"]
+name = "octospi"
+required-features = ["xspi", "rm0468"]
 
 [[example]]
 name = "sdmmc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ cm4 = []
 cm7 = []
 smps = []
 ltdc = ["embedded-display-controller"]
-quadspi = []
+xspi = []
 fmc = ["stm32-fmc"]
 sdmmc = ["sdio-host"]
 sdmmc-fatfs = ["embedded-sdmmc", "sdmmc"]
@@ -145,7 +145,7 @@ required-features = ["fmc", "rm0399"]
 
 [[example]]
 name = "qspi"
-required-features = ["quadspi", "rm0433"]
+required-features = ["xspi", "rm0433"]
 
 [[example]]
 name = "qspi_mdma"

--- a/examples/octospi.rs
+++ b/examples/octospi.rs
@@ -1,0 +1,98 @@
+//! OCTOSPI peripheral example in indirect mode
+//!
+//! Tested on a STM32H735G-DK with a Macronix MX25LM51245GXDI00
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+#[macro_use]
+mod utilities;
+
+use cortex_m_rt::entry;
+use stm32h7xx_hal::rcc::rec::{OctospiClkSel, OctospiClkSelGetter};
+use stm32h7xx_hal::{
+    pac, prelude::*, xspi::OctospiMode, xspi::OctospiWord as XW,
+};
+
+use log::info;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = example_power!(pwr).freeze();
+
+    // Constrain and Freeze clock
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(96.mhz()).freeze(pwrcfg, &dp.SYSCFG);
+
+    // Octospi from HCLK at 48MHz
+    assert_eq!(ccdr.clocks.hclk().0, 48_000_000);
+    assert_eq!(
+        ccdr.peripheral.OCTOSPI1.get_kernel_clk_mux(),
+        OctospiClkSel::RCC_HCLK3
+    );
+
+    // Acquire the GPIO peripherals. This also enables the clock for
+    // the GPIOs in the RCC register.
+    let gpiog = dp.GPIOG.split(ccdr.peripheral.GPIOG);
+    let gpiod = dp.GPIOD.split(ccdr.peripheral.GPIOD);
+    let gpioe = dp.GPIOE.split(ccdr.peripheral.GPIOE);
+    let gpiof = dp.GPIOF.split(ccdr.peripheral.GPIOF);
+
+    let _ncs = gpiog.pg6.into_alternate_af10();
+    let _clk = gpiof.pf10.into_alternate_af9();
+    let _io0 = gpiod.pd11.into_alternate_af9();
+    let _io1 = gpiod.pd12.into_alternate_af9();
+    let _io2 = gpioe.pe2.into_alternate_af9();
+    let _io3 = gpiod.pd13.into_alternate_af9();
+    let _io4 = gpiod.pd4.into_alternate_af10();
+    let _io5 = gpiod.pd5.into_alternate_af10();
+    let _io6 = gpiog.pg9.into_alternate_af9();
+    let _io7 = gpiod.pd7.into_alternate_af10();
+
+    info!("");
+    info!("stm32h7xx-hal example - OCTOSPI");
+    info!("");
+
+    // Initialise the OCTOSPI peripheral.
+    let mut octospi = dp.OCTOSPI1.octospi_unchecked(
+        12.mhz(),
+        &ccdr.clocks,
+        ccdr.peripheral.OCTOSPI1,
+    );
+
+    octospi.configure_mode(OctospiMode::OneBit).unwrap();
+
+    // RDID Read Identification. Abuses address as instruction phase, but that
+    // works in SPI mode.
+    let mut read: [u8; 3] = [0; 3];
+    octospi.read(0x9F, &mut read).unwrap();
+    info!("Read with instruction 0x9F : {:x?}", read);
+
+    // Switch Macronix MX25LM51245GXDI00 to SDR OPI
+    // Set WREN bit
+    octospi
+        .write_extended(XW::U8(0x06), XW::None, XW::None, &[])
+        .unwrap();
+    // Write Configuration Register 2
+    octospi
+        .write_extended(XW::U8(0x72), XW::U32(0), XW::None, &[1])
+        .unwrap();
+    // Change bus mode
+    octospi.configure_mode(OctospiMode::EightBit).unwrap();
+
+    // RDID Read Identification
+    let mut read: [u8; 3] = [0; 3];
+    octospi
+        .read_extended(XW::U16(0x9F60), XW::U32(0), XW::None, 4, &mut read)
+        .unwrap();
+
+    info!("Read with instruction 0x9F60 : {:x?}", read);
+
+    loop {}
+}

--- a/examples/qspi.rs
+++ b/examples/qspi.rs
@@ -6,7 +6,7 @@
 mod utilities;
 
 use cortex_m_rt::entry;
-use stm32h7xx_hal::{pac, prelude::*, qspi::QspiMode};
+use stm32h7xx_hal::{pac, prelude::*, xspi::QspiMode};
 
 use log::info;
 

--- a/examples/qspi_mdma.rs
+++ b/examples/qspi_mdma.rs
@@ -13,7 +13,7 @@ mod utilities;
 use core::mem;
 
 use cortex_m_rt::entry;
-use stm32h7xx_hal::{pac, prelude::*, qspi, qspi::QspiMode};
+use stm32h7xx_hal::{pac, prelude::*, xspi, xspi::QspiMode};
 
 use stm32h7xx_hal::dma::{
     mdma::{
@@ -57,7 +57,7 @@ fn main() -> ! {
     info!("stm32h7xx-hal example - QSPI with MDMA");
     info!("");
 
-    let config: qspi::Config = 1.mhz().into();
+    let config: xspi::Config = 1.mhz().into();
     // Threshold when half full
     let config = config.fifo_threshold(16);
 

--- a/src/dma/mdma.rs
+++ b/src/dma/mdma.rs
@@ -1255,3 +1255,18 @@ peripheral_target_address!(
     (INNER: crate::xspi::Qspi<pac::QUADSPI>, dr, u32, P2M),
     (INNER: crate::xspi::Qspi<pac::QUADSPI>, dr, u32, M2P),
 );
+
+#[cfg(any(feature = "rm0468"))] // TODO feature = "rm0455"
+peripheral_target_address!(
+    (pac::OCTOSPI1, dr, u32, P2M),
+    (pac::OCTOSPI1, dr, u32, M2P),
+    (pac::OCTOSPI2, dr, u32, P2M),
+    (pac::OCTOSPI2, dr, u32, M2P),
+);
+#[cfg(all(feature = "xspi", any(feature = "rm0468")))] // TODO feature = "rm0455"
+peripheral_target_address!(
+    (INNER: crate::xspi::Octospi<pac::OCTOSPI1>, dr, u32, P2M),
+    (INNER: crate::xspi::Octospi<pac::OCTOSPI1>, dr, u32, M2P),
+    (INNER: crate::xspi::Octospi<pac::OCTOSPI2>, dr, u32, P2M),
+    (INNER: crate::xspi::Octospi<pac::OCTOSPI2>, dr, u32, M2P),
+);

--- a/src/dma/mdma.rs
+++ b/src/dma/mdma.rs
@@ -1250,8 +1250,8 @@ peripheral_target_address!(
     (pac::QUADSPI, dr, u32, P2M),
     (pac::QUADSPI, dr, u32, M2P),
 );
-#[cfg(all(feature = "quadspi", any(feature = "rm0433", feature = "rm0399")))]
+#[cfg(all(feature = "xspi", any(feature = "rm0433", feature = "rm0399")))]
 peripheral_target_address!(
-    (INNER: crate::qspi::Qspi, dr, u32, P2M),
-    (INNER: crate::qspi::Qspi, dr, u32, M2P),
+    (INNER: crate::xspi::Qspi<pac::QUADSPI>, dr, u32, P2M),
+    (INNER: crate::xspi::Qspi<pac::QUADSPI>, dr, u32, M2P),
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! * [Serial Peripheral Interface (SPI)](crate::spi)
 //! * [Serial Data (USART/UART)](crate::serial)
 //! * [Serial Audio Interface](crate::sai)
-//! * [Quad SPI](crate::qspi) Feature gate `quadspi`
+//! * [Quad or Octo SPI](crate::xspi) Feature gate `xspi`
 //! * [Ethernet](crate::ethernet) Feature gate `ethernet`
 //! * [USB HS](crate::usb_hs) Feature gate `usb_hs`
 //! * [LCD-TFT Display Controller](crate::ltdc) Feature gate `ldtc`
@@ -174,12 +174,6 @@ pub mod pwm;
 pub mod pwr;
 #[cfg(feature = "device-selected")]
 pub mod qei;
-#[cfg(all(
-    feature = "device-selected",
-    feature = "quadspi",
-    not(any(feature = "rm0455", feature = "rm0468"))
-))]
-pub mod qspi;
 #[cfg(feature = "device-selected")]
 pub mod rcc;
 #[cfg(feature = "device-selected")]
@@ -204,3 +198,5 @@ pub mod timer;
 pub mod usb_hs;
 #[cfg(feature = "device-selected")]
 pub mod watchdog;
+#[cfg(all(feature = "device-selected", feature = "xspi"))]
+pub mod xspi;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,11 +15,6 @@ pub use crate::i2c::I2cExt as _stm32h7xx_hal_i2c_I2cExt;
 pub use crate::pwm::PwmAdvExt as _stm32_hal_pwm_PwmAdvExt;
 pub use crate::pwm::PwmExt as _stm32_hal_pwm_PwmExt;
 pub use crate::pwr::PwrExt as _stm32h7xx_hal_pwr_PwrExt;
-#[cfg(all(
-    feature = "quadspi",
-    not(any(feature = "rm0455", feature = "rm0468"))
-))]
-pub use crate::qspi::QspiExt as _stm32h7xx_hal_qspi_QspiExt;
 pub use crate::rcc::RccExt as _stm32h7xx_hal_rcc_RccExt;
 pub use crate::rng::RngCore as _stm32h7xx_hal_rng_RngCore;
 pub use crate::rng::RngExt as _stm32h7xx_hal_rng_RngExt;
@@ -30,3 +25,5 @@ pub use crate::serial::SerialExt as _stm32h7xx_hal_serial_SerialExt;
 pub use crate::spi::SpiExt as _stm32h7xx_hal_spi_SpiExt;
 pub use crate::time::U32Ext as _stm32h7xx_hal_time_U32Ext;
 pub use crate::timer::TimerExt as _stm32h7xx_hal_timer_TimerExt;
+#[cfg(all(feature = "xspi"))]
+pub use crate::xspi::XspiExt as _stm32h7xx_hal_xspi_XspiExt;

--- a/src/xspi/mod.rs
+++ b/src/xspi/mod.rs
@@ -373,13 +373,21 @@ mod common {
             }
 
             pub(super) fn get_clock(clocks: &CoreClocks) -> Option<Hertz> {
-                let d1ccipr = unsafe { (*stm32::RCC::ptr()).d1ccipr.read() };
+                #[cfg(not(feature = "rm0455"))]
+                use stm32::rcc::d1ccipr as ccipr;
+                #[cfg(feature = "rm0455")]
+                use stm32::rcc::cdccipr as ccipr;
 
-                match d1ccipr.$ccip().variant() {
-                    stm32::rcc::d1ccipr::[< $ccip:upper _A >]::RCC_HCLK3 => Some(clocks.hclk()),
-                    stm32::rcc::d1ccipr::[< $ccip:upper _A >]::PLL1_Q => clocks.pll1_q_ck(),
-                    stm32::rcc::d1ccipr::[< $ccip:upper _A >]::PLL2_R => clocks.pll2_r_ck(),
-                    stm32::rcc::d1ccipr::[< $ccip:upper _A >]::PER => clocks.per_ck(),
+                #[cfg(not(feature = "rm0455"))]
+                let ccipr = unsafe { (*stm32::RCC::ptr()).d1ccipr.read() };
+                #[cfg(feature = "rm0455")]
+                let ccipr = unsafe { (*stm32::RCC::ptr()).cdccipr.read() };
+
+                match ccipr.$ccip().variant() {
+                    ccipr::[< $ccip:upper _A >]::RCC_HCLK3 => Some(clocks.hclk()),
+                    ccipr::[< $ccip:upper _A >]::PLL1_Q => clocks.pll1_q_ck(),
+                    ccipr::[< $ccip:upper _A >]::PLL2_R => clocks.pll2_r_ck(),
+                    ccipr::[< $ccip:upper _A >]::PER => clocks.per_ck(),
                 }
             }
 
@@ -795,7 +803,7 @@ mod common {
     #[cfg(any(feature = "rm0433", feature = "rm0399"))]
     xspi_impl! { stm32::QUADSPI, rec::Qspi, qspisel }
 
-    #[cfg(any(feature = "rm0455", feature = "rm0468"))]
+    #[cfg(any(feature = "rm0468"))] // TODO feature = "rm0455"
     xspi_impl! { stm32::OCTOSPI1, rec::Octospi1, octospisel }
     #[cfg(any(feature = "rm0455", feature = "rm0468"))]
     xspi_impl! { stm32::OCTOSPI2, rec::Octospi2, octospisel }

--- a/src/xspi/mod.rs
+++ b/src/xspi/mod.rs
@@ -1,0 +1,541 @@
+//! Quad or Octo SPI bus
+//!
+//! STM32H7 parts support either Quad or Octo SPI using dedicated peripheral(s).
+//!
+//! | Interface | Parts | # IO lines |
+//! | --- | --- | --- |
+//! | Quad Spi | H742/743/750/753/747/757 | 1-bit, 2-bit or 4-bit |
+//! | Octo Spi | H725/735/7a3/7b0/7b3 | 1-bit, 2-bit, 4-bit or 8-bit |
+//!
+//! # Usage
+//!
+//! This driver supports using the xSPI peripheral in indirect mode. This allows
+//! the peripheral to be used to read and write from an address over a
+//! SPI/QUADSPI/OCTOSPI interface.
+//!
+//! The QUADSPI interface can be configured to operate on either of the two
+//! available banks.
+//!
+//! ```
+//! use stm32h7xx_hal::xspi;
+//!
+//! // Get the device peripherals and instantiate IO pins.
+//! let dp = ...;
+//! let (sck, io0, io1, io2, io3) = ...;
+//!
+//! let mut qspi = dp.QUADSPI.bank1((sck, io0, io1, io2, io3), 3.mhz(), &ccdr.clocks,
+//!                                 ccdr.peripheral.QSPI);
+//!
+//! // Configure QSPI to operate in 4-bit mode.
+//! qspi.configure_mode(xspi::QspiMode::FourBit).unwrap();
+//!
+//! // Write data to address 0x00 on the QSPI interface.
+//! qspi.write(0x00, &[0xAB, 0xCD]).unwrap();
+//! ```
+//!
+//! # Limitations
+//!
+//! This driver currently only supports indirect operation mode of the xSPI
+//! interface. Automatic polling or memory-mapped modes are not supported.
+
+// Parts of the Quad and Octo SPI support are shared (this file), but they are
+// different enough to require different initialisation routines and pin
+// allocations (for example). The Octospi peripheral appears to be 'loosly'
+// based upon the (older?) Quadspi peripheral
+
+// Quadspi
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
+mod qspi;
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
+pub use common::{
+    Bank, Xspi as Qspi, XspiError as QspiError, XspiMode as QspiMode,
+};
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
+pub use qspi::QspiExt as XspiExt;
+
+// Octospi
+#[cfg(any(feature = "rm0455", feature = "rm0468"))]
+mod octospi;
+#[cfg(any(feature = "rm0455", feature = "rm0468"))]
+pub use common::{
+    Xspi as Octospi, XspiError as OctospiError, XspiMode as OctospiMode,
+};
+#[cfg(any(feature = "rm0455", feature = "rm0468"))]
+pub use octospi::OctospiExt as XspiExt;
+
+// Both
+pub use common::{AddressSize, Config, Event, SamplingEdge};
+
+/// This modulate contains functionality common to both Quad and Octo SPI
+mod common {
+    use crate::{
+        rcc::{rec, CoreClocks},
+        stm32,
+        time::Hertz,
+    };
+    use core::{marker::PhantomData, ptr};
+
+    /// Represents operation modes of the XSPI interface.
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub enum XspiMode {
+        /// Only a single IO line (IO0) is used for transmit and a separate line
+        /// (IO1) is used for receive.
+        OneBit,
+
+        /// Two IO lines (IO0 and IO1) are used for transmit/receive.
+        TwoBit,
+
+        /// Four IO lines are used for transmit/receive.
+        FourBit,
+
+        #[cfg(any(feature = "rm0455", feature = "rm0468"))]
+        /// Eight IO lines are used for transmit/receive.
+        EightBit,
+    }
+    impl XspiMode {
+        pub(super) fn reg_value(&self) -> u8 {
+            match self {
+                XspiMode::OneBit => 1,
+                XspiMode::TwoBit => 2,
+                XspiMode::FourBit => 3,
+                #[cfg(any(feature = "rm0455", feature = "rm0468"))]
+                XspiMode::EightBit => 4,
+            }
+        }
+    }
+    /// Indicates an error with the XSPI peripheral.
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub enum XspiError {
+        Busy,
+        Underflow,
+    }
+
+    /// Address sizes used by the XSPI interface
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub enum AddressSize {
+        EightBit,
+        SixteenBit,
+        TwentyFourBit,
+        ThirtyTwoBit,
+    }
+
+    /// Sampling mode for the XSPI interface
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub enum SamplingEdge {
+        Falling,
+        Rising,
+    }
+
+    /// Interrupt events
+    #[derive(Copy, Clone, PartialEq)]
+    pub enum Event {
+        /// FIFO Threashold
+        FIFOThreashold,
+        /// Transfer complete
+        Complete,
+        /// Tranfer error
+        Error,
+    }
+
+    /// Indicates a specific QUADSPI bank to use
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub enum Bank {
+        One,
+        Two,
+        Dual,
+    }
+    // Banks are not supported by the Octospi peripheral (there's two Octospi
+    // peripherals instead)
+
+    /// A structure for specifying the XSPI configuration.
+    ///
+    /// This structure uses builder semantics to generate the configuration.
+    ///
+    /// ```
+    /// let config = Config::new().dummy_cycles(1);
+    /// ```
+    #[derive(Copy, Clone)]
+    pub struct Config {
+        pub(super) mode: XspiMode,
+        pub(super) frequency: Hertz,
+        pub(super) address_size: AddressSize,
+        pub(super) dummy_cycles: u8,
+        pub(super) sampling_edge: SamplingEdge,
+        pub(super) fifo_threshold: u8,
+    }
+
+    impl Config {
+        /// Create a default configuration for the XSPI interface.
+        ///
+        /// * Bus in 1-bit Mode
+        /// * 8-bit Address
+        /// * No dummy cycle
+        /// * Sample on falling edge
+        pub fn new<T: Into<Hertz>>(freq: T) -> Self {
+            Config {
+                mode: XspiMode::OneBit,
+                frequency: freq.into(),
+                address_size: AddressSize::EightBit,
+                dummy_cycles: 0,
+                sampling_edge: SamplingEdge::Falling,
+                fifo_threshold: 1,
+            }
+        }
+
+        /// Specify the operating mode of the XSPI bus. Can be 1-bit, 2-bit or
+        /// 4-bit for Quadspi; 1-bit, 2-bit, 4-bit or 8-bit for Octospi.
+        ///
+        /// The operating mode can also be changed using the
+        /// [`configure_mode`](Xspi#method.configure_mode) method
+        pub fn mode(mut self, mode: XspiMode) -> Self {
+            self.mode = mode;
+            self
+        }
+
+        /// Specify the size of the address phase
+        pub fn address_size(mut self, address_size: AddressSize) -> Self {
+            self.address_size = address_size;
+            self
+        }
+
+        /// Specify the number of dummy cycles in between the address and data
+        /// phases.
+        ///
+        /// Hardware supports 0-31 dummy cycles.
+        ///
+        /// # Note
+        ///
+        /// With zero dummy cycles, the QUADSPI peripheral will erroneously drive the
+        /// output pins for an extra half clock cycle before IO is swapped from
+        /// output to input. Refer to
+        /// https://github.com/quartiq/stabilizer/issues/101 for more information.
+        pub fn dummy_cycles(mut self, cycles: u8) -> Self {
+            debug_assert!(
+                cycles < 32,
+                "Hardware only supports 0-31 dummy cycles"
+            );
+
+            self.dummy_cycles = cycles;
+            self
+        }
+
+        /// Specify the sampling edge for the XSPI receiver.
+        ///
+        /// # Note
+        ///
+        /// If zero dummy cycles are used, during read operations the QUADSPI
+        /// peripheral will erroneously drive the output pins for an extra half
+        /// clock cycle before IO is swapped from output to input. Refer to
+        /// https://github.com/quartiq/stabilizer/issues/101 for more information.
+        ///
+        /// In this case it is recommended to sample on the falling edge. Although
+        /// this doesn't stop the possible bus contention, delaying the sampling
+        /// point by an extra half cycle results in a sampling point after the bus
+        /// contention.
+        pub fn sampling_edge(mut self, sampling_edge: SamplingEdge) -> Self {
+            self.sampling_edge = sampling_edge;
+            self
+        }
+
+        /// Specify the number of bytes in the FIFO that will set the FIFO threshold
+        /// flag. Must be in the range 1-32 inclusive.
+        ///
+        /// In indirect write mode, this is the number of free bytes that will raise
+        /// the FIFO threshold flag.
+        ///
+        /// In indirect read mode, this is the number of valid pending bytes that
+        /// will raise the FIFO threshold flag.
+        pub fn fifo_threshold(mut self, threshold: u8) -> Self {
+            debug_assert!(threshold > 0 && threshold <= 32);
+
+            self.fifo_threshold = threshold;
+            self
+        }
+    }
+
+    impl<T: Into<Hertz>> From<T> for Config {
+        fn from(frequency: T) -> Self {
+            Self::new(frequency)
+        }
+    }
+
+    /// Generic type for Quad or Octo SPI
+    pub struct Xspi<XSPI> {
+        pub(super) rb: XSPI,
+    }
+
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
+    macro_rules! fmode_reg {
+        ($e:expr) => {
+            $e.rb.ccr
+        };
+    }
+    #[cfg(any(feature = "rm0455", feature = "rm0468"))]
+    macro_rules! fmode_reg {
+        ($e:expr) => {
+            $e.rb.cr
+        };
+    }
+
+    // This macro uses the paste::item! macro to create identifiers.
+    //
+    // https://crates.io/crates/paste
+    macro_rules! xspi_impl {
+        ($peripheral:expr, $rec:expr, $ccip:ident) => {
+    paste::item! {
+        impl Xspi<$peripheral> {
+            /// Deconstructs the XSPI HAL and returns the component parts
+            pub fn free(self) -> ($peripheral, $rec) {
+                (
+                    self.rb,
+                    $rec {
+                        _marker: PhantomData,
+                    },
+                )
+            }
+
+            /// Returns a reference to the inner peripheral
+            pub fn inner(&self) -> &$peripheral {
+                &self.rb
+            }
+
+            /// Returns a mutable reference to the inner peripheral
+            pub fn inner_mut(&mut self) -> &mut $peripheral {
+                &mut self.rb
+            }
+
+            /// Check if the XSPI peripheral is currently busy with a
+            /// transaction
+            pub fn is_busy(&self) -> bool {
+                self.rb.sr.read().busy().bit_is_set()
+            }
+
+            /// Enable interrupts for the given `event`
+            pub fn listen(&mut self, event: Event) {
+                self.rb.cr.modify(|_, w| match event {
+                    Event::FIFOThreashold => w.ftie().set_bit(),
+                    Event::Complete => w.tcie().set_bit(),
+                    Event::Error => w.teie().set_bit(),
+                });
+            }
+
+            /// Disable interrupts for the given `event`
+            pub fn unlisten(&mut self, event: Event) {
+                self.rb.cr.modify(|_, w| match event {
+                    Event::FIFOThreashold => w.ftie().clear_bit(),
+                    Event::Complete => w.tcie().clear_bit(),
+                    Event::Error => w.teie().clear_bit(),
+                });
+                let _ = self.rb.cr.read();
+                let _ = self.rb.cr.read(); // Delay 2 peripheral clocks
+            }
+
+            pub(super) fn get_clock(clocks: &CoreClocks) -> Option<Hertz> {
+                let d1ccipr = unsafe { (*stm32::RCC::ptr()).d1ccipr.read() };
+
+                match d1ccipr.$ccip().variant() {
+                    stm32::rcc::d1ccipr::[< $ccip:upper _A >]::RCC_HCLK3 => Some(clocks.hclk()),
+                    stm32::rcc::d1ccipr::[< $ccip:upper _A >]::PLL1_Q => clocks.pll1_q_ck(),
+                    stm32::rcc::d1ccipr::[< $ccip:upper _A >]::PLL2_R => clocks.pll2_r_ck(),
+                    stm32::rcc::d1ccipr::[< $ccip:upper _A >]::PER => clocks.per_ck(),
+                }
+            }
+
+            /// Configure the operational mode of the XSPI interface.
+            ///
+            /// # Args
+            /// * `mode` - The newly desired mode of the interface.
+            ///
+            /// # Errors
+            /// Returns XspiError::Busy if an operation is ongoing
+            pub fn configure_mode(&mut self, mode: XspiMode) -> Result<(), XspiError> {
+                if self.is_busy() {
+                    return Err(XspiError::Busy);
+                }
+
+                self.rb.ccr.modify(|_, w| unsafe {
+                    w.admode()
+                        .bits(mode.reg_value())
+                        .dmode()
+                        .bits(mode.reg_value())
+                });
+
+                // if mode == XspiMode::EightBit {
+                //     // TODO
+                //     self.rb.ccr.modify(|_, w| unsafe {
+                //         w.admode()
+                //             .bits(mode.reg_value())
+                //             .adsize()
+                //             .bits(3) // 32-bit
+                //             .isize()
+                //             .bits(1) // 16-bit
+                //             .imode()
+                //             .bits(mode.reg_value())
+                //             .dmode()
+                //             .bits(mode.reg_value())
+                //     });
+                //     self.rb.tcr.write(|w| unsafe { w.dcyc().bits(4) });
+                // }
+
+                Ok(())
+            }
+
+            /// Begin a write over the XSPI interface. This is mostly useful for use with
+            /// DMA or if you are managing the read yourself. If you want to complete a
+            /// whole transaction, see the [`write`](#method.write) method.
+            ///
+            /// # Args
+            /// * `addr` - The address to write data to. If the address size is less
+            ///            than 32-bit, then unused bits are discarded.
+            /// * `length` - The length of the write operation in bytes
+            pub fn begin_write(
+                &mut self,
+                addr: u32,
+                length: usize,
+            ) -> Result<(), XspiError> {
+                if self.is_busy() {
+                    return Err(XspiError::Busy);
+                }
+
+                // Clear the transfer complete flag.
+                self.rb.fcr.write(|w| w.ctcf().set_bit());
+
+                // Write the length
+                self.rb
+                    .dlr
+                    .write(|w| unsafe { w.dl().bits(length as u32 - 1) });
+
+                // Configure the mode to indirect write.
+                fmode_reg!(self).modify(|_, w| unsafe { w.fmode().bits(0b00) });
+
+                // Write the address to force the write to start
+                self.rb.ar.write(|w| unsafe { w.address().bits(addr) });
+
+                Ok(())
+            }
+
+            /// Write data over the XSPI interface.
+            ///
+            /// # Args
+            /// * `addr` - The address to write data to. If the address size is less
+            ///            than 32-bit, then unused bits are discarded.
+            /// * `data` - An array of data to transfer over the XSPI interface.
+            ///
+            /// # Panics
+            ///
+            /// Panics if the length of `data` is greater than the size of the XSPI
+            /// hardware FIFO (32 bytes).
+            pub fn write(&mut self, addr: u32, data: &[u8]) -> Result<(), XspiError> {
+                assert!(
+                    data.len() <= 32,
+                    "Transactions larger than the XSPI FIFO are currently unsupported"
+                );
+
+                self.begin_write(addr, data.len())?;
+
+                // Write data to the FIFO in a byte-wise manner.
+                unsafe {
+                    for byte in data {
+                        ptr::write_volatile(&self.rb.dr as *const _ as *mut u8, *byte);
+                    }
+                }
+
+                // Wait for the transaction to complete
+                while self.rb.sr.read().tcf().bit_is_clear() {}
+
+                // Wait for the peripheral to indicate it is no longer busy.
+                while self.is_busy() {}
+
+                Ok(())
+            }
+
+            /// Begin a read over the XSPI interface. This is mostly useful for use with
+            /// DMA or if you are managing the read yourself. If you want to complete a
+            /// whole transaction, see the [`read`](#method.read) method.
+            ///
+            /// # Args
+            /// * `addr` - The address to read data from. If the address size is less
+            ///            than 32-bit, then unused bits are discarded.
+            /// * `length` - The length of the read operation in bytes
+            pub fn begin_read(
+                &mut self,
+                addr: u32,
+                length: usize,
+            ) -> Result<(), XspiError> {
+                if self.is_busy() {
+                    return Err(XspiError::Busy);
+                }
+
+                // Clear the transfer complete flag.
+                self.rb.fcr.write(|w| w.ctcf().set_bit());
+
+                // Write the length that should be read.
+                self.rb
+                    .dlr
+                    .write(|w| unsafe { w.dl().bits(length as u32 - 1) });
+
+                // Configure the mode to indirect read.
+                fmode_reg!(self).modify(|_, w| unsafe { w.fmode().bits(0b01) });
+
+                // Write the address to force the read to start.
+                self.rb.ar.write(|w| unsafe { w.address().bits(addr) });
+
+                Ok(())
+            }
+
+            /// Read data over the XSPI interface.
+            ///
+            /// # Args
+            /// * `addr` - The address to read data from. If the address size is less
+            ///            than 32-bit, then unused bits are discarded.
+            /// * `dest` - An array to store the result of the read into.
+            ///
+            /// # Panics
+            ///
+            /// Panics if the length of `data` is greater than the size of the XSPI
+            /// hardware FIFO (32 bytes).
+            pub fn read(
+                &mut self,
+                addr: u32,
+                dest: &mut [u8],
+            ) -> Result<(), XspiError> {
+                assert!(
+                    dest.len() <= 32,
+                    "Transactions larger than the XSPI FIFO are currently unsupported"
+                );
+
+                // Begin the read operation
+                self.begin_read(addr, dest.len())?;
+
+                // Wait for the transaction to complete
+                while self.rb.sr.read().tcf().bit_is_clear() {}
+
+                // Check for underflow on the FIFO.
+                if (self.rb.sr.read().flevel().bits() as usize) < dest.len() {
+                    return Err(XspiError::Underflow);
+                }
+
+                // Read data from the FIFO in a byte-wise manner.
+                unsafe {
+                    for location in dest {
+                        *location =
+                            ptr::read_volatile(&self.rb.dr as *const _ as *const u8);
+                    }
+                }
+
+                // Wait for the peripheral to indicate it is no longer busy.
+                while self.is_busy() {}
+
+                Ok(())
+            }
+        }}}
+    }
+
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
+    xspi_impl! { stm32::QUADSPI, rec::Qspi, qspisel }
+
+    #[cfg(any(feature = "rm0455", feature = "rm0468"))]
+    xspi_impl! { stm32::OCTOSPI1, rec::Octospi1, octospisel }
+    #[cfg(any(feature = "rm0455", feature = "rm0468"))]
+    xspi_impl! { stm32::OCTOSPI2, rec::Octospi2, octospisel }
+}

--- a/src/xspi/mod.rs
+++ b/src/xspi/mod.rs
@@ -33,6 +33,37 @@
 //! qspi.write(0x00, &[0xAB, 0xCD]).unwrap();
 //! ```
 //!
+//! For OCTOSPI there are two peripherals, which can be initialised separately.
+//!
+//! ```
+//! use stm32h7xx_hal::{xspi, xspi::OctospiWord as XW};
+//!
+//! // Get the device peripherals and instantiate IO pins.
+//! let dp = ...;
+//! let _ = ...;
+//!
+//! let mut octospi = dp.OCTOSPI1.octospi_unchecked(12.mhz(), &ccdr.clocks,
+//!                                 ccdr.peripheral.OCTOSPI1);
+//!
+//! // Configure OCTOSPI to operate in 8-bit mode.
+//! octospi.configure_mode(xspi::OctospiMode::EightBit).unwrap();
+//!
+//! // Example RDID Read Indentification
+//! let mut read: [u8; 3] = [0; 3];
+//! octospi
+//!     .read_extended(XW::U16(0x9F60), XW::U32(0), XW::None, 4, &mut read)
+//!     .unwrap();
+//! ```
+//!
+//! # Configuration
+//!
+//! A [`Config`](#struct.Config) struct is used to configure the xSPI.
+//!
+//! ```
+//! use stm32h7xx_hal::xspi;
+//! let config = xspi::Config::new(12.mhz()).fifo_threshold(16);
+//! ```
+//!
 //! # Limitations
 //!
 //! This driver currently only supports indirect operation mode of the xSPI

--- a/src/xspi/mod.rs
+++ b/src/xspi/mod.rs
@@ -181,6 +181,7 @@ mod common {
 
     /// Indicates a specific QUADSPI bank to use
     #[derive(Debug, Copy, Clone, PartialEq)]
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
     pub enum Bank {
         One,
         Two,

--- a/src/xspi/octospi.rs
+++ b/src/xspi/octospi.rs
@@ -277,18 +277,17 @@ macro_rules! octospi_impl {
                         .bits(0x1F)
                 });
 
-                // // Communications configuration register
-                // regs.ccr.write(|w| unsafe {
-                //     w.dmode().bits(1)   // Data on a single line
-
-                //         .dmode()
-                // .bits(config.mode.reg_value())
-                // .admode()
-                // .bits(config.mode.reg_value())
-                // .adsize()
-                // .bits(config.address_size as u8)
-                // .imode()
-                // .bits(0) // No instruction phase
+                // Communications configuration register
+                regs.ccr.write(|w| unsafe {
+                    w.dmode()
+                        .bits(config.mode.reg_value())
+                        .admode()
+                        .bits(config.mode.reg_value())
+                        .adsize()
+                        .bits(0) // Eight-bit address
+                        .imode()
+                        .bits(0) // No instruction phase
+                });
 
                 // Prescaler
                 let spi_frequency = config.frequency.0;
@@ -318,7 +317,10 @@ macro_rules! octospi_impl {
                 // Enable the peripheral
                 regs.cr.modify(|_, w| w.en().set_bit());
 
-                Octospi { rb: regs }
+                Octospi {
+                    rb: regs,
+                    mode: config.mode,
+                }
             }
         }
 

--- a/src/xspi/octospi.rs
+++ b/src/xspi/octospi.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         gpiog::{PG0, PG1, PG10, PG11, PG12, PG14, PG15, PG6, PG7, PG9},
         gpioh::{PH2, PH3},
-        Alternate, AF10, AF9,
+        Alternate, AF0, AF10, AF11, AF12, AF3, AF4, AF6, AF9,
     },
     rcc::{rec, CoreClocks, ResetEnable},
     stm32,
@@ -47,165 +47,177 @@ pub trait PinIo7<OSPI> {}
 // {
 // }
 
-// macro_rules! pins {
-//     (Bank1: [IO0: [$($IO0:ty),*] IO1: [$($IO1:ty),*] IO2: [$($IO2:ty),*] IO3: [$($IO3:ty),*]]) => {
-//         $(
-//             impl PinIo0Bank1 for $IO0 {}
-//         )*
-//         $(
-//             impl PinIo1Bank1 for $IO1 {}
-//         )*
-//         $(
-//             impl PinIo2Bank1 for $IO2 {}
-//         )*
-//         $(
-//             impl PinIo3Bank1 for $IO3 {}
-//         )*
-//     };
+macro_rules! pins {
+    (
+        $($BANK:ident:
+            CLK: [$($CLK:ty),*] NCLK: [$($NCLK:ty),*] DQS: [$($DQS:ty),*] NCS: [$($NCS:ty),*]
+                IO0: [$($IO0:ty),*] IO1: [$($IO1:ty),*] IO2: [$($IO2:ty),*] IO3: [$($IO3:ty),*]
+                IO4: [$($IO4:ty),*] IO5: [$($IO5:ty),*] IO6: [$($IO6:ty),*] IO7: [$($IO7:ty),*]
+        )*
+    ) => {
+        $(
+            $(
+                impl PinClk<stm32::$BANK> for $CLK {}
+            )*
+            $(
+                impl PinNclk<stm32::$BANK> for $NCLK {}
+            )*
+            $(
+                impl PinDQS<stm32::$BANK> for $DQS {}
+            )*
+            $(
+                impl PinNCS<stm32::$BANK> for $NCS {}
+            )*
+            $(
+                impl PinIo0<stm32::$BANK> for $IO0 {}
+            )*
+            $(
+                impl PinIo1<stm32::$BANK> for $IO1 {}
+            )*
+            $(
+                impl PinIo2<stm32::$BANK> for $IO2 {}
+            )*
+            $(
+                impl PinIo3<stm32::$BANK> for $IO3 {}
+            )*
+            $(
+                impl PinIo4<stm32::$BANK> for $IO4 {}
+            )*
+            $(
+                impl PinIo5<stm32::$BANK> for $IO5 {}
+            )*
+            $(
+                impl PinIo6<stm32::$BANK> for $IO6 {}
+            )*
+            $(
+                impl PinIo7<stm32::$BANK> for $IO7 {}
+            )*
+        )*
+    };
+}
 
-//     (Bank2: [IO0: [$($IO0:ty),*] IO1: [$($IO1:ty),*] IO2: [$($IO2:ty),*] IO3: [$($IO3:ty),*]]) => {
-//         $(
-//             impl PinIo0Bank2 for $IO0 {}
-//         )*
-//         $(
-//             impl PinIo1Bank2 for $IO1 {}
-//         )*
-//         $(
-//             impl PinIo2Bank2 for $IO2 {}
-//         )*
-//         $(
-//             impl PinIo3Bank2 for $IO3 {}
-//         )*
-//     };
-
-//     (SCK: [$($SCK:ty),*], Bank1: $bank1:tt, Bank2: $bank2:tt) => {
-//         $(
-//             impl PinSck for $SCK {}
-//         )*
-//         pins!(Bank1: $bank1);
-//         pins!(Bank2: $bank2);
-//     };
-// }
-
-// pins! {
-//     OCTOSPIM_P1:
-//         CLK: [
-//             PA3<Alternate<AF12>>,
-//             PB2<Alternate<AF9>>,
-//             PF10<Alternate<AF9>>
-//         ]
-//         NCLK: [
-//             PB12<Alternate<AF3>>,
-//             PF11<Alternate<AF9>>
-//         ]
-//         DQS: [
-//             PA1<Alternate<AF12>>,
-//             PB2<Alternate<AF10>>,
-//             PC5<Alternate<AF10>>
-//         ]
-//         NCS: [
-//             PB6<Alternate<AF10>>,
-//             PB10<Alternate<AF9>>,
-//             PC11<Alternate<AF9>>,
-//             PE11<Alternate<AF11>>,
-//             PG6<Alternate<AF10>>
-//         ]
-//         IO0: [
-//             PA2<Alternate<AF6>>,
-//             PB1<Alternate<AF4>>,
-//             PB12<Alternate<AF12>>,
-//             PC3<Alternate<AF9>>,
-//             PC3<Alternate<AF0>>,
-//             PC9<Alternate<AF9>>,
-//             PD11<Alternate<AF9>>,
-//             PF8<Alternate<AF10>>
-//         ]
-//         IO1: [
-//             PB0<Alternate<AF4>>,
-//             PC10<Alternate<AF9>>,
-//             PD12<Alternate<AF9>>,
-//             PF9<Alternate<AF10>>
-//         ]
-//         IO2: [
-//             PA3<Alternate<AF6>>,
-//             PA7<Alternate<AF10>>,
-//             PB13<Alternate<AF4>>,
-//             PC2<Alternate<AF9>>,
-//             PC2<Alternate<AF0>>,
-//             PE2<Alternate<AF9>>,
-//             PF7<Alternate<AF10>>
-//         ]
-//         IO3: [
-//             PA1<Alternate<AF9>>,
-//             PA6<Alternate<AF6>>,
-//             PD13<Alternate<AF9>>,
-//             PF6<Alternate<AF10>>
-//         ]
-//         IO4: [
-//             PC1<Alternate<AF10>>,
-//             PD4<Alternate<AF10>>,
-//             PE7<Alternate<AF10>>,
-//             PH2<Alternate<AF9>>
-//         ]
-//         IO5: [
-//             PC2<Alternate<AF4>>,
-//             PC2<Alternate<AF0>>,
-//             PD5<Alternate<AF10>>,
-//             PE8<Alternate<AF10>>,
-//             PH3<Alternate<AF9>>
-//         ]
-//         IO6: [
-//             PC3<Alternate<AF4>>,
-//             PC3<Alternate<AF0>>,
-//             PD6<Alternate<AF10>>,
-//             PE9<Alternate<AF10>>,
-//             PG9<Alternate<AF9>>
-//         ]
-//         IO7: [
-//             PD7<Alternate<AF10>>,
-//             PE10<Alternate<AF10>>,
-//             PG14<Alternate<AF9>>
-//         ]
-//     OCTOSPIM_P2:
-//         CLK: [
-//             PF4<Alternate<AF9>>
-//         ]
-//         NCLK: [
-//             PF5<Alternate<AF9>>
-//         ]
-//         DQS: [
-//             PF12<Alternate<AF9>>,
-//             PG7<Alternate<AF9>>,
-//             PG15<Alternate<AF9>>
-//         ]
-//         NCS: [
-//             PG12<Alternate<AF3>>
-//         ]
-//         IO0: [
-//             PF0<Alternate<AF9>>
-//         ]
-//         IO1: [
-//             PF1<Alternate<AF9>>
-//         ]
-//         IO2: [
-//             PF2<Alternate<AF9>>
-//         ]
-//         IO3: [
-//             PF3<Alternate<AF9>>
-//         ]
-//         IO4: [
-//             PG0<Alternate<AF9>>
-//         ]
-//         IO5: [
-//             PG1<Alternate<AF9>>
-//         ]
-//         IO6: [
-//             PG10<Alternate<AF3>>
-//         ]
-//         IO7: [
-//             PG11<Alternate<AF9>>
-//         ]
-// }
+#[cfg(any(feature = "rm0468"))] // TODO
+pins! {
+    OCTOSPI1:
+        CLK: [
+            PA3<Alternate<AF12>>,
+            PB2<Alternate<AF9>>,
+            PF10<Alternate<AF9>>
+        ]
+        NCLK: [
+            PB12<Alternate<AF3>>,
+            PF11<Alternate<AF9>>
+        ]
+        DQS: [
+            PA1<Alternate<AF12>>,
+            PB2<Alternate<AF10>>,
+            PC5<Alternate<AF10>>
+        ]
+        NCS: [
+            PB6<Alternate<AF10>>,
+            PB10<Alternate<AF9>>,
+            PC11<Alternate<AF9>>,
+            PE11<Alternate<AF11>>,
+            PG6<Alternate<AF10>>
+        ]
+        IO0: [
+            PA2<Alternate<AF6>>,
+            PB1<Alternate<AF4>>,
+            PB12<Alternate<AF12>>,
+            PC3<Alternate<AF9>>,
+            PC3<Alternate<AF0>>,
+            PC9<Alternate<AF9>>,
+            PD11<Alternate<AF9>>,
+            PF8<Alternate<AF10>>
+        ]
+        IO1: [
+            PB0<Alternate<AF4>>,
+            PC10<Alternate<AF9>>,
+            PD12<Alternate<AF9>>,
+            PF9<Alternate<AF10>>
+        ]
+        IO2: [
+            PA3<Alternate<AF6>>,
+            PA7<Alternate<AF10>>,
+            PB13<Alternate<AF4>>,
+            PC2<Alternate<AF9>>,
+            PC2<Alternate<AF0>>,
+            PE2<Alternate<AF9>>,
+            PF7<Alternate<AF10>>
+        ]
+        IO3: [
+            PA1<Alternate<AF9>>,
+            PA6<Alternate<AF6>>,
+            PD13<Alternate<AF9>>,
+            PF6<Alternate<AF10>>
+        ]
+        IO4: [
+            PC1<Alternate<AF10>>,
+            PD4<Alternate<AF10>>,
+            PE7<Alternate<AF10>>,
+            PH2<Alternate<AF9>>
+        ]
+        IO5: [
+            PC2<Alternate<AF4>>,
+            PC2<Alternate<AF0>>,
+            PD5<Alternate<AF10>>,
+            PE8<Alternate<AF10>>,
+            PH3<Alternate<AF9>>
+        ]
+        IO6: [
+            PC3<Alternate<AF4>>,
+            PC3<Alternate<AF0>>,
+            PD6<Alternate<AF10>>,
+            PE9<Alternate<AF10>>,
+            PG9<Alternate<AF9>>
+        ]
+        IO7: [
+            PD7<Alternate<AF10>>,
+            PE10<Alternate<AF10>>,
+            PG14<Alternate<AF9>>
+        ]
+}
+pins! {
+    OCTOSPI2:
+        CLK: [
+            PF4<Alternate<AF9>>
+        ]
+        NCLK: [
+            PF5<Alternate<AF9>>
+        ]
+        DQS: [
+            PF12<Alternate<AF9>>,
+            PG7<Alternate<AF9>>,
+            PG15<Alternate<AF9>>
+        ]
+        NCS: [
+            PG12<Alternate<AF3>>
+        ]
+        IO0: [
+            PF0<Alternate<AF9>>
+        ]
+        IO1: [
+            PF1<Alternate<AF9>>
+        ]
+        IO2: [
+            PF2<Alternate<AF9>>
+        ]
+        IO3: [
+            PF3<Alternate<AF9>>
+        ]
+        IO4: [
+            PG0<Alternate<AF9>>
+        ]
+        IO5: [
+            PG1<Alternate<AF9>>
+        ]
+        IO6: [
+            PG10<Alternate<AF3>>
+        ]
+        IO7: [
+            PG11<Alternate<AF9>>
+        ]
+}
 
 pub trait OctospiExt<OSPI>: Sized {
     /// The `ResetEnable` singleton for this peripheral

--- a/src/xspi/octospi.rs
+++ b/src/xspi/octospi.rs
@@ -1,0 +1,344 @@
+//! Octo SPI (OCTOSPI) bus
+//!
+//! See the parent module for documentation
+
+use crate::{
+    gpio::{
+        gpioa::{PA1, PA2, PA3, PA6, PA7},
+        gpiob::{PB0, PB1, PB10, PB12, PB13, PB2, PB6},
+        gpioc::{PC1, PC10, PC11, PC2, PC3, PC5, PC9},
+        gpiod::{PD11, PD12, PD13, PD4, PD5, PD6, PD7},
+        gpioe::{PE10, PE11, PE2, PE7, PE8, PE9},
+        gpiof::{
+            PF0, PF1, PF10, PF11, PF12, PF2, PF3, PF4, PF5, PF6, PF7, PF8, PF9,
+        },
+        gpiog::{PG0, PG1, PG10, PG11, PG12, PG14, PG15, PG6, PG7, PG9},
+        gpioh::{PH2, PH3},
+        Alternate, AF10, AF9,
+    },
+    rcc::{rec, CoreClocks, ResetEnable},
+    stm32,
+};
+
+use super::{Config, Octospi, SamplingEdge};
+
+pub trait PinClk<OSPI> {}
+pub trait PinNclk<OSPI> {}
+pub trait PinDQS<OSPI> {}
+pub trait PinNCS<OSPI> {}
+pub trait PinIo0<OSPI> {}
+pub trait PinIo1<OSPI> {}
+pub trait PinIo2<OSPI> {}
+pub trait PinIo3<OSPI> {}
+pub trait PinIo4<OSPI> {}
+pub trait PinIo5<OSPI> {}
+pub trait PinIo6<OSPI> {}
+pub trait PinIo7<OSPI> {}
+
+// impl<OSPI, CLK, NCS, IO0, IO1, IO2, IO3> PinsQuad<OSPI>
+//     for (CLK, NCS, IO0, IO1, IO2, IO3)
+// where
+//     CLK: PinClk<OSPI>,
+//     NCS: PinNCS<OSPI>,
+//     IO0: PinIo0<OSPI>,
+//     IO1: PinIo1<OSPI>,
+//     IO2: PinIo2<OSPI>,
+//     IO3: PinIo3<OSPI>,
+// {
+// }
+
+// macro_rules! pins {
+//     (Bank1: [IO0: [$($IO0:ty),*] IO1: [$($IO1:ty),*] IO2: [$($IO2:ty),*] IO3: [$($IO3:ty),*]]) => {
+//         $(
+//             impl PinIo0Bank1 for $IO0 {}
+//         )*
+//         $(
+//             impl PinIo1Bank1 for $IO1 {}
+//         )*
+//         $(
+//             impl PinIo2Bank1 for $IO2 {}
+//         )*
+//         $(
+//             impl PinIo3Bank1 for $IO3 {}
+//         )*
+//     };
+
+//     (Bank2: [IO0: [$($IO0:ty),*] IO1: [$($IO1:ty),*] IO2: [$($IO2:ty),*] IO3: [$($IO3:ty),*]]) => {
+//         $(
+//             impl PinIo0Bank2 for $IO0 {}
+//         )*
+//         $(
+//             impl PinIo1Bank2 for $IO1 {}
+//         )*
+//         $(
+//             impl PinIo2Bank2 for $IO2 {}
+//         )*
+//         $(
+//             impl PinIo3Bank2 for $IO3 {}
+//         )*
+//     };
+
+//     (SCK: [$($SCK:ty),*], Bank1: $bank1:tt, Bank2: $bank2:tt) => {
+//         $(
+//             impl PinSck for $SCK {}
+//         )*
+//         pins!(Bank1: $bank1);
+//         pins!(Bank2: $bank2);
+//     };
+// }
+
+// pins! {
+//     OCTOSPIM_P1:
+//         CLK: [
+//             PA3<Alternate<AF12>>,
+//             PB2<Alternate<AF9>>,
+//             PF10<Alternate<AF9>>
+//         ]
+//         NCLK: [
+//             PB12<Alternate<AF3>>,
+//             PF11<Alternate<AF9>>
+//         ]
+//         DQS: [
+//             PA1<Alternate<AF12>>,
+//             PB2<Alternate<AF10>>,
+//             PC5<Alternate<AF10>>
+//         ]
+//         NCS: [
+//             PB6<Alternate<AF10>>,
+//             PB10<Alternate<AF9>>,
+//             PC11<Alternate<AF9>>,
+//             PE11<Alternate<AF11>>,
+//             PG6<Alternate<AF10>>
+//         ]
+//         IO0: [
+//             PA2<Alternate<AF6>>,
+//             PB1<Alternate<AF4>>,
+//             PB12<Alternate<AF12>>,
+//             PC3<Alternate<AF9>>,
+//             PC3<Alternate<AF0>>,
+//             PC9<Alternate<AF9>>,
+//             PD11<Alternate<AF9>>,
+//             PF8<Alternate<AF10>>
+//         ]
+//         IO1: [
+//             PB0<Alternate<AF4>>,
+//             PC10<Alternate<AF9>>,
+//             PD12<Alternate<AF9>>,
+//             PF9<Alternate<AF10>>
+//         ]
+//         IO2: [
+//             PA3<Alternate<AF6>>,
+//             PA7<Alternate<AF10>>,
+//             PB13<Alternate<AF4>>,
+//             PC2<Alternate<AF9>>,
+//             PC2<Alternate<AF0>>,
+//             PE2<Alternate<AF9>>,
+//             PF7<Alternate<AF10>>
+//         ]
+//         IO3: [
+//             PA1<Alternate<AF9>>,
+//             PA6<Alternate<AF6>>,
+//             PD13<Alternate<AF9>>,
+//             PF6<Alternate<AF10>>
+//         ]
+//         IO4: [
+//             PC1<Alternate<AF10>>,
+//             PD4<Alternate<AF10>>,
+//             PE7<Alternate<AF10>>,
+//             PH2<Alternate<AF9>>
+//         ]
+//         IO5: [
+//             PC2<Alternate<AF4>>,
+//             PC2<Alternate<AF0>>,
+//             PD5<Alternate<AF10>>,
+//             PE8<Alternate<AF10>>,
+//             PH3<Alternate<AF9>>
+//         ]
+//         IO6: [
+//             PC3<Alternate<AF4>>,
+//             PC3<Alternate<AF0>>,
+//             PD6<Alternate<AF10>>,
+//             PE9<Alternate<AF10>>,
+//             PG9<Alternate<AF9>>
+//         ]
+//         IO7: [
+//             PD7<Alternate<AF10>>,
+//             PE10<Alternate<AF10>>,
+//             PG14<Alternate<AF9>>
+//         ]
+//     OCTOSPIM_P2:
+//         CLK: [
+//             PF4<Alternate<AF9>>
+//         ]
+//         NCLK: [
+//             PF5<Alternate<AF9>>
+//         ]
+//         DQS: [
+//             PF12<Alternate<AF9>>,
+//             PG7<Alternate<AF9>>,
+//             PG15<Alternate<AF9>>
+//         ]
+//         NCS: [
+//             PG12<Alternate<AF3>>
+//         ]
+//         IO0: [
+//             PF0<Alternate<AF9>>
+//         ]
+//         IO1: [
+//             PF1<Alternate<AF9>>
+//         ]
+//         IO2: [
+//             PF2<Alternate<AF9>>
+//         ]
+//         IO3: [
+//             PF3<Alternate<AF9>>
+//         ]
+//         IO4: [
+//             PG0<Alternate<AF9>>
+//         ]
+//         IO5: [
+//             PG1<Alternate<AF9>>
+//         ]
+//         IO6: [
+//             PG10<Alternate<AF3>>
+//         ]
+//         IO7: [
+//             PG11<Alternate<AF9>>
+//         ]
+// }
+
+pub trait OctospiExt<OSPI>: Sized {
+    /// The `ResetEnable` singleton for this peripheral
+    type Rec: ResetEnable;
+
+    /// Create and enable the Octospi peripheral
+    fn octospi_unchecked<CONFIG>(
+        self,
+        config: CONFIG,
+        clocks: &CoreClocks,
+        prec: Self::Rec,
+    ) -> Octospi<OSPI>
+    where
+        CONFIG: Into<Config>;
+}
+
+macro_rules! octospi_impl {
+    ($name:ident, $peripheral:ty, $rec:ty) => {
+        impl Octospi<$peripheral> {
+            pub fn $name<CONFIG>(
+                regs: $peripheral,
+                config: CONFIG,
+                clocks: &CoreClocks,
+                prec: $rec,
+            ) -> Self
+            where
+                CONFIG: Into<Config>,
+            {
+                prec.enable();
+
+                // Disable OCTOSPI before configuring it.
+                regs.cr.write(|w| w.en().clear_bit());
+
+                let spi_kernel_ck = match Self::get_clock(clocks) {
+                    Some(freq_hz) => freq_hz.0,
+                    _ => panic!("OCTOSPI kernel clock not running!"),
+                };
+
+                while regs.sr.read().busy().bit_is_set() {}
+
+                let config: Config = config.into();
+
+                // Clear all pending flags.
+                regs.fcr.write(|w| {
+                    w.ctof()
+                        .set_bit()
+                        .csmf()
+                        .set_bit()
+                        .ctcf()
+                        .set_bit()
+                        .ctef()
+                        .set_bit()
+                });
+
+                // Configure the communication method for OCTOSPI.
+                regs.cr.write(|w| unsafe {
+                    w.fmode()
+                        .bits(0) // indirect mode
+                        .fthres()
+                        .bits(config.fifo_threshold - 1)
+                });
+
+                regs.dcr1.write(|w| unsafe {
+                    w.mtyp()
+                        .bits(2) // standard mode
+                        // Configure the FSIZE to maximum. It appears that even when addressing
+                        // is not used, the flash size violation may still trigger.
+                        .devsize()
+                        .bits(0x1F)
+                });
+
+                // // Communications configuration register
+                // regs.ccr.write(|w| unsafe {
+                //     w.dmode().bits(1)   // Data on a single line
+
+                //         .dmode()
+                // .bits(config.mode.reg_value())
+                // .admode()
+                // .bits(config.mode.reg_value())
+                // .adsize()
+                // .bits(config.address_size as u8)
+                // .imode()
+                // .bits(0) // No instruction phase
+
+                // Prescaler
+                let spi_frequency = config.frequency.0;
+                let divisor =
+                    match (spi_kernel_ck + spi_frequency - 1) / spi_frequency {
+                        divisor @ 1..=256 => divisor - 1,
+                        _ => panic!("Invalid OCTOSPI frequency requested"),
+                    };
+                regs.dcr2
+                    .write(|w| unsafe { w.prescaler().bits(divisor as u8) });
+
+                // Note that we default to setting SSHIFT (sampling on the falling
+                // edge). This is because it appears that the QSPI may have signal
+                // contention issues when reading with zero dummy cycles. Setting SSHIFT
+                // forces the read to occur on the falling edge instead of the rising
+                // edge. Refer to https://github.com/quartiq/stabilizer/issues/101 for
+                // more information
+                //
+                // SSHIFT must not be set in DDR mode.
+                regs.tcr.write(|w| unsafe {
+                    w.sshift()
+                        .bit(config.sampling_edge == SamplingEdge::Falling)
+                        .dcyc()
+                        .bits(config.dummy_cycles)
+                });
+
+                // Enable the peripheral
+                regs.cr.modify(|_, w| w.en().set_bit());
+
+                Octospi { rb: regs }
+            }
+        }
+
+        impl OctospiExt<$peripheral> for $peripheral {
+            type Rec = $rec;
+
+            fn octospi_unchecked<CONFIG>(
+                self,
+                config: CONFIG,
+                clocks: &CoreClocks,
+                prec: Self::Rec,
+            ) -> Octospi<$peripheral>
+            where
+                CONFIG: Into<Config>,
+            {
+                Octospi::$name(self, config, clocks, prec)
+            }
+        }
+    };
+}
+
+octospi_impl! { octospi1_unchecked, stm32::OCTOSPI1, rec::Octospi1 }
+octospi_impl! { octospi2_unchecked, stm32::OCTOSPI2, rec::Octospi2 }

--- a/src/xspi/octospi.rs
+++ b/src/xspi/octospi.rs
@@ -342,5 +342,6 @@ macro_rules! octospi_impl {
     };
 }
 
+#[cfg(any(feature = "rm0468"))] // TODO feature = "rm0455"
 octospi_impl! { octospi1_unchecked, stm32::OCTOSPI1, rec::Octospi1 }
 octospi_impl! { octospi2_unchecked, stm32::OCTOSPI2, rec::Octospi2 }

--- a/src/xspi/qspi.rs
+++ b/src/xspi/qspi.rs
@@ -1,0 +1,328 @@
+//! Quad SPI (QSPI) bus
+//!
+//! See the parent module for documentation
+
+use crate::{
+    gpio::{
+        gpioa::PA1,
+        gpiob::PB2,
+        gpioc::{PC10, PC9},
+        gpiod::{PD11, PD12, PD13},
+        gpioe::{PE10, PE2, PE7, PE8, PE9},
+        gpiof::{PF10, PF6, PF7, PF8, PF9},
+        gpiog::{PG14, PG9},
+        gpioh::{PH2, PH3},
+        Alternate, AF10, AF9,
+    },
+    rcc::{rec, CoreClocks, ResetEnable},
+    stm32,
+};
+
+use super::{Bank, Config, Qspi, SamplingEdge};
+
+/// Used to indicate that an IO pin is not used by the QSPI interface.
+pub struct NoIo {}
+
+/// Indicates a set of pins can be used for the QSPI interface on bank 1.
+pub trait PinsBank1 {}
+pub trait PinIo0Bank1 {}
+pub trait PinIo1Bank1 {}
+pub trait PinIo2Bank1 {}
+pub trait PinIo3Bank1 {}
+
+/// Indicates a set of pins can be used for the QSPI interface on bank 2.
+pub trait PinsBank2 {}
+pub trait PinSckBank2 {}
+pub trait PinIo0Bank2 {}
+pub trait PinIo1Bank2 {}
+pub trait PinIo2Bank2 {}
+pub trait PinIo3Bank2 {}
+
+pub trait PinSck {}
+
+impl<SCK, IO0, IO1, IO2, IO3> PinsBank1 for (SCK, IO0, IO1, IO2, IO3)
+where
+    SCK: PinSck,
+    IO0: PinIo0Bank1,
+    IO1: PinIo1Bank1,
+    IO2: PinIo2Bank1,
+    IO3: PinIo3Bank1,
+{
+}
+
+impl<SCK, IO0, IO1, IO2, IO3> PinsBank2 for (SCK, IO0, IO1, IO2, IO3)
+where
+    SCK: PinSck,
+    IO0: PinIo0Bank2,
+    IO1: PinIo1Bank2,
+    IO2: PinIo2Bank2,
+    IO3: PinIo3Bank2,
+{
+}
+
+macro_rules! pins {
+    (Bank1: [IO0: [$($IO0:ty),*] IO1: [$($IO1:ty),*] IO2: [$($IO2:ty),*] IO3: [$($IO3:ty),*]]) => {
+        $(
+            impl PinIo0Bank1 for $IO0 {}
+        )*
+        $(
+            impl PinIo1Bank1 for $IO1 {}
+        )*
+        $(
+            impl PinIo2Bank1 for $IO2 {}
+        )*
+        $(
+            impl PinIo3Bank1 for $IO3 {}
+        )*
+    };
+
+    (Bank2: [IO0: [$($IO0:ty),*] IO1: [$($IO1:ty),*] IO2: [$($IO2:ty),*] IO3: [$($IO3:ty),*]]) => {
+        $(
+            impl PinIo0Bank2 for $IO0 {}
+        )*
+        $(
+            impl PinIo1Bank2 for $IO1 {}
+        )*
+        $(
+            impl PinIo2Bank2 for $IO2 {}
+        )*
+        $(
+            impl PinIo3Bank2 for $IO3 {}
+        )*
+    };
+
+    (SCK: [$($SCK:ty),*], Bank1: $bank1:tt, Bank2: $bank2:tt) => {
+        $(
+            impl PinSck for $SCK {}
+        )*
+        pins!(Bank1: $bank1);
+        pins!(Bank2: $bank2);
+    };
+}
+
+pins! {
+    SCK: [
+        PB2<Alternate<AF9>>,
+        PF10<Alternate<AF9>>
+    ],
+    Bank1: [
+        IO0: [
+            PC9<Alternate<AF9>>,
+            PD11<Alternate<AF9>>,
+            PF8<Alternate<AF10>>
+        ]
+        IO1: [
+            PC10<Alternate<AF9>>,
+            PD12<Alternate<AF9>>,
+            PF9<Alternate<AF10>>,
+            NoIo
+        ]
+        IO2: [
+            PE2<Alternate<AF9>>,
+            PF7<Alternate<AF9>>,
+            NoIo
+        ]
+        IO3: [
+            PA1<Alternate<AF9>>,
+            PD13<Alternate<AF9>>,
+            PF6<Alternate<AF9>>,
+            NoIo
+        ]
+    ],
+    Bank2: [
+        IO0: [
+            PE7<Alternate<AF10>>,
+            PF8<Alternate<AF10>>,
+            PH2<Alternate<AF9>>
+        ]
+        IO1: [
+            PE8<Alternate<AF10>>,
+            PF9<Alternate<AF10>>,
+            PH3<Alternate<AF9>>,
+            NoIo
+        ]
+        IO2: [
+            PE9<Alternate<AF10>>,
+            PG9<Alternate<AF9>>,
+            NoIo
+        ]
+        IO3: [
+            PE10<Alternate<AF10>>,
+            PG14<Alternate<AF9>>,
+            NoIo
+        ]
+    ]
+}
+
+pub trait QspiExt {
+    fn bank1<CONFIG, PINS>(
+        self,
+        _pins: PINS,
+        config: CONFIG,
+        clocks: &CoreClocks,
+        prec: rec::Qspi,
+    ) -> Qspi<stm32::QUADSPI>
+    where
+        CONFIG: Into<Config>,
+        PINS: PinsBank1;
+
+    fn bank2<CONFIG, PINS>(
+        self,
+        _pins: PINS,
+        config: CONFIG,
+        clocks: &CoreClocks,
+        prec: rec::Qspi,
+    ) -> Qspi<stm32::QUADSPI>
+    where
+        CONFIG: Into<Config>,
+        PINS: PinsBank2;
+
+    fn qspi_unchecked<CONFIG>(
+        self,
+        config: CONFIG,
+        bank: Bank,
+        clocks: &CoreClocks,
+        prec: rec::Qspi,
+    ) -> Qspi<stm32::QUADSPI>
+    where
+        CONFIG: Into<Config>;
+}
+
+impl Qspi<stm32::QUADSPI> {
+    pub fn qspi_unchecked<CONFIG>(
+        regs: stm32::QUADSPI,
+        config: CONFIG,
+        bank: Bank,
+        clocks: &CoreClocks,
+        prec: rec::Qspi,
+    ) -> Self
+    where
+        CONFIG: Into<Config>,
+    {
+        prec.enable();
+
+        // Disable QUADSPI before configuring it.
+        regs.cr.write(|w| w.en().clear_bit());
+
+        let spi_kernel_ck = match Self::get_clock(clocks) {
+            Some(freq_hz) => freq_hz.0,
+            _ => panic!("QSPI kernel clock not running!"),
+        };
+
+        while regs.sr.read().busy().bit_is_set() {}
+
+        let config: Config = config.into();
+
+        // Configure the FSIZE to maximum. It appears that even when addressing is not used, the
+        // flash size violation may still trigger.
+        regs.dcr.write(|w| unsafe { w.fsize().bits(0x1F) });
+
+        // Clear all pending flags.
+        regs.fcr.write(|w| {
+            w.ctof()
+                .set_bit()
+                .csmf()
+                .set_bit()
+                .ctcf()
+                .set_bit()
+                .ctef()
+                .set_bit()
+        });
+
+        // Configure the communication method for QSPI.
+        regs.ccr.write(|w| unsafe {
+            w.fmode()
+                .bits(0) // indirect mode
+                .dmode()
+                .bits(config.mode.reg_value())
+                .admode()
+                .bits(config.mode.reg_value())
+                .adsize()
+                .bits(config.address_size as u8)
+                .imode()
+                .bits(0) // No instruction phase
+                .dcyc()
+                .bits(config.dummy_cycles)
+        });
+
+        let spi_frequency = config.frequency.0;
+        let divisor = match (spi_kernel_ck + spi_frequency - 1) / spi_frequency
+        {
+            divisor @ 1..=256 => divisor - 1,
+            _ => panic!("Invalid QSPI frequency requested"),
+        };
+
+        // Write the prescaler and the SSHIFT bit.
+        //
+        // Note that we default to setting SSHIFT (sampling on the falling
+        // edge). This is because it appears that the QSPI may have signal
+        // contention issues when reading with zero dummy cycles. Setting SSHIFT
+        // forces the read to occur on the falling edge instead of the rising
+        // edge. Refer to https://github.com/quartiq/stabilizer/issues/101 for
+        // more information
+        //
+        // SSHIFT must not be set in DDR mode.
+        regs.cr.write(|w| unsafe {
+            w.prescaler()
+                .bits(divisor as u8)
+                .sshift()
+                .bit(config.sampling_edge == SamplingEdge::Falling)
+                .fthres()
+                .bits(config.fifo_threshold - 1)
+        });
+
+        match bank {
+            Bank::One => regs.cr.modify(|_, w| w.fsel().clear_bit()),
+            Bank::Two => regs.cr.modify(|_, w| w.fsel().set_bit()),
+            Bank::Dual => regs.cr.modify(|_, w| w.dfm().set_bit()),
+        }
+
+        // Enable ther peripheral
+        regs.cr.modify(|_, w| w.en().set_bit());
+
+        Qspi { rb: regs }
+    }
+}
+
+impl QspiExt for stm32::QUADSPI {
+    fn bank1<CONFIG, PINS>(
+        self,
+        _pins: PINS,
+        config: CONFIG,
+        clocks: &CoreClocks,
+        prec: rec::Qspi,
+    ) -> Qspi<stm32::QUADSPI>
+    where
+        CONFIG: Into<Config>,
+        PINS: PinsBank1,
+    {
+        Qspi::qspi_unchecked(self, config, Bank::One, clocks, prec)
+    }
+
+    fn bank2<CONFIG, PINS>(
+        self,
+        _pins: PINS,
+        config: CONFIG,
+        clocks: &CoreClocks,
+        prec: rec::Qspi,
+    ) -> Qspi<stm32::QUADSPI>
+    where
+        CONFIG: Into<Config>,
+        PINS: PinsBank2,
+    {
+        Qspi::qspi_unchecked(self, config, Bank::Two, clocks, prec)
+    }
+
+    fn qspi_unchecked<CONFIG>(
+        self,
+        config: CONFIG,
+        bank: Bank,
+        clocks: &CoreClocks,
+        prec: rec::Qspi,
+    ) -> Qspi<stm32::QUADSPI>
+    where
+        CONFIG: Into<Config>,
+    {
+        Qspi::qspi_unchecked(self, config, bank, clocks, prec)
+    }
+}

--- a/src/xspi/qspi.rs
+++ b/src/xspi/qspi.rs
@@ -238,7 +238,7 @@ impl Qspi<stm32::QUADSPI> {
                 .admode()
                 .bits(config.mode.reg_value())
                 .adsize()
-                .bits(config.address_size as u8)
+                .bits(0) // Eight-bit address
                 .imode()
                 .bits(0) // No instruction phase
                 .dcyc()
@@ -280,7 +280,10 @@ impl Qspi<stm32::QUADSPI> {
         // Enable ther peripheral
         regs.cr.modify(|_, w| w.en().set_bit());
 
-        Qspi { rb: regs }
+        Qspi {
+            rb: regs,
+            mode: config.mode,
+        }
     }
 }
 


### PR DESCRIPTION
`write_extended` and `read_extended` methods allow more complicated transactions, such as those needed to read/write from flash memories.

Rename the `quadspi` flag to `xspi`

Ref #165 