### PR TITLE
Support cortex-m-rt 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ targets = ["thumbv7em-none-eabihf"]
 embedded-hal = "0.2.4"
 embedded-dma = "0.1.2"
 cortex-m = "^0.7.1"
-cortex-m-rt = "^0.6.15"
 stm32h7 = "^0.14.0"
 void = { version = "1.0.2", default-features = false }
 cast = { version = "0.2.3", default-features = false }
@@ -52,6 +51,7 @@ default-features = false
 optional = true
 
 [dev-dependencies]
+cortex-m-rt = ">=0.6.15,<0.8"
 cortex-m-rtic = { version = "0.5.8", default-features = false, features = ["cortex-m-7"] }
 log = "0.4.11"
 panic-halt = "0.2.0"

--- a/examples/ethernet-nucleo-h743zi2.rs
+++ b/examples/ethernet-nucleo-h743zi2.rs
@@ -171,11 +171,11 @@ fn SysTick() {
 }
 
 #[exception]
-fn HardFault(ef: &cortex_m_rt::ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &cortex_m_rt::ExceptionFrame) -> ! {
     panic!("HardFault at {:#?}", ef);
 }
 
 #[exception]
-fn DefaultHandler(irqn: i16) {
+unsafe fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/ethernet-stm32h747i-disco.rs
+++ b/examples/ethernet-stm32h747i-disco.rs
@@ -137,11 +137,11 @@ fn ETH() {
 }
 
 #[exception]
-fn HardFault(ef: &cortex_m_rt::ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &cortex_m_rt::ExceptionFrame) -> ! {
     panic!("HardFault at {:#?}", ef);
 }
 
 #[exception]
-fn DefaultHandler(irqn: i16) {
+unsafe fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }


### PR DESCRIPTION
Tested working with both cortex-m-rt 0.6.15 and 0.7.0.

Also: couldn't cortex-m-rt be optional, enabled by the `rt` feature? We shouldn't disable it now, as some might be relying on it, but for the next release, perhaps.