### PR TITLE
WIP: Refuse PRs with clippy warnings

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --examples --target thumbv7em-none-eabihf --features=rt,stm32h743v
+          args: --examples --target thumbv7em-none-eabihf --features=rt,stm32h743v -- -D warnings


### PR DESCRIPTION
Prevent code violating clippy warnings from getting into the repository. The codebase now contains many unused imports and other more or less serious code smells. These issues can be prevented with a harsher CI.

Follow-up patches will address all the current warnings.

WIP: This still needs to address all those issues.

Signed-off-by: Petr Horacek <hrck@protonmail.com>