### PR TITLE
Add support for STM32H725/735 parts

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -9,6 +9,7 @@ status = [
     "ci (1.51.0, stm32h747cm7)",
     "ci (1.51.0, stm32h7b3)",
     "ci (1.51.0, stm32h7b0)",
+    "ci (1.51.0, stm32h735)",
     "ci (stable, stm32h743)",
     "ci (stable, stm32h753)",
     "ci (stable, stm32h743v)",
@@ -16,4 +17,5 @@ status = [
     "ci (stable, stm32h747cm7)",
     "ci (stable, stm32h7b3)",
     "ci (stable, stm32h7b0)",
+    "ci (stable, stm32h735)",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - stm32h747cm7
           - stm32h7b3
           - stm32h7b0
+          - stm32h735
     env:                        # Peripheral Feature flags
       FLAGS: rt,quadspi,sdmmc,fmc,usb_hs,rtc,ethernet,ltdc,crc
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ revision_v = []
 rm0433 = []                     # aka. "single core" devices
 rm0399 = []                     # aka. "dual core" devices
 rm0455 = []                     # aka. "high memory integration" devices
+rm0468 = []                     # aka. "high speed" devices
 dsi = []
 cm4 = []
 cm7 = []
@@ -104,6 +105,7 @@ stm32h747cm7 = ["stm32h7/stm32h747cm7", "device-selected", "revision_v", "rm0399
 stm32h7b3 = ["stm32h7/stm32h7b3", "device-selected", "revision_v", "rm0455", "smps"]
 stm32h7b0 = ["stm32h7/stm32h7b3", "device-selected", "revision_v", "rm0455", "smps"]
 stm32h7a3 = ["stm32h7/stm32h7b3", "device-selected", "revision_v", "rm0455", "smps"]
+stm32h735 = ["stm32h7/stm32h735", "device-selected", "revision_v", "rm0468", "smps"]
 # Flags for examples
 log-itm = []
 log-rtt = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,10 @@ name = "ethernet-rtic-stm32h747i-disco"
 required-features = ["rt", "stm32h747cm7", "ethernet"]
 
 [[example]]
+name = "ethernet-rtic-stm32h735g-dk"
+required-features = ["rt", "stm32h735", "ethernet"]
+
+[[example]]
 name = "ethernet-nucleo-h743zi2"
 required-features = ["rt", "revision_v", "stm32h743v", "ethernet"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ required-features = ["rt"]
 
 [[example]]
 name = "rtic_timers"
-required-features = ["rt"]
+required-features = ["rt", "rm0433"]
 
 [[example]]
 name = "vos0"
@@ -139,7 +139,7 @@ required-features = ["revision_v", "rm0433"]
 
 [[example]]
 name = "fmc"
-required-features = ["fmc"]
+required-features = ["fmc", "rm0399"]
 
 [[example]]
 name = "qspi"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Supported Configurations
 * __stm32h7b3__
 * __stm32h7b0__
 * __stm32h7a3__
+* __stm32h735__ (stm32h725, stm32h735)
 
 #### Old revision STM32H742/743/750/753 parts
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ Examples
 
 For these parts, the program needs to know more about the power supply
 scheme in order to successfully transition from Run* mode to Run mode. For
-en explaination of Run* mode, see RM0433 Rev 7 Section 6.6.1 "System/D3
+an explaination of Run* mode, see RM0433 Rev 7 Section 6.6.1 "System/D3
 domain modes".
 
 For your own code, see the

--- a/examples/ethernet-rtic-stm32h735g-dk.rs
+++ b/examples/ethernet-rtic-stm32h735g-dk.rs
@@ -1,0 +1,230 @@
+//! Demo for STM32H735G-DK eval board using the Real Time for the Masses
+//! (RTIC) framework.
+//!
+//! This demo responds to pings on 192.168.1.99 (IP address hardcoded below)
+//!
+//! We use the SysTick timer to create a 1ms timebase for use with smoltcp.
+//!
+//! The ethernet ring buffers are placed in AXI SRAM, where they can be
+//! accessed by both the core and the Ethernet DMA.
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m;
+use rtic::app;
+
+#[macro_use]
+#[allow(unused)]
+mod utilities;
+use log::info;
+
+use smoltcp::iface::{
+    EthernetInterface, EthernetInterfaceBuilder, Neighbor, NeighborCache,
+    Route, Routes,
+};
+use smoltcp::socket::{SocketSet, SocketSetItem};
+use smoltcp::time::Instant;
+use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv6Cidr};
+
+use gpio::Speed::*;
+use stm32h7xx_hal::gpio;
+use stm32h7xx_hal::hal::digital::v2::OutputPin;
+use stm32h7xx_hal::rcc::CoreClocks;
+use stm32h7xx_hal::{ethernet, ethernet::PHY};
+use stm32h7xx_hal::{prelude::*, stm32};
+
+use core::sync::atomic::{AtomicU32, Ordering};
+
+/// Configure SYSTICK for 1ms timebase
+fn systick_init(mut syst: stm32::SYST, clocks: CoreClocks) {
+    let c_ck_mhz = clocks.c_ck().0 / 1_000_000;
+
+    let syst_calib = 0x3E8;
+
+    syst.set_clock_source(cortex_m::peripheral::syst::SystClkSource::Core);
+    syst.set_reload((syst_calib * c_ck_mhz) - 1);
+    syst.enable_interrupt();
+    syst.enable_counter();
+}
+
+/// TIME is an atomic u32 that counts milliseconds.
+static TIME: AtomicU32 = AtomicU32::new(0);
+
+/// Locally administered MAC address
+const MAC_ADDRESS: [u8; 6] = [0x02, 0x00, 0x11, 0x22, 0x33, 0x44];
+
+/// Ethernet descriptor rings are a global singleton
+#[link_section = ".axisram.eth"]
+static mut DES_RING: ethernet::DesRing = ethernet::DesRing::new();
+
+/// Net storage with static initialisation - another global singleton
+pub struct NetStorageStatic<'a> {
+    ip_addrs: [IpCidr; 1],
+    socket_set_entries: [Option<SocketSetItem<'a>>; 8],
+    neighbor_cache_storage: [Option<(IpAddress, Neighbor)>; 8],
+    routes_storage: [Option<(IpCidr, Route)>; 1],
+}
+static mut STORE: NetStorageStatic = NetStorageStatic {
+    // Garbage
+    ip_addrs: [IpCidr::Ipv6(Ipv6Cidr::SOLICITED_NODE_PREFIX)],
+    socket_set_entries: [None, None, None, None, None, None, None, None],
+    neighbor_cache_storage: [None; 8],
+    routes_storage: [None; 1],
+};
+
+pub struct Net<'a> {
+    iface: EthernetInterface<'a, ethernet::EthernetDMA<'a>>,
+    sockets: SocketSet<'a>,
+}
+impl<'a> Net<'a> {
+    pub fn new(
+        store: &'static mut NetStorageStatic<'a>,
+        ethdev: ethernet::EthernetDMA<'a>,
+        ethernet_addr: EthernetAddress,
+    ) -> Self {
+        // Set IP address
+        store.ip_addrs =
+            [IpCidr::new(IpAddress::v4(192, 168, 1, 99).into(), 0)];
+
+        let neighbor_cache =
+            NeighborCache::new(&mut store.neighbor_cache_storage[..]);
+        let routes = Routes::new(&mut store.routes_storage[..]);
+
+        let iface = EthernetInterfaceBuilder::new(ethdev)
+            .ethernet_addr(ethernet_addr)
+            .neighbor_cache(neighbor_cache)
+            .ip_addrs(&mut store.ip_addrs[..])
+            .routes(routes)
+            .finalize();
+        let sockets = SocketSet::new(&mut store.socket_set_entries[..]);
+
+        return Net { iface, sockets };
+    }
+
+    /// Polls on the ethernet interface. You should refer to the smoltcp
+    /// documentation for poll() to understand how to call poll efficiently
+    pub fn poll(&mut self, now: i64) {
+        let timestamp = Instant::from_millis(now);
+
+        self.iface
+            .poll(&mut self.sockets, timestamp)
+            .map(|_| ())
+            .unwrap_or_else(|e| info!("Poll: {:?}", e));
+    }
+}
+
+#[app(device = stm32h7xx_hal::stm32, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        net: Net<'static>,
+        lan8742a: ethernet::phy::LAN8742A<ethernet::EthernetMAC>,
+        link_led: gpio::gpioc::PC3<gpio::Output<gpio::PushPull>>,
+    }
+
+    #[init]
+    fn init(mut ctx: init::Context) -> init::LateResources {
+        utilities::logger::init();
+        // Initialise power...
+        let pwr = ctx.device.PWR.constrain();
+        let pwrcfg = pwr.smps().freeze();
+
+        // Initialise clocks...
+        let rcc = ctx.device.RCC.constrain();
+        let ccdr = rcc
+            .sys_ck(200.mhz())
+            .hclk(200.mhz())
+            .freeze(pwrcfg, &ctx.device.SYSCFG);
+
+        // Initialise system...
+        ctx.core.SCB.invalidate_icache();
+        ctx.core.SCB.enable_icache();
+        // TODO: ETH DMA coherence issues
+        // ctx.core.SCB.enable_dcache(&mut ctx.core.CPUID);
+        ctx.core.DWT.enable_cycle_counter();
+
+        // Initialise IO...
+        let gpioa = ctx.device.GPIOA.split(ccdr.peripheral.GPIOA);
+        let gpioc = ctx.device.GPIOC.split(ccdr.peripheral.GPIOC);
+        let gpiob = ctx.device.GPIOB.split(ccdr.peripheral.GPIOB);
+        let mut link_led = gpioc.pc3.into_push_pull_output(); // USR LED1
+        link_led.set_high().ok();
+
+        let _rmii_ref_clk = gpioa.pa1.into_alternate_af11().set_speed(VeryHigh);
+        let _rmii_mdio = gpioa.pa2.into_alternate_af11().set_speed(VeryHigh);
+        let _rmii_mdc = gpioc.pc1.into_alternate_af11().set_speed(VeryHigh);
+        let _rmii_crs_dv = gpioa.pa7.into_alternate_af11().set_speed(VeryHigh);
+        let _rmii_rxd0 = gpioc.pc4.into_alternate_af11().set_speed(VeryHigh);
+        let _rmii_rxd1 = gpioc.pc5.into_alternate_af11().set_speed(VeryHigh);
+        let _rmii_tx_en = gpiob.pb11.into_alternate_af11().set_speed(VeryHigh);
+        let _rmii_txd0 = gpiob.pb12.into_alternate_af11().set_speed(VeryHigh);
+        let _rmii_txd1 = gpiob.pb13.into_alternate_af11().set_speed(VeryHigh);
+
+        // Initialise ethernet...
+        assert_eq!(ccdr.clocks.hclk().0, 200_000_000); // HCLK 200MHz
+        assert_eq!(ccdr.clocks.pclk1().0, 100_000_000); // PCLK 100MHz
+        assert_eq!(ccdr.clocks.pclk2().0, 100_000_000); // PCLK 100MHz
+        assert_eq!(ccdr.clocks.pclk4().0, 100_000_000); // PCLK 100MHz
+
+        let mac_addr = smoltcp::wire::EthernetAddress::from_bytes(&MAC_ADDRESS);
+        let (eth_dma, eth_mac) = unsafe {
+            ethernet::new_unchecked(
+                ctx.device.ETHERNET_MAC,
+                ctx.device.ETHERNET_MTL,
+                ctx.device.ETHERNET_DMA,
+                &mut DES_RING,
+                mac_addr.clone(),
+                ccdr.peripheral.ETH1MAC,
+                &ccdr.clocks,
+            )
+        };
+
+        // Initialise ethernet PHY...
+        let mut lan8742a = ethernet::phy::LAN8742A::new(eth_mac);
+        lan8742a.phy_reset();
+        lan8742a.phy_init();
+        // The eth_dma should not be used until the PHY reports the link is up
+
+        unsafe {
+            ethernet::enable_interrupt();
+        }
+
+        // unsafe: mutable reference to static storage, we only do this once
+        let store = unsafe { &mut STORE };
+        let net = Net::new(store, eth_dma, mac_addr);
+
+        // 1ms tick
+        systick_init(ctx.core.SYST, ccdr.clocks);
+
+        init::LateResources {
+            net,
+            lan8742a,
+            link_led,
+        }
+    }
+
+    #[idle(resources = [lan8742a, link_led])]
+    fn idle(ctx: idle::Context) -> ! {
+        loop {
+            // Ethernet
+            match ctx.resources.lan8742a.poll_link() {
+                true => ctx.resources.link_led.set_low(),
+                _ => ctx.resources.link_led.set_high(),
+            }
+            .ok();
+        }
+    }
+
+    #[task(binds = ETH, resources = [net])]
+    fn ethernet_event(ctx: ethernet_event::Context) {
+        unsafe { ethernet::interrupt_handler() }
+
+        let time = TIME.load(Ordering::Relaxed);
+        ctx.resources.net.poll(time as i64);
+    }
+
+    #[task(binds = SysTick, priority=15)]
+    fn systick_tick(_: systick_tick::Context) {
+        TIME.fetch_add(1, Ordering::Relaxed);
+    }
+};

