### PR TITLE
Mark change to I2S constructor as breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Fixed clippy lints:
    * Added safety docs for some DMA functions
    * Implemented additional conversion utilities for `time`
-   * Changed I2S constructors to take less arguments
+   * **Breaking**: Changed I2S constructors to take less arguments
 
 * MSRV increased to 1.51.0
 * **Breaking**: Simplified API for reading device signature


### PR DESCRIPTION
This change has broken all existing calls to the constructor.

https://github.com/stm32-rs/stm32h7xx-hal/commit/6768a6f4ba9b2abf477851996679819256945593

Signed-off-by: Petr Horacek <hrck@protonmail.com>