### PR TITLE
Remove explicit invalidate_icache from examples

### DIFF
--- a/examples/ethernet-nucleo-h743zi2.rs
+++ b/examples/ethernet-nucleo-h743zi2.rs
@@ -73,7 +73,6 @@ fn main() -> ! {
     let delay = cp.SYST.delay(ccdr.clocks);
 
     // Initialise system...
-    cp.SCB.invalidate_icache();
     cp.SCB.enable_icache();
     // TODO: ETH DMA coherence issues
     // cp.SCB.enable_dcache(&mut cp.CPUID);

--- a/examples/ethernet-rtic-stm32h747i-disco.rs
+++ b/examples/ethernet-rtic-stm32h747i-disco.rs
@@ -140,7 +140,6 @@ const APP: () = {
             .freeze(pwrcfg, &ctx.device.SYSCFG);
 
         // Initialise system...
-        ctx.core.SCB.invalidate_icache();
         ctx.core.SCB.enable_icache();
         // TODO: ETH DMA coherence issues
         // ctx.core.SCB.enable_dcache(&mut ctx.core.CPUID);

--- a/examples/ethernet-stm32h747i-disco.rs
+++ b/examples/ethernet-stm32h747i-disco.rs
@@ -54,7 +54,6 @@ fn main() -> ! {
         .freeze(pwrcfg, &dp.SYSCFG);
 
     // Initialise system...
-    cp.SCB.invalidate_icache();
     cp.SCB.enable_icache();
     // TODO: ETH DMA coherence issues
     // cp.SCB.enable_dcache(&mut cp.CPUID);

--- a/examples/fmc.rs
+++ b/examples/fmc.rs
@@ -55,7 +55,6 @@ const APP: () = {
         let mut delay = ctx.core.SYST.delay(ccdr.clocks);
 
         // Initialise system...
-        ctx.core.SCB.invalidate_icache();
         ctx.core.SCB.enable_icache();
         // See Errata Sheet 2.2.1
         //ctx.core.SCB.enable_dcache(&mut ctx.core.CPUID);


### PR DESCRIPTION
The cortex-m [enable_icache](https://github.com/rust-embedded/cortex-m/blob/master/src/peripheral/scb.rs#L328) method already invalidates before enabling (and is guaranteed to do so in the docs too).