### PR TITLE
Make ethernet::DesRing generic over the number of buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Rename the PeripheralREC object for BDMA2 on 7B3, 7B0, 7A3 parts from BDMA to BDMA2
 * pac: Upgrade to stm32-rs v0.14.0
 
+* ethernet: `ethernet::DesRing` and `ethernet::EthernetDMA` require generic
+  constants to specify how many transmit / receive buffers to include in
+  `ethernet::DesRing`. To replicate the previous behaviour, use `DesRing<4, 4>`
+
 ## [v0.10.0] 2021-07-xx
 
 * **Breaking**: Don't reset peripheral in DMA1/2 `StreamsTuple::new()` method #229

--- a/examples/ethernet-nucleo-h743zi2.rs
+++ b/examples/ethernet-nucleo-h743zi2.rs
@@ -43,7 +43,7 @@ const MAC_ADDRESS: [u8; 6] = [0x02, 0x00, 0x11, 0x22, 0x33, 0x44];
 
 /// Ethernet descriptor rings are a global singleton
 #[link_section = ".sram3.eth"]
-static mut DES_RING: ethernet::DesRing = ethernet::DesRing::new();
+static mut DES_RING: ethernet::DesRing<4, 4> = ethernet::DesRing::new();
 
 // the program entry point
 #[entry]

--- a/examples/ethernet-rtic-stm32h735g-dk.rs
+++ b/examples/ethernet-rtic-stm32h735g-dk.rs
@@ -56,7 +56,7 @@ const MAC_ADDRESS: [u8; 6] = [0x02, 0x00, 0x11, 0x22, 0x33, 0x44];
 
 /// Ethernet descriptor rings are a global singleton
 #[link_section = ".axisram.eth"]
-static mut DES_RING: ethernet::DesRing = ethernet::DesRing::new();
+static mut DES_RING: ethernet::DesRing<4, 4> = ethernet::DesRing::new();
 
 /// Net storage with static initialisation - another global singleton
 pub struct NetStorageStatic<'a> {
@@ -74,13 +74,13 @@ static mut STORE: NetStorageStatic = NetStorageStatic {
 };
 
 pub struct Net<'a> {
