### PR TITLE
Ethernet: Disable RA in filtering, fix MAC address setting

### DIFF
--- a/src/ethernet/eth.rs
+++ b/src/ethernet/eth.rs
@@ -478,7 +478,14 @@ pub unsafe fn new_unchecked<'a>(
                 .dcrcc()
                 .clear_bit()
         });
-        // Set the MAC address
+        // Set the MAC address.
+        // Writes to LR trigger both registers to be loaded into the MAC,
+        // so write to LR last.
+        eth_mac.maca0hr.write(|w| {
+            w.addrhi().bits(
+                u16::from(mac_addr.0[4]) | (u16::from(mac_addr.0[5]) << 8),
+            )
+        });
         eth_mac.maca0lr.write(|w| {
             w.addrlo().bits(
                 u32::from(mac_addr.0[0])
@@ -487,14 +494,6 @@ pub unsafe fn new_unchecked<'a>(
                     | (u32::from(mac_addr.0[3]) << 24),
             )
         });
-        eth_mac.maca0hr.write(
-            |w| {
-                w.addrhi().bits(
-                    u16::from(mac_addr.0[4]) | (u16::from(mac_addr.0[5]) << 8),
-                )
-            }, //.sa().clear_bit()
-               //.mbc().bits(0b000000)
-        );
         // frame filter register
         eth_mac.macpfr.modify(|_, w| {
             w.dntu()
@@ -523,7 +522,7 @@ pub unsafe fn new_unchecked<'a>(
                 .clear_bit()
                 // Receive All
                 .ra()
-                .set_bit()
+                .clear_bit()
                 // Promiscuous mode
                 .pr()
                 .clear_bit()


### PR DESCRIPTION
The MACA0LR/HR registers hold the address the MAC can use for filtering received packets, but they're only loaded into the MAC core when LR is written to. Currently the ethernet driver writes to LR first and then HR, so the MAC core doesn't get the bits from HR, which breaks filtering. I believe that's why the RA (receive-all) bit has been set, which bypasses the filtering.

This PR fixes writing the MAC address and disables the no-longer-required RA bit.

I've tested this with an H745 nucleo board and the ethernet-rtic-stm32h747i-disco example, changing just the GPIO setup to match the Nucleo.

See also https://github.com/embassy-rs/embassy/pull/389.