### PR TITLE
Removing various clippy lints

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --examples --target thumbv7em-none-eabihf --features=rt,stm32h743v
+          args: --examples --target thumbv7em-none-eabihf --features=rt,stm32h743v -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+* Fixed clippy lints:
+   * Added safety docs for some DMA functions
+   * Implemented additional conversion utilities for `time`
+   * Changed I2S constructors to take less arguments
 
 ## [v0.10.0] 2021-07-xx
 

--- a/examples/sai-i2s-passthru.rs
+++ b/examples/sai-i2s-passthru.rs
@@ -16,8 +16,8 @@ pub use stm32h7xx_hal::hal::digital::v2::OutputPin;
 use stm32h7xx_hal::prelude::*;
 use stm32h7xx_hal::rcc::rec::Sai1ClkSel;
 use stm32h7xx_hal::sai::{
-    self, I2SChanConfig, I2SDataSize, I2SDir, I2SSync, Sai, SaiChannel,
-    SaiI2sExt, I2S,
+    self, I2SChanConfig, I2SDataSize, I2SDir, I2SSync, I2sUsers, Sai,
+    SaiChannel, SaiI2sExt, I2S,
 };
 use stm32h7xx_hal::stm32;
 use stm32h7xx_hal::time::{Hertz, U32Ext};
@@ -87,8 +87,7 @@ const APP: () = {
             I2SDataSize::BITS_24,
             sai1_rec,
             &ccdr.clocks,
-            master_config,
-            Some(slave_config),
+            I2sUsers::new(master_config).add_slave(slave_config),
         );
 
         // Setup cache

--- a/examples/sai_dma_passthru.rs
+++ b/examples/sai_dma_passthru.rs
@@ -14,7 +14,7 @@ use hal::device;
 use hal::dma;
 use hal::hal::digital::v2::OutputPin;
 use hal::rcc::rec::Sai1ClkSel;
-use hal::sai::{self, SaiChannel, SaiI2sExt};
+use hal::sai::{self, I2sUsers, SaiChannel, SaiI2sExt};
 use hal::stm32;
 use hal::{pac, prelude::*};
 use stm32h7xx_hal as hal;