-    iface: EthernetInterface<'a, ethernet::EthernetDMA<'a>>,
+    iface: EthernetInterface<'a, ethernet::EthernetDMA<'a, 4, 4>>,
     sockets: SocketSet<'a>,
 }
 impl<'a> Net<'a> {
     pub fn new(
         store: &'static mut NetStorageStatic<'a>,
-        ethdev: ethernet::EthernetDMA<'a>,
+        ethdev: ethernet::EthernetDMA<'a, 4, 4>,
         ethernet_addr: EthernetAddress,
     ) -> Self {
         // Set IP address

--- a/examples/ethernet-rtic-stm32h747i-disco.rs
+++ b/examples/ethernet-rtic-stm32h747i-disco.rs
@@ -56,7 +56,7 @@ const MAC_ADDRESS: [u8; 6] = [0x02, 0x00, 0x11, 0x22, 0x33, 0x44];
 
 /// Ethernet descriptor rings are a global singleton
 #[link_section = ".sram3.eth"]
-static mut DES_RING: ethernet::DesRing = ethernet::DesRing::new();
+static mut DES_RING: ethernet::DesRing<4, 4> = ethernet::DesRing::new();
 
 /// Net storage with static initialisation - another global singleton
 pub struct NetStorageStatic<'a> {
@@ -74,13 +74,13 @@ static mut STORE: NetStorageStatic = NetStorageStatic {
 };
 
 pub struct Net<'a> {
-    iface: EthernetInterface<'a, ethernet::EthernetDMA<'a>>,
+    iface: EthernetInterface<'a, ethernet::EthernetDMA<'a, 4, 4>>,
     sockets: SocketSet<'a>,
 }
 impl<'a> Net<'a> {
     pub fn new(
         store: &'static mut NetStorageStatic<'a>,
-        ethdev: ethernet::EthernetDMA<'a>,
+        ethdev: ethernet::EthernetDMA<'a, 4, 4>,
         ethernet_addr: EthernetAddress,
     ) -> Self {
         // Set IP address

--- a/examples/ethernet-stm32h747i-disco.rs
+++ b/examples/ethernet-stm32h747i-disco.rs
@@ -28,7 +28,7 @@ const MAC_ADDRESS: [u8; 6] = [0x02, 0x00, 0x11, 0x22, 0x33, 0x44];
 
 /// Ethernet descriptor rings are a global singleton
 #[link_section = ".sram3.eth"]
-static mut DES_RING: ethernet::DesRing = ethernet::DesRing::new();
+static mut DES_RING: ethernet::DesRing<4, 4> = ethernet::DesRing::new();
 
 // the program entry point
 #[entry]

--- a/src/ethernet/eth.rs
+++ b/src/ethernet/eth.rs
@@ -355,6 +355,11 @@ impl<const TD: usize, const RD: usize> DesRing<TD, RD> {
         }
     }
 }
+impl<const TD: usize, const RD: usize> Default for DesRing<TD, RD> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 ///
 /// Ethernet DMA

--- a/src/ethernet/eth.rs
+++ b/src/ethernet/eth.rs
@@ -119,8 +119,8 @@ impl<const TD: usize> TDesRing<TD> {
     /// will be stored in the descriptors, so ensure the TDesRing is
     /// not moved after initialisation.
     pub fn init(&mut self) {
-        for td in self.td.iter_mut() {
-            td.init();
+        for x in 0..TD {
+            self.td[x].init();
         }
         self.tdidx = 0;
 
@@ -129,9 +129,8 @@ impl<const TD: usize> TDesRing<TD> {
         unsafe {
             let dma = &*stm32::ETHERNET_DMA::ptr();
             dma.dmactx_dlar
-                .write(|w| w.bits(&self.td as *const _ as u32));
-            dma.dmactx_rlr
-                .write(|w| w.tdrl().bits(self.td.len() as u16 - 1));
+                .write(|w| w.bits(&self.td[0] as *const _ as u32));
+            dma.dmactx_rlr.write(|w| w.tdrl().bits(TD as u16 - 1));
             dma.dmactx_dtpr
                 .write(|w| w.bits(&self.td[0] as *const _ as u32));
         }
@@ -265,8 +264,8 @@ impl<const RD: usize> RDesRing<RD> {
     /// will be stored in the descriptors, so ensure the RDesRing is
     /// not moved after initialisation.
     pub fn init(&mut self) {
-        for rd in self.rd.iter_mut() {
-            rd.init();
+        for x in 0..RD {
+            self.rd[x].init();
         }
         self.rdidx = 0;
 
@@ -274,9 +273,8 @@ impl<const RD: usize> RDesRing<RD> {
         unsafe {
             let dma = &*stm32::ETHERNET_DMA::ptr();
             dma.dmacrx_dlar
-                .write(|w| w.bits(&self.rd as *const _ as u32));
-            dma.dmacrx_rlr
-                .write(|w| w.rdrl().bits(self.rd.len() as u16 - 1));
+                .write(|w| w.bits(&self.rd[0] as *const _ as u32));
+            dma.dmacrx_rlr.write(|w| w.rdrl().bits(RD as u16 - 1));
         }
 
         // Release descriptors to the DMA engine


### PR DESCRIPTION
This allows users to decide how many transmit and receive buffers they wish to have the the `ethernet::DesRing`. Typically this allows a trade-off in performance vs memory usage.

The number of buffers need to be annotated on both `ethernet::DesRing` and `ethernet::EthernetDMA`. Requiring it on both is a slight usability downside. However this is small compared to the previous solution, which was making a local copy of the HAL in order to edit a constant value in `src/ethernet/eth.rs`.