### PR TITLE
Allow parallel conversion on multiple ADCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * MSRV increased to 1.51.0
 * **Breaking**: Simplified API for reading device signature
   values. `VAL::get().read()` becomes `VAL::read()`
+* adc: Allow parallel execution of multiple ADCs through `start_conversion()`
 
 ## [v0.10.0] 2021-07-xx
 

--- a/examples/adc12.rs
+++ b/examples/adc12.rs
@@ -2,6 +2,7 @@
 //!
 //! For an example of using ADC3, see examples/temperature.rs
 //! For an example of using ADC1 alone, see examples/adc.rs
+//! For an example of using ADC1 and ADC2 in parallel, see examples/adc12_parallel.rs
 
 #![no_main]
 #![no_std]

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -2,6 +2,7 @@
 //!
 //! For an example of using ADC1, see examples/adc.rs
 //! For an example of using ADC1 and ADC2 together, see examples/adc12.rs
+//! For an example of using ADC1 and ADC2 in parallel, see examples/adc12_parallel.rs
 
 #![no_main]
 #![no_std]


### PR DESCRIPTION
This patch splits the current `convert()` method of ADC in two public methods: `start_conversion()` and `read_sample()`. With this, it is now possible to start conversion on multiple ADCs at the same time and then collect results.

There is one issue I'm not sure how to solve - I can call `start_conversion` on one channel and then `read_sample` on another and it would successfully read something. I suppose it would be better to protect user by exploding in case two channels are mixed. Thoughts?