@@ -157,8 +157,7 @@ fn main() -> ! {
         sai::I2SDataSize::BITS_24,
         sai1_rec,
         &ccdr.clocks,
-        sai1_tx_config,
-        Some(sai1_rx_config),
+        I2sUsers::new(sai1_tx_config).add_slave(sai1_rx_config),
     );
 
     // - reset ak4556 codec -----------------------------------------------

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -67,7 +67,7 @@ impl Delay {
     pub fn new(mut syst: SYST, clocks: CoreClocks) -> Self {
         syst.set_clock_source(SystClkSource::External);
 
-        Delay { syst, clocks }
+        Delay { clocks, syst }
     }
 
     /// Releases the system timer (SysTick) resource

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -29,6 +29,8 @@ use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
 #[macro_use]
 mod macros;
 
+// Note: In the future, it may make sense to restructure the DMA module.
+#[allow(clippy::module_inception)]
 pub mod dma; // DMA1 and DMA2
 
 pub mod bdma;

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -610,15 +610,18 @@ macro_rules! db_transfer_def {
             /// then call a function on the now inactive buffer and acknowledge the
             /// transfer complete flag.
             ///
-            /// NOTE(panic): This will panic then used in single buffer mode (not DBM).
+            /// # Panics
+            /// This will panic then used in single buffer mode (not DBM).
             ///
-            /// NOTE(unsafe): Memory safety is not guaranteed.
+            /// # Safety
+            /// Memory safety is not guaranteed.
             /// The user must ensure that the user function called on the inactive
             /// buffer completes before the running DMA transfer of the active buffer
             /// completes. If the DMA wins the race to the inactive buffer
             /// a `DMAError::Overflow` is returned but processing continues.
             ///
-            /// NOTE(fence): The user function must ensure buffer access ordering
+            /// ## Memory Fencing
+            /// The user function must ensure buffer access ordering
             /// against the flag accesses. Call
             /// `core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst)`
             /// before and after accessing the buffer.
@@ -632,11 +635,11 @@ macro_rules! db_transfer_def {
                 while !STREAM::get_transfer_complete_flag() { }
                 self.stream.clear_transfer_complete_flag();
 
-                // NOTE(panic): Panic if stream not configured in double buffer mode.
+                // NOTE(unwrap): Panic if stream not configured in double buffer mode.
                 let inactive = STREAM::get_inactive_buffer().unwrap();
 
                 // This buffer is inactive now and can be accessed.
-                // NOTE(panic): We always hold ownership in lieu of the DMA peripheral.
+                // NOTE(unwrap): We always hold ownership in lieu of the DMA peripheral.
                 let buf = self.buf[inactive as usize].as_mut().unwrap();
 
                 let result = func(buf, inactive);

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -96,9 +96,19 @@ pub trait Stream: Sealed {
 /// Trait for Double-Buffered DMA streams
 pub trait DoubleBufferedStream: Stream + Sealed {
     /// Set the peripheral address (par) for the DMA stream.
+    ///
+    /// # Safety
+    /// `value` must point to a valid peripheral hardware address. Once specified, the memory
+    /// pointed to by `value` must not be modified or accessed by the application.
     unsafe fn set_peripheral_address(&mut self, value: usize);
 
     /// Set the memory address (m0ar or m1ar) for the DMA stream.
+    ///
+    /// # Safety
+    /// The memory pointed to by `value` must not be accessed by the application once provided to
+    /// this function. The memory is logically owned by the DMA peripheral at that point and
+    /// synchronization must be completed to ensure that concurrent access by DMA and the
+    /// application does not occur.
     unsafe fn set_memory_address(
         &mut self,
         buffer: CurrentBuffer,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -361,16 +361,16 @@ macro_rules! gpio {
                 let offset2 = 4 * index;
                 unsafe {
                     if offset2 < 32 {
-                        &(*$GPIOX::ptr()).afrl.modify(|r, w| {
+                        (*$GPIOX::ptr()).afrl.modify(|r, w| {
                             w.bits((r.bits() & !(0b1111 << offset2)) | (mode << offset2))
                         });
                     } else {
                         let offset2 = offset2 - 32;
-                        &(*$GPIOX::ptr()).afrh.modify(|r, w| {
+                        (*$GPIOX::ptr()).afrh.modify(|r, w| {
                             w.bits((r.bits() & !(0b1111 << offset2)) | (mode << offset2))
                         });
                     }
-                    &(*$GPIOX::ptr()).moder.modify(|r, w| {
+                    (*$GPIOX::ptr()).moder.modify(|r, w| {
                         w.bits((r.bits() & !(0b11 << offset)) | (0b10 << offset))
                     });
                 }
@@ -484,10 +484,10 @@ macro_rules! gpio {
                     pub fn into_floating_input(self) -> $PXi<Input<Floating>> {
                         let offset = 2 * $i;
                         unsafe {
-                            &(*$GPIOX::ptr()).pupdr.modify(|r, w| {
+                            (*$GPIOX::ptr()).pupdr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b00 << offset))
                             });
-                            &(*$GPIOX::ptr()).moder.modify(|r, w| {
+                            (*$GPIOX::ptr()).moder.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b00 << offset))
                             })
                         };
@@ -500,10 +500,10 @@ macro_rules! gpio {
                     pub fn into_pull_down_input(self) -> $PXi<Input<PullDown>> {
                         let offset = 2 * $i;
                         unsafe {
-                            &(*$GPIOX::ptr()).pupdr.modify(|r, w| {
+                            (*$GPIOX::ptr()).pupdr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b10 << offset))
                             });
-                            &(*$GPIOX::ptr()).moder.modify(|r, w| {
+                            (*$GPIOX::ptr()).moder.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b00 << offset))
                             })
                         };
@@ -516,10 +516,10 @@ macro_rules! gpio {
                     pub fn into_pull_up_input(self) -> $PXi<Input<PullUp>> {
                         let offset = 2 * $i;
                         unsafe {
-                            &(*$GPIOX::ptr()).pupdr.modify(|r, w| {
+                            (*$GPIOX::ptr()).pupdr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b01 << offset))
                             });
-                            &(*$GPIOX::ptr()).moder.modify(|r, w| {
+                            (*$GPIOX::ptr()).moder.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b00 << offset))
                             }
                         )};
@@ -532,13 +532,13 @@ macro_rules! gpio {
                     pub fn into_open_drain_output(self) -> $PXi<Output<OpenDrain>> {
                         let offset = 2 * $i;
                         unsafe {
-                            &(*$GPIOX::ptr()).pupdr.modify(|r, w| {
+                            (*$GPIOX::ptr()).pupdr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b00 << offset))
                             });
-                            &(*$GPIOX::ptr()).otyper.modify(|r, w| {
+                            (*$GPIOX::ptr()).otyper.modify(|r, w| {
                                 w.bits(r.bits() | (0b1 << $i))
                             });
-                            &(*$GPIOX::ptr()).moder.modify(|r, w| {
+                            (*$GPIOX::ptr()).moder.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b01 << offset))
                             })
                         };
@@ -552,13 +552,13 @@ macro_rules! gpio {
                         let offset = 2 * $i;
 
                         unsafe {
-                            &(*$GPIOX::ptr()).pupdr.modify(|r, w| {
+                            (*$GPIOX::ptr()).pupdr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b00 << offset))
                             });
-                            &(*$GPIOX::ptr()).otyper.modify(|r, w| {
+                            (*$GPIOX::ptr()).otyper.modify(|r, w| {
                                 w.bits(r.bits() & !(0b1 << $i))
                             });
-                            &(*$GPIOX::ptr()).moder.modify(|r, w| {
+                            (*$GPIOX::ptr()).moder.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b01 << offset))
                             })
                         };
@@ -572,10 +572,10 @@ macro_rules! gpio {
                         let offset = 2 * $i;
 
                         unsafe {
-                            &(*$GPIOX::ptr()).pupdr.modify(|r, w| {
+                            (*$GPIOX::ptr()).pupdr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b00 << offset))
                             });
-                            &(*$GPIOX::ptr()).moder.modify(|r, w| {
+                            (*$GPIOX::ptr()).moder.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b11 << offset))
                             }
                         )};
@@ -590,7 +590,7 @@ macro_rules! gpio {
                         let offset = 2 * $i;
 
                         unsafe {
-                            &(*$GPIOX::ptr()).ospeedr.modify(|r, w| {
+                            (*$GPIOX::ptr()).ospeedr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | ((speed as u32) << offset))
                             })
                         };
@@ -605,7 +605,7 @@ macro_rules! gpio {
                         let offset = 2 * $i;
                         let value = if on { 0b01 } else { 0b00 };
                         unsafe {
-                            &(*$GPIOX::ptr()).pupdr.modify(|r, w| {
+                            (*$GPIOX::ptr()).pupdr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (value << offset))
                             })
                         };
@@ -618,7 +618,7 @@ macro_rules! gpio {
                         let offset = 2 * $i;
 
                         unsafe {
-                            &(*$GPIOX::ptr()).ospeedr.modify(|r, w| {
+                            (*$GPIOX::ptr()).ospeedr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | ((speed as u32) << offset))
                             })
                         };
@@ -631,7 +631,7 @@ macro_rules! gpio {
                         let offset = 2 * $i;
                         let value = if on { 0b01 } else { 0b00 };
                         unsafe {
-                            &(*$GPIOX::ptr()).pupdr.modify(|r, w| {
+                            (*$GPIOX::ptr()).pupdr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (value << offset))
                             })
                         };
@@ -646,7 +646,7 @@ macro_rules! gpio {
                     pub fn set_open_drain(self) -> Self {
                         let offset = $i;
                         unsafe {
-                            &(*$GPIOX::ptr()).otyper.modify(|r, w| {
+                            (*$GPIOX::ptr()).otyper.modify(|r, w| {
                                 w.bits(r.bits() | (1 << offset))
                             })
                         };

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -168,7 +168,6 @@ use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 
 use crate::hal;
-use crate::stm32;
 use crate::stm32::{lptim1, lptim3};
 use crate::stm32::{LPTIM1, LPTIM2, LPTIM3};
 #[cfg(not(feature = "rm0455"))]

--- a/src/sai/mod.rs
+++ b/src/sai/mod.rs
@@ -26,7 +26,7 @@ pub use pdm::SaiPdmExt;
 mod i2s;
 pub use i2s::{
     I2SChanConfig, I2SClockStrobe, I2SCompanding, I2SComplement, I2SDataSize,
-    I2SDir, I2SMode, I2SProtocol, I2SSync, SaiI2sExt, I2S,
+    I2SDir, I2SMode, I2SProtocol, I2SSync, I2sUsers, SaiI2sExt, I2S,
 };
 
 /// Trait for associating clocks with SAI instances

--- a/src/sai/pdm.rs
+++ b/src/sai/pdm.rs
@@ -162,10 +162,10 @@ pins! {
 }
 
 /// Pulse Density Modulation Interface
-pub struct PDM {
+pub struct Pdm {
     invalid_countdown: u8,
 }
-impl INTERFACE for PDM {}
+impl INTERFACE for Pdm {}
 
 /// Trait to extend SAI peripherals
 pub trait SaiPdmExt<SAI>: Sized {
@@ -177,7 +177,7 @@ pub trait SaiPdmExt<SAI>: Sized {
         clock: T,
         prec: Self::Rec,
         clocks: &CoreClocks,
-    ) -> Sai<SAI, PDM>
+    ) -> Sai<SAI, Pdm>
     where
         PINS: PulseDensityPins<Self>,
         T: Into<Hertz>;
@@ -195,7 +195,7 @@ macro_rules! hal {
                     clock: T,
                     prec: rec::$Rec,
                     clocks: &CoreClocks,
-                ) -> Sai<Self, PDM>
+                ) -> Sai<Self, Pdm>
                 where
                     PINS: PulseDensityPins<Self>,
                     T: Into<Hertz>,
@@ -203,7 +203,7 @@ macro_rules! hal {
                     Sai::$pdm_saiX(self, _pins, clock.into(), prec, clocks)
                 }
             }
-            impl Sai<$SAIX, PDM> {
+            impl Sai<$SAIX, Pdm> {
                 /// Read a single data word (one 'slot')
                 pub fn read_data(&mut self) -> nb::Result<u32, Never> {
                     while self.interface.invalid_countdown > 0 {
@@ -261,7 +261,7 @@ macro_rules! hal {
                         rb: sai,
                         master_channel: SaiChannel::ChannelA,
                         slave_channel: None,
-                        interface: PDM {
+                        interface: Pdm {
                             // count slots for 2 frames
                             invalid_countdown: 2 * (nbslot + 1),
                         },

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -286,17 +286,11 @@ impl HardwareCS {
     }
 
     fn enabled(&self) -> bool {
-        match self.mode {
-            HardwareCSMode::Disabled => false,
-            _ => true,
-        }
+        !matches!(self.mode, HardwareCSMode::Disabled)
     }
 
     fn interleaved_cs(&self) -> bool {
-        match self.mode {
-            HardwareCSMode::WordTransaction { .. } => true,
-            _ => false,
-        }
+        matches!(self.mode, HardwareCSMode::WordTransaction { .. })
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -123,114 +123,112 @@ impl U32Ext for u32 {
 }
 
 // Unit conversions
-impl Into<Hertz> for Bps {
-    fn into(self) -> Hertz {
-        Hertz(self.0)
+impl From<Bps> for Hertz {
+    fn from(bps: Bps) -> Self {
+        Self(bps.0)
     }
 }
 
-impl Into<Hertz> for KiloHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000)
+impl From<KiloHertz> for Hertz {
+    fn from(khz: KiloHertz) -> Self {
+        Self(khz.0 * 1_000)
     }
 }
 
-impl Into<Hertz> for MegaHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000_000)
+impl From<MegaHertz> for Hertz {
+    fn from(mhz: MegaHertz) -> Self {
+        Self(mhz.0 * 1_000_000)
     }
 }
 
-impl Into<KiloHertz> for MegaHertz {
-    fn into(self) -> KiloHertz {
-        KiloHertz(self.0 * 1_000)
+impl From<MegaHertz> for KiloHertz {
+    fn from(mhz: MegaHertz) -> Self {
+        Self(mhz.0 * 1_000)
     }
 }
 
-impl Into<NanoSeconds> for MicroSeconds {
-    fn into(self) -> NanoSeconds {
-        NanoSeconds(self.0 * 1_000)
+impl From<MicroSeconds> for NanoSeconds {
+    fn from(us: MicroSeconds) -> Self {
+        Self(us.0 * 1_000)
     }
 }
 
-impl Into<NanoSeconds> for MilliSeconds {
-    fn into(self) -> NanoSeconds {
-        NanoSeconds(self.0 * 1_000_000)
+impl From<MilliSeconds> for NanoSeconds {
+    fn from(ms: MilliSeconds) -> Self {
+        Self(ms.0 * 1_000_000)
     }
 }
 
-impl Into<MicroSeconds> for MilliSeconds {
-    fn into(self) -> MicroSeconds {
-        MicroSeconds(self.0 * 1_000)
+impl From<MilliSeconds> for MicroSeconds {
+    fn from(ms: MilliSeconds) -> Self {
+        Self(ms.0 * 1_000)
     }
 }
 
 // MilliSeconds <-> Hertz
-impl Into<MilliSeconds> for Hertz {
-    fn into(self) -> MilliSeconds {
-        let freq = self.0;
+impl From<Hertz> for MilliSeconds {
+    fn from(hz: Hertz) -> Self {
+        let freq = hz.0;
         assert!(freq != 0 && freq <= 1_000);
-        MilliSeconds(1_000 / freq)
+        Self(1_000 / freq)
     }
 }
-impl Into<Hertz> for MilliSeconds {
-    fn into(self) -> Hertz {
-        let period = self.0;
+impl From<MilliSeconds> for Hertz {
+    fn from(ms: MilliSeconds) -> Self {
+        let period = ms.0;
         assert!(period != 0 && period <= 1_000);
-        Hertz(1_000 / period)
+        Self(1_000 / period)
     }
 }
 
 // MicroSeconds <-> Hertz
-impl Into<MicroSeconds> for Hertz {
-    fn into(self) -> MicroSeconds {
-        let freq = self.0;
+impl From<Hertz> for MicroSeconds {
+    fn from(hz: Hertz) -> Self {
+        let freq = hz.0;
         assert!(freq != 0 && freq <= 1_000_000);
-        MicroSeconds(1_000_000 / freq)
+        Self(1_000_000 / freq)
     }
 }
-impl Into<Hertz> for MicroSeconds {
-    fn into(self) -> Hertz {
-        let period = self.0;
+impl From<MicroSeconds> for Hertz {
+    fn from(us: MicroSeconds) -> Self {
+        let period = us.0;
         assert!(period != 0 && period <= 1_000_000);
-        Hertz(1_000_000 / period)
+        Self(1_000_000 / period)
     }
 }
 
 // NanoSeconds <-> Hertz
-impl Into<NanoSeconds> for Hertz {
-    fn into(self) -> NanoSeconds {
-        let freq = self.0;
+impl From<Hertz> for NanoSeconds {
+    fn from(hz: Hertz) -> Self {
+        let freq = hz.0;
         assert!(freq != 0 && freq <= 1_000_000_000);
-        NanoSeconds(1_000_000_000 / freq)
+        Self(1_000_000_000 / freq)
     }
 }
-impl Into<Hertz> for NanoSeconds {
-    fn into(self) -> Hertz {
-        let period = self.0;
+impl From<NanoSeconds> for Hertz {
+    fn from(ns: NanoSeconds) -> Self {
+        let period = ns.0;
         assert!(period != 0 && period <= 1_000_000_000);
-        Hertz(1_000_000_000 / period)
+        Self(1_000_000_000 / period)
     }
 }
 
-// Into core::time::Duration
-impl Into<Duration> for MilliSeconds {
-    fn into(self) -> Duration {
-        Duration::from_millis(self.0 as u64)
+// Implement conversion from time periods into core::time::Duration
+impl From<MilliSeconds> for Duration {
+    fn from(ms: MilliSeconds) -> Self {
+        Self::from_millis(ms.0 as u64)
     }
 }
 
-// Into core::time::Duration
-impl Into<Duration> for MicroSeconds {
-    fn into(self) -> Duration {
-        Duration::from_micros(self.0 as u64)
+impl From<MicroSeconds> for Duration {
+    fn from(us: MicroSeconds) -> Self {
+        Self::from_micros(us.0 as u64)
     }
 }
 
-// Into core::time::Duration
-impl Into<Duration> for NanoSeconds {
-    fn into(self) -> Duration {
-        Duration::from_nanos(self.0 as u64)
+impl From<NanoSeconds> for Duration {
+    fn from(ns: NanoSeconds) -> Self {
+        Self::from_nanos(ns.0 as u64)
     }
 }
 


### PR DESCRIPTION
This PR removes a variety of clippy lints.

Notable changes:
* Time conversion now implements more traits (preferring From over Into)
* I2S constructor now uses a combination type to take less arguments
* Lint warnings are now elevated to failure in CI