### PR TITLE
Simplify device signature API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
    * Changed I2S constructors to take less arguments
 
 * MSRV increased to 1.51.0
+* **Breaking**: Simplified API for reading device signature
+  values. `VAL::get().read()` becomes `VAL::read()`
 
 ## [v0.10.0] 2021-07-xx
 

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -76,13 +76,12 @@ fn main() -> ! {
             adc.read(&mut channel).expect("Temperature read failed.");
 
         // Average slope
-        let cal = (110.0 - 30.0)
-            / (TS_CAL_110::get().read() - TS_CAL_30::get().read()) as f32;
+        let cal =
+            (110.0 - 30.0) / (TS_CAL_110::read() - TS_CAL_30::read()) as f32;
         // Calibration values are measured at VDDA = 3.3 V ± 10 mV
         let word_3v3 = word as f32 * vdda / 3.3;
         // Linear interpolation
-        let temperature =
-            cal * (word_3v3 - TS_CAL_30::get().read() as f32) + 30.0;
+        let temperature = cal * (word_3v3 - TS_CAL_30::read() as f32) + 30.0;
 
         info!("ADC reading: {}, Temperature: {:.1} °C", word, temperature);
     }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -6,108 +6,82 @@
 /// the factory
 pub const VDDA_CALIB: u32 = 3300;
 
-macro_rules! define_ptr_type {
-    ($name: ident, $ptr: expr) => {
-        impl $name {
-            fn ptr() -> *const Self {
-                $ptr as *const _
-            }
-
-            /// Returns a wrapped reference to the value in flash
-            /// memory
-            pub fn get() -> &'static Self {
-                unsafe { &*Self::ptr() }
-            }
-        }
-    };
-}
-
 /// Uniqure Device ID register
-#[derive(Hash, Debug)]
-#[repr(C)]
-pub struct Uid(u128);
+pub struct Uid;
 
 #[cfg(not(feature = "rm0455"))]
-define_ptr_type!(Uid, 0x1FF1_E800);
+const UID_PTR: *const u8 = 0x1FF1_E800 as _;
 #[cfg(feature = "rm0455")]
-define_ptr_type!(Uid, 0x08FF_F800);
+const UID_PTR: *const u8 = 0x08FF_F800 as _;
 
 impl Uid {
     /// Read Unique Deivce ID
-    pub fn read(&self) -> u128 {
-        self.0
+    pub fn read() -> &'static [u8; 12] {
+        unsafe { &*UID_PTR.cast::<[u8; 12]>() }
     }
 }
 
 /// Size of integrated flash
-#[derive(Debug)]
-#[repr(C)]
-pub struct FlashSize(u16);
+pub struct FlashSize;
 
 #[cfg(not(feature = "rm0455"))]
-define_ptr_type!(FlashSize, 0x1FF1_E880);
+const FLASH_SIZE_PTR: *const u16 = 0x1FF1_E880 as _;
 #[cfg(feature = "rm0455")]
-define_ptr_type!(FlashSize, 0x08FF_F80C);
+const FLASH_SIZE_PTR: *const u16 = 0x08FF_F80C as _;
 
 impl FlashSize {
     /// Read flash size in kilobytes
-    pub fn kilo_bytes(&self) -> u16 {
-        self.0
+    pub fn kilo_bytes() -> u16 {
+        unsafe { *FLASH_SIZE_PTR }
     }
 
     /// Read flash size in bytes
-    pub fn bytes(&self) -> usize {
-        usize::from(self.kilo_bytes()) * 1024
+    pub fn bytes() -> usize {
+        usize::from(Self::kilo_bytes()) * 1024
     }
 }
 
 /// ADC VREF calibration value is stored in at the factory
-#[derive(Debug)]
-#[repr(C)]
-pub struct VREFIN_CAL(u16);
+pub struct VREFIN_CAL;
 
 #[cfg(not(feature = "rm0455"))]
-define_ptr_type!(VREFIN_CAL, 0x1FF1_E860);
+const VREFIN_CAL_PTR: *const u16 = 0x1FF1_E860 as _;
 #[cfg(feature = "rm0455")]
-define_ptr_type!(VREFIN_CAL, 0x08FF_F810);
+const VREFIN_CAL_PTR: *const u16 = 0x08FF_F810 as _;
 
 impl VREFIN_CAL {
     /// Read calibration value
-    pub fn read(&self) -> u16 {
-        self.0
+    pub fn read() -> u16 {
+        unsafe { *VREFIN_CAL_PTR }
     }
 }
 
 /// A temperature reading taken at 30°C stored at the factory
-#[derive(Debug)]
-#[repr(C)]
-pub struct TS_CAL_30(u16);
+pub struct TS_CAL_30;
 
 #[cfg(not(feature = "rm0455"))]
-define_ptr_type!(TS_CAL_30, 0x1FF1_E820);
+const TS_CAL_30_PTR: *const u16 = 0x1FF1_E820 as _;
 #[cfg(feature = "rm0455")]
-define_ptr_type!(TS_CAL_30, 0x08FF_F814);
+const TS_CAL_30_PTR: *const u16 = 0x08FF_F814 as _;
 
 impl TS_CAL_30 {
     /// Read calibration value
-    pub fn read(&self) -> u16 {
-        self.0
+    pub fn read() -> u16 {
+        unsafe { *TS_CAL_30_PTR }
     }
 }
 
 /// A temperature reading taken at 110°C stored at the factory
-#[derive(Debug)]
-#[repr(C)]
-pub struct TS_CAL_110(u16);
+pub struct TS_CAL_110;
 
 #[cfg(not(feature = "rm0455"))]
-define_ptr_type!(TS_CAL_110, 0x1FF1_E840);
+const TS_CAL_110_PTR: *const u16 = 0x1FF1_E840 as _;
 #[cfg(feature = "rm0455")]
-define_ptr_type!(TS_CAL_110, 0x08FF_F818);
+const TS_CAL_110_PTR: *const u16 = 0x08FF_F818 as _;
 
 impl TS_CAL_110 {
     /// Read calibration value
-    pub fn read(&self) -> u16 {
-        self.0
+    pub fn read() -> u16 {
+        unsafe { *TS_CAL_110_PTR }
     }
 }


### PR DESCRIPTION
Takes some inspiration from the [stm32-device-signature](https://crates.io/crates/stm32-device-signature) crate.

Avoids reading 32 additional bits above the signature value. Fixes #206