--- a/examples/fmc.rs
+++ b/examples/fmc.rs
@@ -1,4 +1,7 @@
 //! FMC Example
+//!
+//! Tested on a STM32H747I-DISCO
+
 #![no_main]
 #![no_std]
 

--- a/examples/prec_kernel_clocks.rs
+++ b/examples/prec_kernel_clocks.rs
@@ -6,7 +6,7 @@
 mod utilities;
 
 use cortex_m_rt::entry;
-use stm32h7xx_hal::rcc::{rec, rec::I2c123ClkSel, ResetEnable};
+use stm32h7xx_hal::rcc::{rec, rec::Spi123ClkSel, ResetEnable};
 use stm32h7xx_hal::{pac, prelude::*};
 
 fn enable_fdcan(rec: rec::Fdcan) {
@@ -34,8 +34,8 @@ fn main() -> ! {
         .pll3_r_ck(4.mhz())
         .freeze(pwrcfg, &dp.SYSCFG);
 
-    // Set group kernel clock to PLL3 R CK. Needs mutable ccdr
-    ccdr.peripheral.kernel_i2c123_clk_mux(I2c123ClkSel::PLL3_R);
+    // Set group kernel clock to PLL3 P CK. Needs mutable ccdr
+    ccdr.peripheral.kernel_spi123_clk_mux(Spi123ClkSel::PLL3_P);
 
     // (now ccdr can be immutable)
 

--- a/examples/rtic.rs
+++ b/examples/rtic.rs
@@ -8,7 +8,7 @@ extern crate rtic;
 use stm32h7xx_hal::hal::digital::v2::ToggleableOutputPin;
 
 use rtic::app;
-use stm32h7xx_hal::gpio::{gpioc::PC13, gpioi::PI13};
+use stm32h7xx_hal::gpio::gpioc::{PC13, PC3};
 use stm32h7xx_hal::gpio::{Edge, ExtiPin, Floating, Input};
 use stm32h7xx_hal::gpio::{Output, PushPull};
 use stm32h7xx_hal::prelude::*;
@@ -23,7 +23,7 @@ use panic_halt as _;
 const APP: () = {
     struct Resources {
         button: PC13<Input<Floating>>,
-        led: PI13<Output<PushPull>>,
+        led: PC3<Output<PushPull>>,
     }
 
     #[init]
@@ -37,7 +37,6 @@ const APP: () = {
 
         // GPIO
         let gpioc = ctx.device.GPIOC.split(ccdr.peripheral.GPIOC);
-        let gpioi = ctx.device.GPIOI.split(ccdr.peripheral.GPIOI);
 
         // Button
         let mut button = gpioc.pc13.into_floating_input();
@@ -47,7 +46,7 @@ const APP: () = {
 
         init::LateResources {
             button,
-            led: gpioi.pi13.into_push_pull_output(),
+            led: gpioc.pc3.into_push_pull_output(),
         }
     }
 

--- a/examples/rtic_low_power.rs
+++ b/examples/rtic_low_power.rs
@@ -25,7 +25,7 @@ extern crate rtic;
 use stm32h7xx_hal::hal::digital::v2::{OutputPin, ToggleableOutputPin};
 
 use rtic::app;
-use stm32h7xx_hal::gpio::gpioi::{PI12, PI13, PI14};
+use stm32h7xx_hal::gpio::gpioc::{PC2, PC3, PC4};
 use stm32h7xx_hal::gpio::{Edge, ExtiPin, Output, PushPull};
 use stm32h7xx_hal::prelude::*;
 use stm32h7xx_hal::rcc::LowPowerMode;
@@ -35,9 +35,9 @@ use stm32h7xx_hal::timer::{Enabled, Event, LpTimer, Timer};
 #[app(device = stm32h7xx_hal::stm32, peripherals = true)]
 const APP: () = {
     struct Resources {
-        led1: PI12<Output<PushPull>>,
-        led2: PI13<Output<PushPull>>,
-        led3: PI14<Output<PushPull>>,
+        led1: PC2<Output<PushPull>>,
+        led2: PC3<Output<PushPull>>,
+        led3: PC4<Output<PushPull>>,
         timer1: Timer<TIM1>,
         timer2: Timer<TIM2>,
         timer3: LpTimer<LPTIM3, Enabled>,
@@ -96,7 +96,6 @@ const APP: () = {
 
         // GPIO
         let gpioc = ctx.device.GPIOC.split(ccdr.peripheral.GPIOC);
-        let gpioi = ctx.device.GPIOI.split(ccdr.peripheral.GPIOI);
 
         // Enter CStop mode
         let mut scb = ctx.core.SCB;
@@ -110,9 +109,9 @@ const APP: () = {
         wakeup.enable_interrupt(&mut exti);
 
         // LEDs
-        let mut led1 = gpioi.pi12.into_push_pull_output();
-        let mut led2 = gpioi.pi13.into_push_pull_output();
-        let mut led3 = gpioi.pi14.into_push_pull_output();
+        let mut led1 = gpioc.pc2.into_push_pull_output();
+        let mut led2 = gpioc.pc3.into_push_pull_output();
+        let mut led3 = gpioc.pc4.into_push_pull_output();
 
         led1.set_high().ok();
         led2.set_high().ok();

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
     ccdr.peripheral.kernel_usb_clk_mux(UsbClkSel::HSI48);
 
     // IO
-    #[cfg(not(feature = "rm0455"))]
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
     let (pin_dm, pin_dp) = {
         let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
         (
@@ -44,7 +44,7 @@ fn main() -> ! {
         )
     };
 
-    #[cfg(feature = "rm0455")]
+    #[cfg(any(feature = "rm0455", feature = "rm0468"))]
     let (pin_dm, pin_dp) = {
         let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
         (

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -33,6 +33,10 @@ fn main() -> ! {
     #[cfg(all(feature = "rm0399", feature = "cm4"))]
     let mut watchdog = SystemWindowWatchdog::new(dp.WWDG2, &ccdr);
 
+    // RM0468
+    #[cfg(all(feature = "rm0468"))]
+    let mut watchdog = SystemWindowWatchdog::new(dp.WWDG1, &ccdr);
+
     info!("");
     info!("stm32h7xx-hal example - Watchdog");
     info!("");

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -43,9 +43,9 @@ const ADC_KER_CK_MAX: u32 = 36_000_000;
 #[cfg(feature = "revision_v")]
 const ADC_KER_CK_MAX: u32 = 100_000_000;
 
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 pub type Resolution = crate::stm32::adc3::cfgr::RES_A;
-#[cfg(feature = "rm0455")]
+#[cfg(any(feature = "rm0455", feature = "rm0468"))]
 pub type Resolution = crate::stm32::adc1::cfgr::RES_A;
 
 trait NumberOfBits {

--- a/src/dma/bdma.rs
+++ b/src/dma/bdma.rs
@@ -617,6 +617,7 @@ macro_rules! bdma_stream {
     };
 }
 
+#[cfg(not(feature = "rm0468"))]
 bdma_stream!(
     // Note: the field names start from one, unlike the RM where they start from
     // zero. May need updating if it gets fixed upstream.
@@ -651,6 +652,42 @@ bdma_stream!(
     (
         Stream7, 7, ifcr, ctcif8, chtif8, cteif8, cgif8, isr, tcif8, htif8,
         teif8, gif8
+    ),
+);
+#[cfg(feature = "rm0468")]
+bdma_stream!(
+    // For this sub-familiy, the field names do match the RM.
+    (
+        Stream0, 0, ifcr, ctcif0, chtif0, cteif0, cgif0, isr, tcif0, htif0,
+        teif0, gif0
+    ),
+    (
+        Stream1, 1, ifcr, ctcif1, chtif1, cteif1, cgif1, isr, tcif1, htif1,
+        teif1, gif1
+    ),
+    (
+        Stream2, 2, ifcr, ctcif2, chtif2, cteif2, cgif2, isr, tcif2, htif2,
+        teif2, gif2
+    ),
+    (
+        Stream3, 3, ifcr, ctcif3, chtif3, cteif3, cgif3, isr, tcif3, htif3,
+        teif3, gif3
+    ),
+    (
+        Stream4, 4, ifcr, ctcif4, chtif4, cteif4, cgif4, isr, tcif4, htif4,
+        teif4, gif4
+    ),
+    (
+        Stream5, 5, ifcr, ctcif5, chtif5, cteif5, cgif5, isr, tcif5, htif5,
+        teif5, gif5
+    ),
+    (
+        Stream6, 6, ifcr, ctcif6, chtif6, cteif6, cgif6, isr, tcif6, htif6,
+        teif6, gif6
+    ),
+    (
+        Stream7, 7, ifcr, ctcif7, chtif7, cteif7, cgif7, isr, tcif7, htif7,
+        teif7, gif7
     ),
 );
 

--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -936,10 +936,13 @@ peripheral_target_address!(
 peripheral_target_address!(
     (pac::SAI1, cha.dr, u32, M2P, DMAReq::SAI1A_DMA),
     (pac::SAI1, chb.dr, u32, P2M, DMAReq::SAI1B_DMA),
+);
+#[cfg(not(feature = "rm0468"))]
+peripheral_target_address!(
     (pac::SAI2, cha.dr, u32, M2P, DMAReq::SAI2A_DMA),
     (pac::SAI2, chb.dr, u32, P2M, DMAReq::SAI2B_DMA),
 );
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 peripheral_target_address!(
     (pac::SAI3, cha.dr, u32, M2P, DMAReq::SAI3_A_DMA),
     (pac::SAI3, chb.dr, u32, P2M, DMAReq::SAI3_B_DMA),

--- a/src/ethernet/mod.rs
+++ b/src/ethernet/mod.rs
@@ -97,143 +97,60 @@ pub trait Txd2 {}
 /// Marks a type as a TXD3 pin
 pub trait Txd3 {}
 
-macro_rules! pins {
-    (REF_CLK: [$($REF_CLK:ty),*] TX_CLK: [$($TX_CLK:ty),*]
-     MDIO: [$($MDIO:ty),*] MDC: [$($MDC:ty),*] COL: [$($COL:ty),*]
-     CRS: [$($CRS:ty),*] CRS_DV: [$($CRS_DV:ty),*] PPS_OUT: [$($PPS_OUT:ty),*]
-     RX_ER: [$($RX_ER:ty),*] TX_EN: [$($TX_EN:ty),*]
-     RXD0: [$($RXD0:ty),*] RXD1: [$($RXD1:ty),*] RXD2: [$($RXD2:ty),*] RXD3: [$($RXD3:ty),*]
-     TXD0: [$($TXD0:ty),*] TXD1: [$($TXD1:ty),*] TXD2: [$($TXD2:ty),*] TXD3: [$($TXD3:ty),*]) => {
-        $(
-            impl RefClk for $REF_CLK {}
-        )*
-        $(
-            impl TxClk for $TX_CLK {}
-        )*
-        $(
-            impl Mdio for $MDIO {}
-        )*
-        $(
-            impl Mdc for $MDC {}
-        )*
-        $(
-            impl Col for $COL {}
-        )*
-        $(
-            impl Crs for $CRS {}
-        )*
-        $(
-            impl CrsDv for $CRS_DV {}
-        )*
-        $(
-            impl PpsOut for $PPS_OUT {}
-        )*
-        $(
-            impl RxEr for $RX_ER {}
-        )*
-        $(
-            impl TxEn for $TX_EN {}
-        )*
-        $(
-            impl Rxd0 for $RXD0 {}
-        )*
-        $(
-            impl Rxd1 for $RXD1 {}
-        )*
-        $(
-            impl Rxd2 for $RXD2 {}
-        )*
-        $(
-            impl Rxd3 for $RXD3 {}
-        )*
-        $(
-            impl Txd0 for $TXD0 {}
-        )*
-        $(
-            impl Txd1 for $TXD1 {}
-        )*
-        $(
-            impl Txd2 for $TXD2 {}
-        )*
-        $(
-            impl Txd3 for $TXD3 {}
-        )*
-    }
-}
-
 use crate::gpio::gpioa::{PA0, PA1, PA2, PA3, PA7};
 use crate::gpio::gpiob::{PB0, PB1, PB10, PB11, PB12, PB13, PB5, PB8};
 use crate::gpio::gpioc::{PC1, PC2, PC3, PC4, PC5};
 use crate::gpio::gpioe::PE2;
 use crate::gpio::gpiog::{PG11, PG12, PG13, PG14, PG8};
 use crate::gpio::gpioh::{PH2, PH3, PH6, PH7};
+#[cfg(not(feature = "rm0468"))]
 use crate::gpio::gpioi::PI10;
 use crate::gpio::{Alternate, AF11};
 
-pins! {
-    REF_CLK: [
-        PA1<Alternate<AF11>>
-    ]
-    TX_CLK: [
-        PC3<Alternate<AF11>>
-    ]
-    MDIO: [
-        PA2<Alternate<AF11>>
-    ]
-    MDC: [
-        PC1<Alternate<AF11>>
-    ]
-    COL: [
-        PA3<Alternate<AF11>>,
-        PH3<Alternate<AF11>>
-    ]
-    CRS: [
-        PA0<Alternate<AF11>>,
-        PH2<Alternate<AF11>>
-    ]
-    CRS_DV: [
-        PA7<Alternate<AF11>>
-    ]
-    PPS_OUT: [
-        PB5<Alternate<AF11>>,
-        PG8<Alternate<AF11>>
-    ]
-    RX_ER: [
-        PB10<Alternate<AF11>>,
-        PI10<Alternate<AF11>>
-    ]
-    TX_EN: [
-        PB11<Alternate<AF11>>,
-        PG11<Alternate<AF11>>
-    ]
-    RXD0: [
-        PC4<Alternate<AF11>>
-    ]
-    RXD1: [
-        PC5<Alternate<AF11>>
-    ]
-    RXD2: [
-        PB0<Alternate<AF11>>,
-        PH6<Alternate<AF11>>
-    ]
-    RXD3: [
-        PB1<Alternate<AF11>>,
-        PH7<Alternate<AF11>>
-    ]
-    TXD0: [
-        PB12<Alternate<AF11>>,
-        PG13<Alternate<AF11>>
-    ]
-    TXD1: [
-        PB13<Alternate<AF11>>,
-        PG12<Alternate<AF11>>,
-        PG14<Alternate<AF11>>
-    ]
-    TXD2: [
-        PC2<Alternate<AF11>>
-    ]
-    TXD3: [
-        PB8<Alternate<AF11>>,
-        PE2<Alternate<AF11>>
-    ]
-}
+impl RefClk for PA1<Alternate<AF11>> {}
+
+impl TxClk for PC3<Alternate<AF11>> {}
+
+impl Mdio for PA2<Alternate<AF11>> {}
+
+impl Mdc for PC1<Alternate<AF11>> {}
+
+impl Col for PA3<Alternate<AF11>> {}
+impl Col for PH3<Alternate<AF11>> {}
+
+impl Crs for PA0<Alternate<AF11>> {}
+impl Crs for PH2<Alternate<AF11>> {}
+
+impl CrsDv for PA7<Alternate<AF11>> {}
+
+impl PpsOut for PB5<Alternate<AF11>> {}
+impl PpsOut for PG8<Alternate<AF11>> {}
+
+impl RxEr for PB10<Alternate<AF11>> {}
+#[cfg(not(feature = "rm0468"))]
+impl RxEr for PI10<Alternate<AF11>> {}
+
+impl TxEn for PB11<Alternate<AF11>> {}
+impl TxEn for PG11<Alternate<AF11>> {}
+
+impl Rxd0 for PC4<Alternate<AF11>> {}
+
+impl Rxd1 for PC5<Alternate<AF11>> {}
+
+impl Rxd2 for PB0<Alternate<AF11>> {}
+impl Rxd2 for PH6<Alternate<AF11>> {}
+
+impl Rxd3 for PB1<Alternate<AF11>> {}
+impl Rxd3 for PH7<Alternate<AF11>> {}
+
+impl Txd0 for PB12<Alternate<AF11>> {}
+impl Txd0 for PG13<Alternate<AF11>> {}
+
+impl Txd1 for PB13<Alternate<AF11>> {}
+impl Txd1 for PG12<Alternate<AF11>> {}
+impl Txd1 for PG14<Alternate<AF11>> {}
+
+impl Txd2 for PC2<Alternate<AF11>> {}
+
+impl Txd3 for PB8<Alternate<AF11>> {}
+impl Txd3 for PE2<Alternate<AF11>> {}

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -95,7 +95,7 @@ pub enum Event {
 }
 
 /// Return an EXTI register for the current CPU
-#[cfg(any(feature = "rm0433", feature = "rm0455"))]
+#[cfg(not(feature = "rm0399"))]
 macro_rules! reg_for_cpu {
     ($self:ident, imr1) => {
         $self.cpuimr1

--- a/src/fmc.rs
+++ b/src/fmc.rs
@@ -61,6 +61,7 @@ use crate::gpio::gpiog::{
 use crate::gpio::gpioh::{
     PH10, PH11, PH12, PH13, PH14, PH15, PH2, PH3, PH5, PH6, PH7, PH8, PH9,
 };
+#[cfg(not(feature = "rm0468"))]
 use crate::gpio::gpioi::{PI0, PI1, PI10, PI2, PI3, PI4, PI5, PI6, PI7, PI9};
 use crate::gpio::{Alternate, AF12, AF9};
 
@@ -149,9 +150,10 @@ unsafe impl FmcPeripheral for FMC {
 }
 
 macro_rules! pins {
-    (FMC: $($pin:ident: [$($inst:ty),*])+) => {
+    (FMC: $($pin:ident: [$( $( #[ $pmeta:meta ] )* $inst:ty),*])+) => {
         $(
             $(
+                $( #[ $pmeta ] )*
                 impl stm32_fmc::$pin for $inst {}
             )*
         )+
@@ -216,14 +218,14 @@ pins! {
         D21: [ PH13<Alternate<AF12>> ]
         D22: [ PH14<Alternate<AF12>> ]
         D23: [ PH15<Alternate<AF12>> ]
-        D24: [ PI0<Alternate<AF12>> ]
-        D25: [ PI1<Alternate<AF12>> ]
-        D26: [ PI2<Alternate<AF12>> ]
-        D27: [ PI3<Alternate<AF12>> ]
-        D28: [ PI6<Alternate<AF12>> ]
-        D29: [ PI7<Alternate<AF12>> ]
-        D30: [ PI9<Alternate<AF12>> ]
-        D31: [ PI10<Alternate<AF12>> ]
+        D24: [ #[cfg(not(feature = "rm0468"))] PI0<Alternate<AF12>> ]
+        D25: [ #[cfg(not(feature = "rm0468"))] PI1<Alternate<AF12>> ]
+        D26: [ #[cfg(not(feature = "rm0468"))] PI2<Alternate<AF12>> ]
+        D27: [ #[cfg(not(feature = "rm0468"))] PI3<Alternate<AF12>> ]
+        D28: [ #[cfg(not(feature = "rm0468"))] PI6<Alternate<AF12>> ]
+        D29: [ #[cfg(not(feature = "rm0468"))] PI7<Alternate<AF12>> ]
+        D30: [ #[cfg(not(feature = "rm0468"))] PI9<Alternate<AF12>> ]
+        D31: [ #[cfg(not(feature = "rm0468"))] PI10<Alternate<AF12>> ]
 
         DA0: [ PD14<Alternate<AF12>> ]
         DA1: [ PD15<Alternate<AF12>> ]
@@ -246,8 +248,8 @@ pins! {
 
         NBL0: [ PE0<Alternate<AF12>> ]
         NBL1: [ PE1<Alternate<AF12>> ]
-        NBL2: [ PI4<Alternate<AF12>> ]
-        NBL3: [ PI5<Alternate<AF12>> ]
+        NBL2: [ #[cfg(not(feature = "rm0468"))] PI4<Alternate<AF12>> ]
+        NBL3: [ #[cfg(not(feature = "rm0468"))] PI5<Alternate<AF12>> ]
 
         // NAND
         NCE: [

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -336,7 +336,7 @@ macro_rules! gpio {
 
                 /// Enable external interrupts from this pin.
                 fn enable_interrupt(&mut self, exti: &mut EXTI) {
-                    #[cfg(any(feature = "rm0433", feature = "rm0455"))]
+                    #[cfg(not(feature = "rm0399"))]
                     let imr1 = &exti.cpuimr1;
                     #[cfg(all(feature = "rm0399", feature = "cm7"))]
                     let imr1 = &exti.c1imr1;
@@ -348,7 +348,7 @@ macro_rules! gpio {
 
                 /// Disable external interrupts from this pin
                 fn disable_interrupt(&mut self, exti: &mut EXTI) {
-                    #[cfg(any(feature = "rm0433", feature = "rm0455"))]
+                    #[cfg(not(feature = "rm0399"))]
                     let imr1 = &exti.cpuimr1;
                     #[cfg(all(feature = "rm0399", feature = "cm7"))]
                     let imr1 = &exti.c1imr1;
@@ -361,7 +361,7 @@ macro_rules! gpio {
                 /// Clear the interrupt pending bit for this pin
                 fn clear_interrupt_pending_bit(&mut self) {
                     unsafe {
-                        #[cfg(any(feature = "rm0433", feature = "rm0455"))]
+                        #[cfg(not(feature = "rm0399"))]
                         let pr1 = &(*EXTI::ptr()).cpupr1;
                         #[cfg(all(feature = "rm0399", feature = "cm7"))]
                         let pr1 = &(*EXTI::ptr()).c1pr1;
@@ -798,7 +798,7 @@ macro_rules! gpio {
 
                     /// Enable external interrupts from this pin.
                     fn enable_interrupt(&mut self, exti: &mut EXTI) {
-                        #[cfg(any(feature = "rm0433", feature = "rm0455"))]
+                        #[cfg(not(feature = "rm0399"))]
                         let imr1 = &exti.cpuimr1;
                         #[cfg(all(feature = "rm0399", feature = "cm7"))]
                         let imr1 = &exti.c1imr1;
@@ -810,7 +810,7 @@ macro_rules! gpio {
 
                     /// Disable external interrupts from this pin
                     fn disable_interrupt(&mut self, exti: &mut EXTI) {
-                        #[cfg(any(feature = "rm0433", feature = "rm0455"))]
+                        #[cfg(not(feature = "rm0399"))]
                         let imr1 = &exti.cpuimr1;
                         #[cfg(all(feature = "rm0399", feature = "cm7"))]
                         let imr1 = &exti.c1imr1;
@@ -823,7 +823,7 @@ macro_rules! gpio {
                     /// Clear the interrupt pending bit for this pin
                     fn clear_interrupt_pending_bit(&mut self) {
                         unsafe {
-                            #[cfg(any(feature = "rm0433", feature = "rm0455"))]
+                            #[cfg(not(feature = "rm0399"))]
                             let pr1 = &(*(EXTI::ptr())).cpupr1;
                             #[cfg(all(feature = "rm0399", feature = "cm7"))]
                             let pr1 = &(*(EXTI::ptr())).c1pr1;
@@ -993,6 +993,7 @@ gpio!(GPIOH, gpioh, "Port H", Gpioh, PH, 7, [
     PH15: (ph15, 15, Analog, exticr4),
 ]);
 
+#[cfg(not(feature = "rm0468"))]
 gpio!(GPIOI, gpioi, "Port I", Gpioi, PI, 8, [
     PI0: (pi0, 0, Analog, exticr1),
     PI1: (pi1, 1, Analog, exticr1),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,14 @@ pub use stm32h7::stm32h757cm7 as stm32;
 ))]
 pub use stm32h7::stm32h7b3 as stm32;
 
+// High Speed
+#[cfg(any(
+    feature = "stm32h725",
+    feature = "stm32h735",
+    feature = "stm32h730",
+))]
+pub use stm32h7::stm32h735 as stm32;
+
 #[cfg(all(feature = "rm0433", feature = "rm0399"))]
 compile_error!("Cannot not select both rm0433 and rm0399");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ pub mod qei;
 #[cfg(all(
     feature = "device-selected",
     feature = "quadspi",
-    not(feature = "rm0455")
+    not(any(feature = "rm0455", feature = "rm0468"))
 ))]
 pub mod qspi;
 #[cfg(feature = "device-selected")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,7 +15,10 @@ pub use crate::i2c::I2cExt as _stm32h7xx_hal_i2c_I2cExt;
 pub use crate::pwm::PwmAdvExt as _stm32_hal_pwm_PwmAdvExt;
 pub use crate::pwm::PwmExt as _stm32_hal_pwm_PwmExt;
 pub use crate::pwr::PwrExt as _stm32h7xx_hal_pwr_PwrExt;
-#[cfg(all(feature = "quadspi", not(feature = "rm0455")))]
+#[cfg(all(
+    feature = "quadspi",
+    not(any(feature = "rm0455", feature = "rm0468"))
+))]
 pub use crate::qspi::QspiExt as _stm32h7xx_hal_qspi_QspiExt;
 pub use crate::rcc::RccExt as _stm32h7xx_hal_rcc_RccExt;
 pub use crate::rng::RngCore as _stm32h7xx_hal_rng_RngCore;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -203,9 +203,13 @@ use crate::gpio::gpioe::{
 use crate::gpio::gpiof::{PF10, PF6, PF7, PF8, PF9};
 use crate::gpio::gpiog::{PG13, PG2, PG3, PG4, PG6};
 use crate::gpio::gpioh::{PH10, PH11, PH12, PH13, PH14, PH15, PH6, PH9};
+#[cfg(not(feature = "rm0468"))]
 use crate::gpio::gpioi::{PI0, PI1, PI2, PI4, PI5, PI6, PI7};
+#[cfg(not(any(feature = "stm32h7b0", feature = "rm0468")))]
+use crate::gpio::gpioj::PJ6;
 #[cfg(not(feature = "stm32h7b0"))]
-use crate::gpio::gpioj::{PJ10, PJ11, PJ6, PJ7, PJ8, PJ9};
+use crate::gpio::gpioj::{PJ10, PJ11, PJ7, PJ8, PJ9};
+
 #[cfg(not(feature = "stm32h7b0"))]
 use crate::gpio::gpiok::{PK0, PK1, PK2};
 
@@ -801,6 +805,7 @@ pins! {
         ]
         CH4(ComplementaryImpossible): [
             PA3<Alternate<AF2>>,
+            #[cfg(not(feature = "rm0468"))]
             PI0<Alternate<AF2>>
         ]
         CH1N: []
@@ -812,26 +817,30 @@ pins! {
     TIM8:
         CH1(ComplementaryDisabled): [
             PC6<Alternate<AF3>>,
+            #[cfg(not(feature = "rm0468"))]
             PI5<Alternate<AF3>>,
             #[cfg(not(feature = "stm32h7b0"))]
             PJ8<Alternate<AF3>>
         ]
         CH2(ComplementaryDisabled): [
             PC7<Alternate<AF3>>,
+            #[cfg(not(feature = "rm0468"))]
             PI6<Alternate<AF3>>,
-            #[cfg(not(feature = "stm32h7b0"))]
+            #[cfg(not(any(feature = "stm32h7b0", feature = "rm0468")))]
             PJ6<Alternate<AF3>>,
             #[cfg(not(feature = "stm32h7b0"))]
             PJ10<Alternate<AF3>>
         ]
         CH3(ComplementaryDisabled): [
             PC8<Alternate<AF3>>,
+            #[cfg(not(feature = "rm0468"))]
             PI7<Alternate<AF3>>,
             #[cfg(not(feature = "stm32h7b0"))]
             PK0<Alternate<AF3>>
         ]
         CH4(ComplementaryImpossible): [
             PC9<Alternate<AF3>>,
+            #[cfg(not(feature = "rm0468"))]
             PI2<Alternate<AF3>>
         ]
         CH1N: [
@@ -861,6 +870,7 @@ pins! {
         BRK: [
             PA6<Alternate<AF3>>,
             PG2<Alternate<AF3>>,
+            #[cfg(not(feature = "rm0468"))]
             PI4<Alternate<AF3>>,
             #[cfg(not(feature = "stm32h7b0"))]
             PK2<Alternate<AF3>>
@@ -868,6 +878,7 @@ pins! {
         BRK2: [
             PA8<Alternate<AF3>>,
             PG3<Alternate<AF3>>,
+            #[cfg(not(feature = "rm0468"))]
             PI1<Alternate<AF3>>
         ]
 }

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -53,7 +53,10 @@
 
 use crate::rcc::backup::BackupREC;
 use crate::stm32::PWR;
-#[cfg(all(feature = "revision_v", not(feature = "rm0455")))]
+#[cfg(all(
+    feature = "revision_v",
+    any(feature = "rm0433", feature = "rm0399")
+))]
 use crate::stm32::{RCC, SYSCFG};
 
 #[cfg(all(feature = "rm0433", feature = "smps"))]
@@ -70,7 +73,10 @@ impl PwrExt for PWR {
             rb: self,
             #[cfg(any(feature = "smps"))]
             supply_configuration: SupplyConfiguration::Default,
-            #[cfg(all(feature = "revision_v", not(feature = "rm0455")))]
+            #[cfg(all(
+                feature = "revision_v",
+                any(feature = "rm0433", feature = "rm0399")
+            ))]
             enable_vos0: false,
         }
     }
@@ -83,7 +89,10 @@ pub struct Pwr {
     pub(crate) rb: PWR,
     #[cfg(any(feature = "smps"))]
     supply_configuration: SupplyConfiguration,
-    #[cfg(all(feature = "revision_v", not(feature = "rm0455")))]
+    #[cfg(all(
+        feature = "revision_v",
+        any(feature = "rm0433", feature = "rm0399")
+    ))]
     enable_vos0: bool,
 }
 
@@ -303,7 +312,10 @@ impl Pwr {
                          the system low-power mode",
     }
 
-    #[cfg(all(feature = "revision_v", not(feature = "rm0455")))]
+    #[cfg(all(
+        feature = "revision_v",
+        any(feature = "rm0433", feature = "rm0399")
+    ))]
     pub fn vos0(mut self, _: &SYSCFG) -> Self {
         self.enable_vos0 = true;
         self
@@ -373,7 +385,10 @@ impl Pwr {
 
         // Enable overdrive for maximum clock
         // Syscfgen required to set enable overdrive
-        #[cfg(all(feature = "revision_v", not(feature = "rm0455")))]
+        #[cfg(all(
+            feature = "revision_v",
+            any(feature = "rm0433", feature = "rm0399")
+        ))]
         if self.enable_vos0 {
             unsafe {
                 &(*RCC::ptr()).apb4enr.modify(|_, w| w.syscfgen().enabled())

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -59,7 +59,10 @@ use crate::stm32::PWR;
 ))]
 use crate::stm32::{RCC, SYSCFG};
 
-#[cfg(all(feature = "rm0433", feature = "smps"))]
+#[cfg(all(
+    feature = "rm0433",
+    any(feature = "smps", feature = "example-smps")
+))]
 compile_error!("SMPS configuration fields are not available for RM0433 parts");
 
 /// Extension trait that constrains the `PWR` peripheral

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -261,7 +261,7 @@ impl Pwr {
         d3cr!(self.rb).write(|w| unsafe {
             // Manually set field values for each family
             w.vos().bits(
-                #[cfg(not(feature = "rm0455"))]
+                #[cfg(any(feature = "rm0433", feature = "rm0399"))]
                 match new_scale {
                     // RM0433 Rev 7 6.8.6
                     VoltageScale::Scale3 => 0b01,
@@ -276,6 +276,14 @@ impl Pwr {
                     VoltageScale::Scale2 => 0b01,
                     VoltageScale::Scale1 => 0b10,
                     VoltageScale::Scale0 => 0b11,
+                },
+                #[cfg(feature = "rm0468")]
+                match new_scale {
+                    // RM0468 Rev 2 6.8.6
+                    VoltageScale::Scale0 => 0b00,
+                    VoltageScale::Scale3 => 0b01,
+                    VoltageScale::Scale2 => 0b10,
+                    VoltageScale::Scale1 => 0b11,
                 },
             )
         });

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -8,9 +8,12 @@ use crate::gpio::gpioc::{PC6, PC7};
 use crate::gpio::gpiod::{PD12, PD13};
 use crate::gpio::gpioe::{PE10, PE11, PE8, PE9};
 use crate::gpio::gpioh::{PH10, PH11, PH13, PH14};
+#[cfg(not(feature = "rm0468"))]
 use crate::gpio::gpioi::{PI5, PI6};
+#[cfg(not(any(feature = "stm32h7b0", feature = "rm0468")))]
+use crate::gpio::gpioj::PJ6;
 #[cfg(not(feature = "stm32h7b0"))]
-use crate::gpio::gpioj::{PJ10, PJ11, PJ6, PJ7, PJ8, PJ9};
+use crate::gpio::gpioj::{PJ10, PJ11, PJ7, PJ8, PJ9};
 #[cfg(not(feature = "stm32h7b0"))]
 use crate::gpio::gpiok::{PK0, PK1};
 
@@ -126,6 +129,7 @@ pins! {
             PA7<Alternate<AF3>>,
             PC6<Alternate<AF3>>,
             PH13<Alternate<AF3>>,
+            #[cfg(not(feature = "rm0468"))]
             PI5<Alternate<AF3>>,
             #[cfg(not(feature = "stm32h7b0"))]
             PJ8<Alternate<AF3>>,
@@ -137,8 +141,9 @@ pins! {
             PB14<Alternate<AF3>>,
             PC7<Alternate<AF3>>,
             PH14<Alternate<AF3>>,
+            #[cfg(not(feature = "rm0468"))]
             PI6<Alternate<AF3>>,
-            #[cfg(not(feature = "stm32h7b0"))]
+            #[cfg(not(any(feature = "stm32h7b0", feature = "rm0468")))]
             PJ6<Alternate<AF3>>,
             #[cfg(not(feature = "stm32h7b0"))]
             PJ7<Alternate<AF3>>,

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -460,7 +460,7 @@ impl Rcc {
 
         // See RM0433 Rev 7 Table 17. FLASH recommended number of wait
         // states and programming delay
-        #[cfg(not(feature = "rm0455"))]
+        #[cfg(any(feature = "rm0433", feature = "rm0399"))]
         let (wait_states, progr_delay) = match vos {
             // VOS 0 range VCORE 1.26V - 1.40V
             Voltage::Scale0 => match rcc_aclk_mhz {
@@ -540,6 +540,39 @@ impl Rcc {
                 44..=65 => (2, 1),
                 66..=87 => (3, 1),
                 _ => (7, 3),
+            },
+        };
+
+        // See RM0468 Rev 2 Table 16
+        #[cfg(feature = "rm0468")]
+        let (wait_states, progr_delay) = match vos {
+            // VOS 0 range VCORE 1.25V - 1.35V
+            Voltage::Scale0 => match rcc_aclk_mhz {
+                0..=69 => (0, 0),
+                70..=139 => (1, 1),
+                140..=209 => (2, 2),
+                _ => (3, 3),
+            },
+            // VOS 1 range VCORE 1.15V - 1.25V
+            Voltage::Scale1 => match rcc_aclk_mhz {
+                0..=66 => (0, 0),
+                67..=132 => (1, 1),
+                133..=199 => (2, 2),
+                _ => (3, 3),
+            },
+            // VOS 2 range VCORE 1.05V - 1.15V
+            Voltage::Scale2 => match rcc_aclk_mhz {
+                0..=49 => (0, 0),
+                50..=99 => (1, 1),
+                100..=149 => (2, 2),
+                _ => (3, 3),
+            },
+            // VOS 3 range VCORE 0.95V - 1.05V
+            Voltage::Scale3 => match rcc_aclk_mhz {
+                0..=34 => (0, 0),
+                35..=69 => (1, 1),
+                70..=84 => (2, 2),
+                _ => (3, 3),
             },
         };
 
@@ -696,7 +729,7 @@ impl Rcc {
         // Refer to part datasheet "General operating conditions"
         // table for (rev V). We do not assert checks for earlier
         // revisions which may have lower limits.
-        #[cfg(not(feature = "rm0455"))]
+        #[cfg(any(feature = "rm0433", feature = "rm0399"))]
         let (sys_d1cpre_ck_max, rcc_hclk_max, pclk_max) = match pwrcfg.vos {
             Voltage::Scale0 => (480_000_000, 240_000_000, 120_000_000),
             Voltage::Scale1 => (400_000_000, 200_000_000, 100_000_000),
@@ -710,6 +743,14 @@ impl Rcc {
             Voltage::Scale1 => (225_000_000, 225_000_000, 112_500_000),
             Voltage::Scale2 => (160_000_000, 160_000_000, 80_000_000),
             _ => (88_000_000, 88_000_000, 44_000_000),
+        };
+
+        #[cfg(feature = "rm0468")] // 725 / 735 / 730
+        let (sys_d1cpre_ck_max, rcc_hclk_max, pclk_max) = match pwrcfg.vos {
+            Voltage::Scale0 => (520_000_000, 275_000_000, 137_500_000),
+            Voltage::Scale1 => (400_000_000, 200_000_000, 100_000_000),
+            Voltage::Scale2 => (300_000_000, 150_000_000, 75_000_000),
+            _ => (170_000_000, 85_000_000, 42_500_000),
         };
 
         // Check resulting sys_d1cpre_ck

--- a/src/rcc/pll.rs
+++ b/src/rcc/pll.rs
@@ -117,12 +117,14 @@ macro_rules! vco_setup {
     (ITERATIVE: $pllsrc:ident, $output:ident,
      $rcc:ident, $pllXvcosel:ident, $pllXrge:ident $(,$pll1_p:ident)*) => {{
          // VCO output frequency limits
-         #[cfg(all(not(feature = "rm0455"), not(feature = "revision_v")))]
+         #[cfg(all(any(feature = "rm0433", feature = "rm0399"), not(feature = "revision_v")))]
          let (vco_min, vco_max) = (192_000_000, 836_000_000);
-         #[cfg(all(not(feature = "rm0455"), feature = "revision_v"))]
+         #[cfg(all(any(feature = "rm0433", feature = "rm0399"), feature = "revision_v"))]
          let (vco_min, vco_max) = (192_000_000, 960_000_000);
          #[cfg(feature = "rm0455")]
          let (vco_min, vco_max) = (128_000_000, 560_000_000);
+         #[cfg(feature = "rm0468")]
+         let (vco_min, vco_max) = (192_000_000, 836_000_000);
 
          // VCO output frequency. Choose the highest VCO frequency
          let (vco_ck_target, pll_x_p) = {

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -482,11 +482,11 @@ peripheral_reset_and_enable_control! {
     AHB1, "" => [
         Eth1Mac,
         #[cfg(any(feature = "rm0399"))] Art,
-        Adc12 [group clk: Adc(Variant) d3ccip "ADC"]
+        Adc12 [group clk: Adc(Variant) d3ccip "ADC"],
+        Usb1Otg [group clk: Usb d2ccip2 "USB"]
     ];
     #[cfg(any(feature = "rm0433", feature = "rm0399"))]
     AHB1, "" => [
-        Usb1Otg [group clk: Usb d2ccip2 "USB"],
         Usb2Otg [group clk: Usb]
     ];
     #[cfg(feature = "rm0455")]
@@ -494,10 +494,6 @@ peripheral_reset_and_enable_control! {
         Crc,
         Usb1Otg [group clk: Usb cdccip2 "USB"],
         Adc12 [group clk: Adc(Variant) srdccip "ADC"]
-    ];
-    #[cfg(feature = "rm0468")]
-    AHB1, "" => [
-        Usb1Otg [kernel clk: Usb d2ccip2 "USB"]
     ];
 
 

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -480,17 +480,24 @@ peripheral_reset_and_enable_control! {
     ];
     #[cfg(not(feature = "rm0455"))]
     AHB1, "" => [
-        Usb1Otg [group clk: Usb d2ccip2 "USB"],
-        Usb2Otg [group clk: Usb],
         Eth1Mac,
         #[cfg(any(feature = "rm0399"))] Art,
         Adc12 [group clk: Adc(Variant) d3ccip "ADC"]
+    ];
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
+    AHB1, "" => [
+        Usb1Otg [group clk: Usb d2ccip2 "USB"],
+        Usb2Otg [group clk: Usb]
     ];
     #[cfg(feature = "rm0455")]
     AHB1, "" => [
         Crc,
         Usb1Otg [group clk: Usb cdccip2 "USB"],
         Adc12 [group clk: Adc(Variant) srdccip "ADC"]
+    ];
+    #[cfg(feature = "rm0468")]
+    AHB1, "" => [
+        Usb1Otg [kernel clk: Usb d2ccip2 "USB"]
     ];
 
 
@@ -507,22 +514,36 @@ peripheral_reset_and_enable_control! {
     AHB2, "" => [
         Rng [kernel clk: Rng cdccip2 "RNG"]
     ];
+    #[cfg(feature = "rm0468")]
+    AHB2, "" => [
+        Cordic, Fmac
+    ];
 
 
     #[cfg(all())]
     AHB3, "AMBA High-performance Bus (AHB3) peripherals" => [
-        Jpgdec, Dma2d, Mdma
+        Dma2d, Mdma
     ];
     #[cfg(not(feature = "rm0455"))]
     AHB3, "" => [
         Sdmmc1 [group clk: Sdmmc d1ccip "SDMMC"],
-        Fmc [kernel clk: Fmc d1ccip "FMC"],
+        Fmc [kernel clk: Fmc d1ccip "FMC"]
+    ];
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
+    AHB3, "" => [
+        Jpgdec,
         Qspi [kernel clk: Qspi d1ccip "QUADSPI"]
     ];
     #[cfg(feature = "rm0455")]
     AHB3, "" => [
+        Jpgdec,
         Sdmmc1 [group clk: Sdmmc cdccip "SDMMC"],
         Fmc [kernel clk: Fmc cdccip "FMC"]
+    ];
+    #[cfg(feature = "rm0468")]
+    AHB3, "" => [
+        Octospi1 [group clk: Octospi d1ccip "OCTOSPI"],
+        Octospi2 [group clk: Octospi]
     ];
 
 
@@ -544,9 +565,6 @@ peripheral_reset_and_enable_control! {
 
     #[cfg(all())]
     APB1L, "Advanced Peripheral Bus 1L (APB1L) peripherals" => [
-        I2c2 [group clk: I2c123],
-        I2c3 [group clk: I2c123],
-
         Spi2 [group clk: Spi123],
         Spi3 [group clk: Spi123],
 
@@ -562,19 +580,33 @@ peripheral_reset_and_enable_control! {
     APB1L, "" => [
         Dac12,
 
-        I2c1 [group clk: I2c123 d2ccip2 "I2C1/2/3"],
         Cec [kernel clk: Cec(Variant) d2ccip2 "CEC"],
         Lptim1 [kernel clk: Lptim1(Variant) d2ccip2 "LPTIM1"],
         Usart2 [group clk: Usart234578(Variant) d2ccip2 "USART2/3/4/5/7/8"]
+    ];
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
+    APB1L, "" => [
+        I2c1 [group clk: I2c123 d2ccip2 "I2C1/2/3"],
+        I2c2 [group clk: I2c123],
+        I2c3 [group clk: I2c123]
     ];
     #[cfg(feature = "rm0455")]
     APB1L, "" => [
         Dac1,
 
         I2c1 [group clk: I2c123 cdccip2 "I2C1/2/3"],
+        I2c2 [group clk: I2c123],
+        I2c3 [group clk: I2c123],
         Cec [kernel clk: Cec(Variant) cdccip2 "CEC"],
         Lptim1 [kernel clk: Lptim1(Variant) cdccip2 "LPTIM1"],
         Usart2 [group clk: Usart234578(Variant) cdccip2 "USART2/3/4/5/7/8"]
+    ];
+    #[cfg(feature = "rm0468")]
+    APB1L, "" => [
+        I2c1 [group clk: I2c1235 d2ccip2 "I2C1/2/3/5"],
+        I2c2 [group clk: I2c1235],
+        I2c3 [group clk: I2c1235],
+        I2c5 [group clk: I2c1235]
     ];
 
 
@@ -584,13 +616,20 @@ peripheral_reset_and_enable_control! {
     ];
     #[cfg(not(feature = "rm0455"))]
     APB1H, "" => [
-        Fdcan [kernel clk: Fdcan(Variant) d2ccip1 "FDCAN"],
+        Fdcan [kernel clk: Fdcan(Variant) d2ccip1 "FDCAN"]
+    ];
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
+    APB1H, "" => [
         Swp [kernel clk: Swp d2ccip1 "SWPMI"]
     ];
     #[cfg(feature = "rm0455")]
     APB1H, "" => [
         Fdcan [kernel clk: Fdcan(Variant) cdccip1 "FDCAN"],
         Swpmi [kernel clk: Swpmi cdccip1 "SWPMI"]
+    ];
+    #[cfg(feature = "rm0468")]
+    APB1H, "" => [
+        Swpmi [kernel clk: Swpmi d2ccip1 "SWPMI"]
     ];
 
 
@@ -600,16 +639,20 @@ peripheral_reset_and_enable_control! {
     ];
     #[cfg(not(feature = "rm0455"))]
     APB2, "" => [
-        Hrtim,
         Dfsdm1 [kernel clk: Dfsdm1 d2ccip1 "DFSDM1"],
 
         Sai1 [kernel clk: Sai1(Variant) d2ccip1 "SAI1"],
-        Sai2 [group clk: Sai23(Variant) d2ccip1 "SAI2/3"],
-        Sai3 [group clk: Sai23],
 
         Spi1 [group clk: Spi123(Variant) d2ccip1 "SPI1/2/3"],
         Spi4 [group clk: Spi45(Variant) d2ccip1 "SPI4/5"],
-        Spi5 [group clk: Spi45],
+        Spi5 [group clk: Spi45]
+    ];
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
+    APB2, "" => [
+        Hrtim,
+
+        Sai2 [group clk: Sai23(Variant) d2ccip1 "SAI2/3"],
+        Sai3 [group clk: Sai23],
 
         Usart1 [group clk: Usart16(Variant) d2ccip2 "USART1/6"],
         Usart6 [group clk: Usart16]
@@ -629,6 +672,11 @@ peripheral_reset_and_enable_control! {
         Spi5 [group clk: Spi45],
 
         Usart1 [group clk: Usart16910(Variant) cdccip2 "USART1/6/9/10"],
+        Usart6 [group clk: Usart16910]
+    ];
+    #[cfg(feature = "rm0468")]
+    APB2, "" => [
+        Usart1 [group clk: Usart16910(Variant) d2ccip2 "USART1/6/9/10"],
         Usart6 [group clk: Usart16910]
     ];
 

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -534,7 +534,9 @@ peripheral_reset_and_enable_control! {
     AHB3, "" => [
         Jpgdec,
         Sdmmc1 [group clk: Sdmmc cdccip "SDMMC"],
-        Fmc [kernel clk: Fmc cdccip "FMC"]
+        Fmc [kernel clk: Fmc cdccip "FMC"],
+        Octospi1 [group clk: Octospi cdccip "OCTOSPI"],
+        Octospi2 [group clk: Octospi]
     ];
     #[cfg(feature = "rm0468")]
     AHB3, "" => [

--- a/src/sai/i2s.rs
+++ b/src/sai/i2s.rs
@@ -9,37 +9,54 @@ use crate::sai::{GetClkSAI, Sai, SaiChannel, CLEAR_ALL_FLAGS_BITS, INTERFACE};
 use crate::stm32;
 use crate::time::Hertz;
 
-use crate::stm32::{SAI1, SAI2};
-#[cfg(not(feature = "rm0455"))]
-use crate::stm32::{SAI3, SAI4};
-
+use crate::stm32::SAI1;
 #[cfg(feature = "rm0455")]
+use crate::stm32::SAI2;
+#[cfg(feature = "rm0468")]
+use crate::stm32::SAI4;
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
+use crate::stm32::{SAI2, SAI3, SAI4};
+
+#[cfg(any(feature = "rm0455", feature = "rm0468"))]
 use crate::device::sai1::ch::sr;
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 use crate::device::sai4::ch::sr;
 
-#[cfg(feature = "rm0455")]
+#[cfg(any(feature = "rm0455", feature = "rm0468"))]
 type CH = stm32::sai1::CH;
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 type CH = stm32::sai4::CH;
 
+#[cfg(not(feature = "rm0468"))]
 use crate::gpio::gpioa::{PA0, PA1, PA12, PA2};
 use crate::gpio::gpiob::PB2;
-use crate::gpio::gpioc::{PC0, PC1};
+#[cfg(not(feature = "rm0468"))]
+use crate::gpio::gpioc::PC0;
+use crate::gpio::gpioc::PC1;
 #[cfg(not(feature = "rm0455"))]
+use crate::gpio::gpiod::PD6;
+#[cfg(not(any(feature = "rm0455", feature = "rm0468")))]
 use crate::gpio::gpiod::{
-    PD0, PD1, PD10, PD11, PD12, PD13, PD14, PD15, PD4, PD6, PD8, PD9,
+    PD0, PD1, PD10, PD11, PD12, PD13, PD14, PD15, PD4, PD8, PD9,
 };
 #[cfg(feature = "rm0455")]
 use crate::gpio::gpiod::{PD11, PD12, PD13, PD6};
-use crate::gpio::gpioe::{
-    PE0, PE11, PE12, PE13, PE14, PE2, PE3, PE4, PE5, PE6,
-};
-use crate::gpio::gpiof::{PF11, PF6, PF7, PF8, PF9};
-use crate::gpio::gpiog::{PG10, PG7, PG9};
+#[cfg(not(feature = "rm0468"))]
+use crate::gpio::gpioe::{PE0, PE11, PE12, PE13, PE14};
+use crate::gpio::gpioe::{PE2, PE3, PE4, PE5, PE6};
+#[cfg(not(feature = "rm0468"))]
+use crate::gpio::gpiof::PF11;
+use crate::gpio::gpiof::{PF6, PF7, PF8, PF9};
+use crate::gpio::gpiog::PG7;
+#[cfg(not(feature = "rm0468"))]
+use crate::gpio::gpiog::{PG10, PG9};
+#[cfg(not(feature = "rm0468"))]
 use crate::gpio::gpioh::{PH2, PH3};
+#[cfg(not(feature = "rm0468"))]
 use crate::gpio::gpioi::{PI4, PI5, PI6, PI7};
-use crate::gpio::{Alternate, AF10, AF6, AF8};
+#[cfg(not(feature = "rm0468"))]
+use crate::gpio::AF10;
+use crate::gpio::{Alternate, AF6, AF8};
 
 use crate::traits::i2s::FullDuplex;
 // use embedded_hal::i2s::FullDuplex;
@@ -607,13 +624,21 @@ macro_rules! i2s {
 }
 
 i2s! {
-    SAI1, Sai1: [i2s_sai1_ch_a, i2s_sai1_ch_b],
-    SAI2, Sai2: [i2s_sai2_ch_a, i2s_sai2_ch_b]
+    SAI1, Sai1: [i2s_sai1_ch_a, i2s_sai1_ch_b]
 }
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 i2s! {
+    SAI2, Sai2: [i2s_sai2_ch_a, i2s_sai2_ch_b],
     SAI3, Sai3: [i2s_sai3_ch_a, i2s_sai3_ch_b],
     SAI4, Sai4: [i2s_sai4_ch_a, i2s_sai4_ch_b]
+}
+#[cfg(feature = "rm0455")]
+i2s! {
+    SAI2, Sai2: [i2s_sai2_ch_a, i2s_sai2_ch_b]
+}
+#[cfg(feature = "rm0468")]
+i2s! {
+    SAI4, Sai4: [i4s_sai4_ch_a, i4s_sai4_ch_b]
 }
 
 fn i2s_config_channel(
@@ -828,6 +853,9 @@ pins! {
             PE3<Alternate<AF6>>,
             PF6<Alternate<AF6>>
         ]
+}
+#[cfg(any(feature = "rm0433", feature = "rm0399", feature = "rm0455"))]
+pins! {
     SAI2:
         MCLK_A: [
             PE0<Alternate<AF10>>,
@@ -869,7 +897,7 @@ pins! {
             PG10<Alternate<AF10>>
         ]
 }
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 pins! {
     SAI3:
         MCLK_A: [
@@ -896,6 +924,9 @@ pins! {
         SD_B: [
             PD9<Alternate<AF6>>
         ]
+}
+#[cfg(any(feature = "rm0433", feature = "rm0399", feature = "rm0468"))]
+pins! {
     SAI4:
         MCLK_A: [
             PE2<Alternate<AF8>>

--- a/src/sai/mod.rs
+++ b/src/sai/mod.rs
@@ -11,16 +11,20 @@
 
 use core::marker::PhantomData;
 
-#[cfg(feature = "rm0455")]
+#[cfg(any(feature = "rm0455", feature = "rm0468"))]
 use crate::stm32::sai1::CH;
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 use crate::stm32::sai4::CH;
 
-use crate::stm32::{SAI1, SAI2};
-#[cfg(not(feature = "rm0455"))]
-use crate::stm32::{SAI3, SAI4};
+use crate::stm32::SAI1;
+#[cfg(feature = "rm0455")]
+use crate::stm32::SAI2;
+#[cfg(feature = "rm0468")]
+use crate::stm32::SAI4;
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
+use crate::stm32::{SAI2, SAI3, SAI4};
 
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 use crate::rcc::rec::Sai23ClkSelGetter;
 
 // clocks
@@ -83,11 +87,11 @@ macro_rules! impl_sai_ker_ck {
 impl_sai_ker_ck! {
     Sai1, get_kernel_clk_mux, get_kernel_clk_mux, Sai1ClkSel, Sai1ClkSel: SAI1
 }
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 impl_sai_ker_ck! {
     Sai2, get_kernel_clk_mux, get_kernel_clk_mux, Sai23ClkSel, Sai23ClkSel: SAI2
 }
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 impl_sai_ker_ck! {
     Sai3, get_kernel_clk_mux, get_kernel_clk_mux, Sai23ClkSel, Sai23ClkSel: SAI3
 }
@@ -316,10 +320,18 @@ macro_rules! sai_hal {
 
 sai_hal! {
     SAI1: (sai1, Sai1),
+}
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
+sai_hal! {
+    SAI2: (sai2, Sai2),
+    SAI3: (sai3, Sai3),
+    SAI4: (sai4, Sai4),
+}
+#[cfg(feature = "rm0455")]
+sai_hal! {
     SAI2: (sai2, Sai2),
 }
-#[cfg(not(feature = "rm0455"))]
+#[cfg(feature = "rm0468")]
 sai_hal! {
-    SAI3: (sai3, Sai3),
     SAI4: (sai4, Sai4),
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -28,6 +28,7 @@ use crate::gpio::gpioe::{PE0, PE1, PE7, PE8};
 use crate::gpio::gpiof::{PF6, PF7};
 use crate::gpio::gpiog::{PG14, PG7, PG9};
 use crate::gpio::gpioh::{PH13, PH14};
+#[cfg(not(feature = "rm0468"))]
 use crate::gpio::gpioi::PI9;
 #[cfg(not(feature = "stm32h7b0"))]
 use crate::gpio::gpioj::{PJ8, PJ9};
@@ -36,8 +37,11 @@ use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::stm32;
 #[cfg(feature = "rm0455")]
 use crate::stm32::rcc::cdccip2r::{USART16910SEL_A, USART234578SEL_A};
-#[cfg(not(feature = "rm0455"))]
+#[cfg(feature = "rm0468")]
+use crate::stm32::rcc::d2ccip2r::{USART16910SEL_A, USART234578SEL_A};
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 use crate::stm32::rcc::d2ccip2r::{USART16SEL_A, USART234578SEL_A};
+
 use crate::stm32::usart1::cr1::{M0_A as M0, PCE_A as PCE, PS_A as PS};
 use crate::stm32::{UART4, UART5, UART7, UART8};
 use crate::stm32::{USART1, USART2, USART3, USART6};
@@ -340,6 +344,7 @@ uart_pins! {
             PC11<Alternate<AF8>>,
             PD0<Alternate<AF8>>,
             PH14<Alternate<AF8>>,
+            #[cfg(not(feature = "rm0468"))]
             PI9<Alternate<AF8>>
         ]
     UART5:
@@ -926,7 +931,7 @@ usart! {
     UART8: (uart8, Uart8, pclk1),
 }
 
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 usart_sel! {
     d2ccip2r, USART16SEL_A, usart16sel, RCC_PCLK2, pclk2;
 
@@ -936,6 +941,13 @@ usart_sel! {
 #[cfg(feature = "rm0455")]
 usart_sel! {
     cdccip2r, USART16910SEL_A, usart16910sel, RCC_PCLK2, pclk2;
+
+    USART1: "USART1",
+    USART6: "USART6",
+}
+#[cfg(feature = "rm0468")]
+usart_sel! {
+    d2ccip2r, USART16910SEL_A, usart16910sel, RCC_PCLK2, pclk2;
 
     USART1: "USART1",
     USART6: "USART6",

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -89,6 +89,7 @@ use crate::gpio::gpioe::{PE11, PE12, PE13, PE14, PE2, PE4, PE5, PE6};
 use crate::gpio::gpiof::{PF11, PF6, PF7, PF8, PF9};
 use crate::gpio::gpiog::{PG10, PG11, PG12, PG13, PG14, PG8, PG9};
 use crate::gpio::gpioh::{PH5, PH6, PH7};
+#[cfg(not(feature = "rm0468"))]
 use crate::gpio::gpioi::{PI0, PI1, PI2, PI3};
 #[cfg(not(feature = "stm32h7b0"))]
 use crate::gpio::gpioj::{PJ10, PJ11};
@@ -366,12 +367,14 @@ pins! {
             PB10<Alternate<AF5>>,
             PB13<Alternate<AF5>>,
             PD3<Alternate<AF5>>,
+            #[cfg(not(feature = "rm0468"))]
             PI1<Alternate<AF5>>
         ]
         MISO: [
             NoMiso,
             PB14<Alternate<AF5>>,
             PC2<Alternate<AF5>>,
+            #[cfg(not(feature = "rm0468"))]
             PI2<Alternate<AF5>>
         ]
         MOSI: [
@@ -379,6 +382,7 @@ pins! {
             PB15<Alternate<AF5>>,
             PC1<Alternate<AF5>>,
             PC3<Alternate<AF5>>,
+            #[cfg(not(feature = "rm0468"))]
             PI3<Alternate<AF5>>
         ]
         HCS: [
@@ -386,6 +390,7 @@ pins! {
             PB4<Alternate<AF7>>,
             PB9<Alternate<AF5>>,
             PB12<Alternate<AF5>>,
+            #[cfg(not(feature = "rm0468"))]
             PI0<Alternate<AF5>>
         ]
     SPI3:

--- a/src/usb_hs.rs
+++ b/src/usb_hs.rs
@@ -15,11 +15,13 @@ use crate::gpio::{
     gpiob::{PB0, PB1, PB10, PB11, PB12, PB13, PB5},
     gpioc::{PC0, PC2, PC3},
     gpioh::PH4,
-    gpioi::PI11,
     Alternate, AF10,
 };
 
-#[cfg(not(feature = "rm0455"))]
+#[cfg(not(feature = "rm0468"))]
+use crate::gpio::gpioi::PI11;
+
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 use crate::gpio::{
     gpiob::{PB14, PB15},
     AF12,
@@ -38,7 +40,7 @@ pub struct USB1 {
     pub hclk: Hertz,
 }
 impl USB1 {
-    #[cfg(not(feature = "rm0455"))]
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
     pub fn new(
         usb_global: stm32::OTG1_HS_GLOBAL,
         usb_device: stm32::OTG1_HS_DEVICE,
@@ -50,7 +52,7 @@ impl USB1 {
     ) -> Self {
         Self::new_unchecked(usb_global, usb_device, usb_pwrclk, prec, clocks)
     }
-    #[cfg(feature = "rm0455")]
+    #[cfg(any(feature = "rm0455", feature = "rm0468"))]
     pub fn new(
         usb_global: stm32::OTG1_HS_GLOBAL,
         usb_device: stm32::OTG1_HS_DEVICE,
@@ -79,7 +81,7 @@ impl USB1 {
     }
 }
 
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 pub struct USB2 {
     pub usb_global: stm32::OTG2_HS_GLOBAL,
     pub usb_device: stm32::OTG2_HS_DEVICE,
@@ -87,7 +89,7 @@ pub struct USB2 {
     pub prec: rcc::rec::Usb2Otg,
     pub hclk: Hertz,
 }
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 impl USB2 {
     pub fn new(
         usb_global: stm32::OTG2_HS_GLOBAL,
@@ -161,11 +163,11 @@ usb_peripheral! {
 }
 pub type Usb1BusType = UsbBus<USB1>;
 
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 usb_peripheral! {
     USB2, OTG2_HS_GLOBAL, usb2otgen, usb2otgrst
 }
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 pub type Usb2BusType = UsbBus<USB2>;
 
 pub struct USB1_ULPI {
@@ -178,9 +180,11 @@ pub struct USB1_ULPI {
 
 pub enum Usb1UlpiDirPin {
     PC2(PC2<Alternate<AF10>>),
+    #[cfg(not(feature = "rm0468"))]
     PI11(PI11<Alternate<AF10>>),
 }
 
+#[cfg(not(feature = "rm0468"))]
 impl From<PI11<Alternate<AF10>>> for Usb1UlpiDirPin {
     fn from(v: PI11<Alternate<AF10>>) -> Self {
         Usb1UlpiDirPin::PI11(v)

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -14,6 +14,8 @@ use cast::u8;
 use crate::stm32::WWDG;
 #[cfg(all(feature = "rm0399", feature = "cm7"))]
 use crate::stm32::WWDG1 as WWDG;
+#[cfg(feature = "rm0468")]
+use crate::stm32::WWDG1 as WWDG;
 #[cfg(all(feature = "rm0399", feature = "cm4"))]
 use crate::stm32::WWDG2 as WWDG;
 


### PR DESCRIPTION
Reference Manual is RM0468

Ref #163 

- [x] Updates to support STM32H725/735 parts
- [x] Successfully build examples
- [x] At least one example for these parts specifically - _examples/ethernet-rtic-stm32h735g-dk.rs_
- [x] Fix other breakages from https://github.com/stm32-rs/stm32-rs/pull/554
- [x] Remove dependency on nightly PAC build