### PR TITLE
Update to stm32-rs v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   values. `VAL::get().read()` becomes `VAL::read()`
 * adc: Allow parallel execution of multiple ADCs through `start_conversion()`
 * Rename the PeripheralREC object for BDMA2 on 7B3, 7B0, 7A3 parts from BDMA to BDMA2
+* pac: Upgrade to stm32-rs v0.14.0
 
 ## [v0.10.0] 2021-07-xx
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * **Breaking**: Simplified API for reading device signature
   values. `VAL::get().read()` becomes `VAL::read()`
 * adc: Allow parallel execution of multiple ADCs through `start_conversion()`
+* Rename the PeripheralREC object for BDMA2 on 7B3, 7B0, 7A3 parts from BDMA to BDMA2
 
 ## [v0.10.0] 2021-07-xx
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = ["thumbv7em-none-eabihf"]
 embedded-hal = "0.2.4"
 embedded-dma = "0.1.2"
 cortex-m = "^0.7.1"
-cortex-m-rt = "^0.6.12"
+cortex-m-rt = "^0.6.15"
 stm32h7 = "^0.13.0"
 void = { version = "1.0.2", default-features = false }
 cast = { version = "0.2.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,9 @@ optional = true
 cortex-m-rtic = { version = "0.5.8", default-features = false, features = ["cortex-m-7"] }
 log = "0.4.11"
 panic-halt = "0.2.0"
-cfg-if = "0.1.10"
-rtt-target = { version = "0.2.0", features = ["cortex-m"] }
 panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }
+cfg-if = "1.0.0"
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 cortex-m-log = { version = "~0.7.0", features = ["itm", "semihosting", "log-integration"] }
 panic-itm = { version = "~0.4.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ embedded-hal = "0.2.4"
 embedded-dma = "0.1.2"
 cortex-m = "^0.7.1"
 cortex-m-rt = "^0.6.15"
-stm32h7 = "^0.13.0"
+stm32h7 = "^0.14.0"
 void = { version = "1.0.2", default-features = false }
 cast = { version = "0.2.3", default-features = false }
 nb = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ default-features = false
 optional = true
 
 [dev-dependencies]
-cortex-m-rtic = "0.5.3"
+cortex-m-rtic = { version = "0.5.8", default-features = false, features = ["cortex-m-7"] }
 log = "0.4.11"
 panic-halt = "0.2.0"
 cfg-if = "0.1.10"

--- a/examples/i2c4_bdma.rs
+++ b/examples/i2c4_bdma.rs
@@ -37,7 +37,10 @@ fn main() -> ! {
     let dp = pac::Peripherals::take().expect("Cannot take peripherals");
 
     // Run D3 / SRD domain
+    #[cfg(not(feature = "rm0455"))]
     dp.PWR.cpucr.modify(|_, w| w.run_d3().set_bit());
+    #[cfg(feature = "rm0455")]
+    dp.PWR.cpucr.modify(|_, w| w.run_srd().set_bit());
 
     let pwr = dp.PWR.constrain();
     let pwrcfg = example_power!(pwr).freeze();
@@ -84,7 +87,7 @@ fn main() -> ! {
     #[cfg(feature = "rm0455")]
     let streams = StreamsTuple::new(
         dp.BDMA2,
-        ccdr.peripheral.BDMA.low_power(LowPowerMode::Autonomous),
+        ccdr.peripheral.BDMA2.low_power(LowPowerMode::Autonomous),
     );
 
     let config = BdmaConfig::default().memory_increment(true);

--- a/examples/rtic_low_power.rs
+++ b/examples/rtic_low_power.rs
@@ -3,9 +3,10 @@
 //! After the end of init the CPU transitions into CStop mode, and D1/D2
 //! (aka. CD) transition into DStop mode.
 //!
-//! However we set the run_d3 flag, and enable Autonomous mode on the LPTIM3
-//! PREC struture. Therefore LPTIM3 continues to run and fires an interrupt that
-//! wakes the core. Following each interrupt the core returns to CStop mode.
+//! However we set the run_d3/run_srd flag, and enable Autonomous mode on the
+//! LPTIM3 PREC struture. Therefore LPTIM3 continues to run and fires an
+//! interrupt that wakes the core. Following each interrupt the core returns to
+//! CStop mode.
 //!
 //! On the first rising edge on PC13, the EXTI interrupt fires. We do not clear
 //! this interrupt, so we loop in the handler forever.
@@ -47,7 +48,10 @@ const APP: () = {
         let mut syscfg = ctx.device.SYSCFG;
 
         // Run D3 / SRD domain
+        #[cfg(not(feature = "rm0455"))]
         ctx.device.PWR.cpucr.modify(|_, w| w.run_d3().set_bit());
+        #[cfg(feature = "rm0455")] // 7b3/7a3/7b0 parts
+        ctx.device.PWR.cpucr.modify(|_, w| w.run_srd().set_bit());
 
         let pwr = ctx.device.PWR.constrain();
         let vos = pwr.freeze();

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -29,7 +29,6 @@ use crate::gpio::Analog;
 use crate::rcc::rec::AdcClkSelGetter;
 use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::time::Hertz;
-use stm32h7::Variant::Val;
 
 #[cfg(not(feature = "revision_v"))]
 const ADC_KER_CK_MAX: u32 = 36_000_000;
@@ -324,9 +323,9 @@ pub struct StoredConfig(AdcSampleTime, Resolution, AdcLshift);
 fn check_clock(prec: &impl AdcClkSelGetter, clocks: &CoreClocks) -> Hertz {
     // Select Kernel Clock
     let adc_clock = match prec.get_kernel_clk_mux() {
-        Val(rec::AdcClkSel::PLL2_P) => clocks.pll2_p_ck(),
-        Val(rec::AdcClkSel::PLL3_R) => clocks.pll3_r_ck(),
-        Val(rec::AdcClkSel::PER) => clocks.per_ck(),
+        Some(rec::AdcClkSel::PLL2_P) => clocks.pll2_p_ck(),
+        Some(rec::AdcClkSel::PLL3_R) => clocks.pll3_r_ck(),
+        Some(rec::AdcClkSel::PER) => clocks.per_ck(),
         _ => unreachable!(),
     }
     .expect("adc_ker_ck_input is not running!");

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -57,18 +57,18 @@ impl Crc {
         let mut words = data.chunks_exact(4);
         for word in words.by_ref() {
             let word = u32::from_be_bytes(word.try_into().unwrap());
-            self.reg.dr_mut().write(|w| w.dr().bits(word));
+            self.reg.dr().write(|w| w.dr().bits(word));
         }
 
         // there will be at most 3 bytes remaining, so 1 half-word and 1 byte
         let mut half_word = words.remainder().chunks_exact(2);
         if let Some(half_word) = half_word.next() {
             let half_word = u16::from_be_bytes(half_word.try_into().unwrap());
-            self.reg.dr16_mut().write(|w| w.dr16().bits(half_word));
+            self.reg.dr16().write(|w| w.dr16().bits(half_word));
         }
 
         if let Some(byte) = half_word.remainder().first() {
-            self.reg.dr8_mut().write(|w| w.dr8().bits(*byte));
+            self.reg.dr8().write(|w| w.dr8().bits(*byte));
         }
     }
 

--- a/src/dma/bdma.rs
+++ b/src/dma/bdma.rs
@@ -70,7 +70,7 @@ impl Instance for BDMA {
 
 #[cfg(feature = "rm0455")]
 impl Instance for BDMA2 {
-    type Rec = rec::Bdma;
+    type Rec = rec::Bdma2;
 
     #[inline(always)]
     fn ptr() -> *const BDMARegisterBlock {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,6 @@ pub mod traits;
 pub use nb;
 pub use nb::block;
 
-pub use stm32h7::Variant;
-
 // Single core
 #[cfg(any(
     feature = "stm32h742",

--- a/src/ltdc.rs
+++ b/src/ltdc.rs
@@ -125,93 +125,45 @@ impl DisplayController for Ltdc {
                 .bit(config.pixel_clock_pol)
         });
 
-        // TODO: remove when fixed upstream
-        // unsafe: bit ranges not defined for fields
-        #[cfg(feature = "rm0399")]
-        unsafe {
-            // Set synchronization pulse width
-            self.ltdc.sscr.modify(|_, w| {
-                w.vsh()
-                    .bits(config.v_sync - 1)
-                    .hsw()
-                    .bits(config.h_sync - 1)
-            });
+        // Set synchronization pulse width
+        self.ltdc.sscr.modify(|_, w| {
+            w.vsh()
+                .bits(config.v_sync - 1)
+                .hsw()
+                .bits(config.h_sync - 1)
+        });
 
-            // Set accumulated back porch
-            self.ltdc.bpcr.modify(|_, w| {
-                w.avbp()
-                    .bits(config.v_sync + config.v_back_porch - 1)
-                    .ahbp()
-                    .bits(config.h_sync + config.h_back_porch - 1)
-            });
+        // Set accumulated back porch
+        self.ltdc.bpcr.modify(|_, w| {
+            w.avbp()
+                .bits(config.v_sync + config.v_back_porch - 1)
+                .ahbp()
+                .bits(config.h_sync + config.h_back_porch - 1)
+        });
 
-            // Set accumulated active width
-            let aa_height =
-                config.v_sync + config.v_back_porch + config.active_height - 1;
-            let aa_width =
-                config.h_sync + config.h_back_porch + config.active_width - 1;
-            self.ltdc
-                .awcr
-                .modify(|_, w| w.aah().bits(aa_height).aaw().bits(aa_width));
+        // Set accumulated active width
+        let aa_height =
+            config.v_sync + config.v_back_porch + config.active_height - 1;
+        let aa_width =
+            config.h_sync + config.h_back_porch + config.active_width - 1;
+        self.ltdc
+            .awcr
+            .modify(|_, w| w.aah().bits(aa_height).aaw().bits(aa_width));
 
-            // Set total width and height
-            let total_height: u16 = config.v_sync
-                + config.v_back_porch
-                + config.active_height
-                + config.v_front_porch
-                - 1;
-            let total_width: u16 = config.h_sync
-                + config.h_back_porch
-                + config.active_width
-                + config.h_front_porch
-                - 1;
-            self.ltdc.twcr.modify(|_, w| {
-                w.totalh().bits(total_height).totalw().bits(total_width)
-            });
-        }
-
-        #[cfg(not(feature = "rm0399"))]
-        {
-            // Set synchronization pulse width
-            self.ltdc.sscr.modify(|_, w| {
-                w.vsh()
-                    .bits(config.v_sync - 1)
-                    .hsw()
-                    .bits(config.h_sync - 1)
-            });
-
-            // Set accumulated back porch
-            self.ltdc.bpcr.modify(|_, w| {
-                w.avbp()
-                    .bits(config.v_sync + config.v_back_porch - 1)
-                    .ahbp()
-                    .bits(config.h_sync + config.h_back_porch - 1)
-            });
-
-            // Set accumulated active width
-            let aa_height =
-                config.v_sync + config.v_back_porch + config.active_height - 1;
-            let aa_width =
-                config.h_sync + config.h_back_porch + config.active_width - 1;
-            self.ltdc
-                .awcr
-                .modify(|_, w| w.aah().bits(aa_height).aaw().bits(aa_width));
-
-            // Set total width and height
-            let total_height: u16 = config.v_sync
-                + config.v_back_porch
-                + config.active_height
-                + config.v_front_porch
-                - 1;
-            let total_width: u16 = config.h_sync
-                + config.h_back_porch
-                + config.active_width
-                + config.h_front_porch
-                - 1;
-            self.ltdc.twcr.modify(|_, w| {
-                w.totalh().bits(total_height).totalw().bits(total_width)
-            });
-        }
+        // Set total width and height
+        let total_height: u16 = config.v_sync
+            + config.v_back_porch
+            + config.active_height
+            + config.v_front_porch
+            - 1;
+        let total_width: u16 = config.h_sync
+            + config.h_back_porch
+            + config.active_width
+            + config.h_front_porch
+            - 1;
+        self.ltdc.twcr.modify(|_, w| {
+            w.totalh().bits(total_height).totalw().bits(total_width)
+        });
 
         // Set the background color value
         self.ltdc.bccr.reset();

--- a/src/rcc/backup.rs
+++ b/src/rcc/backup.rs
@@ -87,8 +87,16 @@ mod rtc {
             // unsafe: Owned exclusive access to this bitfield
             interrupt::free(|_| {
                 let bdcr = unsafe { &(*RCC::ptr()).bdcr };
+
+                #[cfg(not(feature = "rm0455"))]
                 bdcr.modify(|_, w| w.bdrst().set_bit());
+                #[cfg(not(feature = "rm0455"))]
                 bdcr.modify(|_, w| w.bdrst().clear_bit());
+
+                #[cfg(feature = "rm0455")]
+                bdcr.modify(|_, w| w.vswrst().set_bit());
+                #[cfg(feature = "rm0455")]
+                bdcr.modify(|_, w| w.vswrst().set_bit());
             });
             self
         }

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -439,7 +439,7 @@ macro_rules! peripheral_reset_and_enable_control_generator {
 macro_rules! variant_return_type {
     ($t:ty) => { $t };
     ($t:ty, $Variant: ident) => {
-        stm32h7::Variant<u8, $t>
+        Option<$t>
     };
 }
 

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -444,9 +444,16 @@ macro_rules! variant_return_type {
 }
 
 // Register for autonomous mode enable bits
+#[cfg(not(feature = "rm0455"))]
 macro_rules! autonomous {
     ($Auto:ident) => {
         &(*RCC::ptr()).d3amr
+    };
+}
+#[cfg(feature = "rm0455")]
+macro_rules! autonomous {
+    ($Auto:ident) => {
+        &(*RCC::ptr()).srdamr
     };
 }
 
@@ -481,6 +488,7 @@ peripheral_reset_and_enable_control! {
     ];
     #[cfg(feature = "rm0455")]
     AHB1, "" => [
+        Crc,
         Usb1Otg [group clk: Usb cdccip2 "USB"],
         Adc12 [group clk: Adc(Variant) srdccip "ADC"]
     ];
@@ -520,14 +528,17 @@ peripheral_reset_and_enable_control! {
 
     #[cfg(all())]
     AHB4, "AMBA High-performance Bus (AHB4) peripherals" => [
-        (Auto) Bdma,
-        (Auto) Crc,
-
         Gpioa, Gpiob, Gpioc, Gpiod, Gpioe, Gpiof, Gpiog, Gpioh, Gpioi, Gpioj, Gpiok
     ];
     #[cfg(not(feature = "rm0455"))]
     AHB4, "" => [
+        (Auto) Crc,
+        (Auto) Bdma,
         (Auto) Adc3 [group clk: Adc]
+    ];
+    #[cfg(feature = "rm0455")]
+    AHB4, "" => [
+        (Auto) Bdma2
     ];
 
 
@@ -579,17 +590,17 @@ peripheral_reset_and_enable_control! {
     #[cfg(feature = "rm0455")]
     APB1H, "" => [
         Fdcan [kernel clk: Fdcan(Variant) cdccip1 "FDCAN"],
-        Swp [kernel clk: Swp cdccip1 "SWPMI"]
+        Swpmi [kernel clk: Swpmi cdccip1 "SWPMI"]
     ];
 
 
     #[cfg(all())]
     APB2, "Advanced Peripheral Bus 2 (APB2) peripherals" => [
-        Hrtim,
         Tim1, Tim8, Tim15, Tim16, Tim17
     ];
     #[cfg(not(feature = "rm0455"))]
     APB2, "" => [
+        Hrtim,
         Dfsdm1 [kernel clk: Dfsdm1 d2ccip1 "DFSDM1"],
 
         Sai1 [kernel clk: Sai1(Variant) d2ccip1 "SAI1"],

--- a/src/sai/i2s.rs
+++ b/src/sai/i2s.rs
@@ -40,7 +40,6 @@ use crate::gpio::gpiog::{PG10, PG7, PG9};
 use crate::gpio::gpioh::{PH2, PH3};
 use crate::gpio::gpioi::{PI4, PI5, PI6, PI7};
 use crate::gpio::{Alternate, AF10, AF6, AF8};
-use stm32h7::Variant::Val;
 
 use crate::traits::i2s::FullDuplex;
 // use embedded_hal::i2s::FullDuplex;
@@ -732,7 +731,7 @@ fn disable_ch(audio_ch: &CH) {
 
 fn read(audio_ch: &CH) -> nb::Result<(u32, u32), I2SError> {
     match audio_ch.sr.read().flvl().variant() {
-        Val(sr::FLVL_A::EMPTY) => Err(nb::Error::WouldBlock),
+        Some(sr::FLVL_A::EMPTY) => Err(nb::Error::WouldBlock),
         _ => Ok((audio_ch.dr.read().bits(), audio_ch.dr.read().bits())),
     }
 }
@@ -745,8 +744,8 @@ fn send(
     // The FIFO is 8 words long. A write consists of 2 words, in stereo mode.
     // Therefore you need to wait for 3/4s to ensure 2 words are available for writing.
     match audio_ch.sr.read().flvl().variant() {
-        Val(sr::FLVL_A::FULL) => Err(nb::Error::WouldBlock),
-        Val(sr::FLVL_A::QUARTER4) => Err(nb::Error::WouldBlock),
+        Some(sr::FLVL_A::FULL) => Err(nb::Error::WouldBlock),
+        Some(sr::FLVL_A::QUARTER4) => Err(nb::Error::WouldBlock),
         _ => {
             unsafe {
                 audio_ch.dr.write(|w| w.bits(left_word).bits(right_word));

--- a/src/sai/mod.rs
+++ b/src/sai/mod.rs
@@ -17,7 +17,6 @@ use crate::rcc::rec::Sai23ClkSelGetter;
 // clocks
 use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::time::Hertz;
-use stm32h7::Variant::Val;
 
 const CLEAR_ALL_FLAGS_BITS: u32 = 0b0111_0111;
 
@@ -49,22 +48,22 @@ macro_rules! impl_sai_ker_ck {
                 /// Current kernel clock - A
                 fn sai_a_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Option<Hertz> {
                     match prec.$get_mux_A() {
-                        Val(rec::$AccessA::PLL1_Q) => clocks.pll1_q_ck(),
-                        Val(rec::$AccessA::PLL2_P) => clocks.pll2_p_ck(),
-                        Val(rec::$AccessA::PLL3_P) => clocks.pll3_p_ck(),
-                        Val(rec::$AccessA::I2S_CKIN) => unimplemented!(),
-                        Val(rec::$AccessA::PER) => clocks.per_ck(),
+                        Some(rec::$AccessA::PLL1_Q) => clocks.pll1_q_ck(),
+                        Some(rec::$AccessA::PLL2_P) => clocks.pll2_p_ck(),
+                        Some(rec::$AccessA::PLL3_P) => clocks.pll3_p_ck(),
+                        Some(rec::$AccessA::I2S_CKIN) => unimplemented!(),
+                        Some(rec::$AccessA::PER) => clocks.per_ck(),
                         _ => unreachable!(),
                     }
                 }
                 /// Current kernel clock - B
                 fn sai_b_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Option<Hertz> {
                     match prec.$get_mux_B() {
-                        Val(rec::$AccessB::PLL1_Q) => clocks.pll1_q_ck(),
-                        Val(rec::$AccessB::PLL2_P) => clocks.pll2_p_ck(),
-                        Val(rec::$AccessB::PLL3_P) => clocks.pll3_p_ck(),
-                        Val(rec::$AccessB::I2S_CKIN) => unimplemented!(),
-                        Val(rec::$AccessB::PER) => clocks.per_ck(),
+                        Some(rec::$AccessB::PLL1_Q) => clocks.pll1_q_ck(),
+                        Some(rec::$AccessB::PLL2_P) => clocks.pll2_p_ck(),
+                        Some(rec::$AccessB::PLL3_P) => clocks.pll3_p_ck(),
+                        Some(rec::$AccessB::I2S_CKIN) => unimplemented!(),
+                        Some(rec::$AccessB::PER) => clocks.per_ck(),
                         _ => unreachable!(),
                     }
                 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -11,7 +11,6 @@ use nb::block;
 
 use crate::stm32;
 use crate::stm32::usart1::cr1::{M0_A as M0, PCE_A as PCE, PS_A as PS};
-use stm32h7::Variant::Val;
 
 #[cfg(feature = "rm0455")]
 use crate::stm32::rcc::cdccip2r::{USART16910SEL_A, USART234578SEL_A};
@@ -836,12 +835,12 @@ macro_rules! usart_sel {
                     let ccip = unsafe { (*stm32::RCC::ptr()).$ccip.read() };
 
                     match ccip.$sel().variant() {
-                        Val($SEL::$PCLK) => Some(clocks.$pclk()),
-                        Val($SEL::PLL2_Q) => clocks.pll2_q_ck(),
-                        Val($SEL::PLL3_Q) => clocks.pll3_q_ck(),
-                        Val($SEL::HSI_KER) => clocks.hsi_ck(),
-                        Val($SEL::CSI_KER) => clocks.csi_ck(),
-                        Val($SEL::LSE) => unimplemented!(),
+                        Some($SEL::$PCLK) => Some(clocks.$pclk()),
+                        Some($SEL::PLL2_Q) => clocks.pll2_q_ck(),
+                        Some($SEL::PLL3_Q) => clocks.pll3_q_ck(),
+                        Some($SEL::HSI_KER) => clocks.hsi_ck(),
+                        Some($SEL::CSI_KER) => clocks.csi_ck(),
+                        Some($SEL::LSE) => unimplemented!(),
                         _ => unreachable!(),
                     }
                 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -71,7 +71,6 @@ use crate::stm32::spi1::{
 use core::convert::From;
 use core::marker::PhantomData;
 use core::ptr;
-use stm32h7::Variant::Val;
 
 use crate::stm32::{SPI1, SPI2, SPI3, SPI4, SPI5, SPI6};
 
@@ -1076,12 +1075,12 @@ macro_rules! spi123sel {
                     let ccip1r = unsafe { (*stm32::RCC::ptr()).cdccip1r.read() };
 
                     match ccip1r.spi123sel().variant() {
-                        Val(ccip1r::SPI123SEL_A::PLL1_Q) => clocks.pll1_q_ck(),
-                        Val(ccip1r::SPI123SEL_A::PLL2_P) => clocks.pll2_p_ck(),
-                        Val(ccip1r::SPI123SEL_A::PLL3_P) => clocks.pll3_p_ck(),
+                        Some(ccip1r::SPI123SEL_A::PLL1_Q) => clocks.pll1_q_ck(),
+                        Some(ccip1r::SPI123SEL_A::PLL2_P) => clocks.pll2_p_ck(),
+                        Some(ccip1r::SPI123SEL_A::PLL3_P) => clocks.pll3_p_ck(),
                         // Need a method of specifying pin clock
-                        Val(ccip1r::SPI123SEL_A::I2S_CKIN) => unimplemented!(),
-                        Val(ccip1r::SPI123SEL_A::PER) => clocks.per_ck(),
+                        Some(ccip1r::SPI123SEL_A::I2S_CKIN) => unimplemented!(),
+                        Some(ccip1r::SPI123SEL_A::PER) => clocks.per_ck(),
                         _ => unreachable!(),
                     }
                 }
@@ -1102,12 +1101,12 @@ macro_rules! spi45sel {
                     let ccip1r = unsafe { (*stm32::RCC::ptr()).cdccip1r.read() };
 
                     match ccip1r.spi45sel().variant() {
-                        Val(ccip1r::SPI45SEL_A::APB) => Some(clocks.pclk2()),
-                        Val(ccip1r::SPI45SEL_A::PLL2_Q) => clocks.pll2_q_ck(),
-                        Val(ccip1r::SPI45SEL_A::PLL3_Q) => clocks.pll3_q_ck(),
-                        Val(ccip1r::SPI45SEL_A::HSI_KER) => clocks.hsi_ck(),
-                        Val(ccip1r::SPI45SEL_A::CSI_KER) => clocks.csi_ck(),
-                        Val(ccip1r::SPI45SEL_A::HSE) => clocks.hse_ck(),
+                        Some(ccip1r::SPI45SEL_A::APB) => Some(clocks.pclk2()),
+                        Some(ccip1r::SPI45SEL_A::PLL2_Q) => clocks.pll2_q_ck(),
+                        Some(ccip1r::SPI45SEL_A::PLL3_Q) => clocks.pll3_q_ck(),
+                        Some(ccip1r::SPI45SEL_A::HSI_KER) => clocks.hsi_ck(),
+                        Some(ccip1r::SPI45SEL_A::CSI_KER) => clocks.csi_ck(),
+                        Some(ccip1r::SPI45SEL_A::HSE) => clocks.hse_ck(),
                         _ => unreachable!(),
                     }
                 }
@@ -1128,12 +1127,12 @@ macro_rules! spi6sel {
                     let srdccipr = unsafe { (*stm32::RCC::ptr()).srdccipr.read() };
 
                     match srdccipr.spi6sel().variant() {
-                        Val(srdccipr::SPI6SEL_A::RCC_PCLK4) => Some(clocks.pclk4()),
-                        Val(srdccipr::SPI6SEL_A::PLL2_Q) => clocks.pll2_q_ck(),
-                        Val(srdccipr::SPI6SEL_A::PLL3_Q) => clocks.pll3_q_ck(),
-                        Val(srdccipr::SPI6SEL_A::HSI_KER) => clocks.hsi_ck(),
-                        Val(srdccipr::SPI6SEL_A::CSI_KER) => clocks.csi_ck(),
-                        Val(srdccipr::SPI6SEL_A::HSE) => clocks.hse_ck(),
+                        Some(srdccipr::SPI6SEL_A::RCC_PCLK4) => Some(clocks.pclk4()),
+                        Some(srdccipr::SPI6SEL_A::PLL2_Q) => clocks.pll2_q_ck(),
+                        Some(srdccipr::SPI6SEL_A::PLL3_Q) => clocks.pll3_q_ck(),
+                        Some(srdccipr::SPI6SEL_A::HSI_KER) => clocks.hsi_ck(),
+                        Some(srdccipr::SPI6SEL_A::CSI_KER) => clocks.csi_ck(),
+                        Some(srdccipr::SPI6SEL_A::HSE) => clocks.hse_ck(),
                         _ => unreachable!(),
                     }
                 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -29,7 +29,6 @@ use crate::stm32::rcc::{d2ccip2r as ccip2r, d3ccipr as srdccipr};
 use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::stm32;
 use crate::time::Hertz;
-use stm32h7::Variant::Val;
 
 /// Associate clocks with timers
 pub trait GetClk {
@@ -66,12 +65,12 @@ impl GetClk for LPTIM1 {
         let ccip2r = &unsafe { &*stm32::RCC::ptr() }.cdccip2r;
 
         match ccip2r.read().lptim1sel().variant() {
-            Val(ccip2r::LPTIM1SEL_A::RCC_PCLK1) => Some(clocks.pclk1()),
-            Val(ccip2r::LPTIM1SEL_A::PLL2_P) => clocks.pll2_p_ck(),
-            Val(ccip2r::LPTIM1SEL_A::PLL3_R) => clocks.pll3_r_ck(),
-            Val(ccip2r::LPTIM1SEL_A::LSE) => unimplemented!(),
-            Val(ccip2r::LPTIM1SEL_A::LSI) => unimplemented!(),
-            Val(ccip2r::LPTIM1SEL_A::PER) => clocks.per_ck(),
+            Some(ccip2r::LPTIM1SEL_A::RCC_PCLK1) => Some(clocks.pclk1()),
+            Some(ccip2r::LPTIM1SEL_A::PLL2_P) => clocks.pll2_p_ck(),
+            Some(ccip2r::LPTIM1SEL_A::PLL3_R) => clocks.pll3_r_ck(),
+            Some(ccip2r::LPTIM1SEL_A::LSE) => unimplemented!(),
+            Some(ccip2r::LPTIM1SEL_A::LSI) => unimplemented!(),
+            Some(ccip2r::LPTIM1SEL_A::PER) => clocks.per_ck(),
             _ => unreachable!(),
         }
     }
@@ -87,12 +86,12 @@ impl GetClk for LPTIM2 {
         let srdccipr = &unsafe { &*stm32::RCC::ptr() }.srdccipr;
 
         match srdccipr.read().lptim2sel().variant() {
-            Val(srdccipr::LPTIM2SEL_A::RCC_PCLK4) => Some(clocks.pclk4()),
-            Val(srdccipr::LPTIM2SEL_A::PLL2_P) => clocks.pll2_p_ck(),
-            Val(srdccipr::LPTIM2SEL_A::PLL3_R) => clocks.pll3_r_ck(),
-            Val(srdccipr::LPTIM2SEL_A::LSE) => unimplemented!(),
-            Val(srdccipr::LPTIM2SEL_A::LSI) => unimplemented!(),
-            Val(srdccipr::LPTIM2SEL_A::PER) => clocks.per_ck(),
+            Some(srdccipr::LPTIM2SEL_A::RCC_PCLK4) => Some(clocks.pclk4()),
+            Some(srdccipr::LPTIM2SEL_A::PLL2_P) => clocks.pll2_p_ck(),
+            Some(srdccipr::LPTIM2SEL_A::PLL3_R) => clocks.pll3_r_ck(),
+            Some(srdccipr::LPTIM2SEL_A::LSE) => unimplemented!(),
+            Some(srdccipr::LPTIM2SEL_A::LSI) => unimplemented!(),
+            Some(srdccipr::LPTIM2SEL_A::PER) => clocks.per_ck(),
             _ => unreachable!(),
         }
     }
@@ -130,12 +129,12 @@ macro_rules! impl_clk_lptim345 {
                     let d3ccipr = &unsafe { &*stm32::RCC::ptr() }.d3ccipr;
 
                     match d3ccipr.read().lptim345sel().variant() {
-                        Val(srdccipr::LPTIM345SEL_A::RCC_PCLK4) => Some(clocks.pclk4()),
-                        Val(srdccipr::LPTIM345SEL_A::PLL2_P) => clocks.pll2_p_ck(),
-                        Val(srdccipr::LPTIM345SEL_A::PLL3_R) => clocks.pll3_r_ck(),
-                        Val(srdccipr::LPTIM345SEL_A::LSE) => unimplemented!(),
-                        Val(srdccipr::LPTIM345SEL_A::LSI) => unimplemented!(),
-                        Val(srdccipr::LPTIM345SEL_A::PER) => clocks.per_ck(),
+                        Some(srdccipr::LPTIM345SEL_A::RCC_PCLK4) => Some(clocks.pclk4()),
+                        Some(srdccipr::LPTIM345SEL_A::PLL2_P) => clocks.pll2_p_ck(),
+                        Some(srdccipr::LPTIM345SEL_A::PLL3_R) => clocks.pll3_r_ck(),
+                        Some(srdccipr::LPTIM345SEL_A::LSE) => unimplemented!(),
+                        Some(srdccipr::LPTIM345SEL_A::LSI) => unimplemented!(),
+                        Some(srdccipr::LPTIM345SEL_A::PER) => clocks.per_ck(),
                         _ => unreachable!(),
                     }
                 }

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -35,7 +35,11 @@ impl SystemWindowWatchdog {
     /// to indicate the clock has not been used yet
     pub fn new(wwdg: WWDG, ccdr: &Ccdr) -> Self {
         // enable the peripheral inside the APB3
+        #[cfg(not(feature = "rm0455"))]
         ccdr.rb.apb3enr.modify(|_, w| w.wwdg1en().set_bit());
+        #[cfg(feature = "rm0455")]
+        ccdr.rb.apb3enr.modify(|_, w| w.wwdgen().set_bit());
+
         SystemWindowWatchdog {
             wwdg,
             down_counter: 0,


### PR DESCRIPTION
* ~RTIC v0.5 is no longer supported since the PAC does not implement `Nr` trait for Interrupts~
* RCC registers have been renamed for RM0455 parts
* PAC `Variant::Val<T>` replaced with `Option<T>`