### PR TITLE
add spi traits

### DIFF
--- a/src/dma/macros.rs
+++ b/src/dma/macros.rs
@@ -125,7 +125,7 @@ macro_rules! peripheral_target_instance {
             unsafe impl TargetAddress<M2P> for spi::Spi<$peripheral, spi::Disabled, $size> {
                 #[inline(always)]
                 fn address(&self) -> usize {
-                    use spi::SpiAllExt;
+                    use spi::SpiAll;
                     &self.inner().$txreg as *const _ as usize
                 }
 
@@ -137,7 +137,7 @@ macro_rules! peripheral_target_instance {
             unsafe impl TargetAddress<P2M> for spi::Spi<$peripheral, spi::Disabled, $size> {
                 #[inline(always)]
                 fn address(&self) -> usize {
-                    use spi::SpiAllExt;
+                    use spi::SpiAll;
                     &self.inner().$rxreg as *const _ as usize
                 }
 

--- a/src/dma/macros.rs
+++ b/src/dma/macros.rs
@@ -125,6 +125,7 @@ macro_rules! peripheral_target_instance {
             unsafe impl TargetAddress<M2P> for spi::Spi<$peripheral, spi::Disabled, $size> {
                 #[inline(always)]
                 fn address(&self) -> usize {
+                    use spi::SpiAllExt;
                     &self.inner().$txreg as *const _ as usize
                 }
 
@@ -136,6 +137,7 @@ macro_rules! peripheral_target_instance {
             unsafe impl TargetAddress<P2M> for spi::Spi<$peripheral, spi::Disabled, $size> {
                 #[inline(always)]
                 fn address(&self) -> usize {
+                    use spi::SpiAllExt;
                     &self.inner().$rxreg as *const _ as usize
                 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,6 +2,7 @@
 pub use embedded_hal::prelude::*;
 
 pub use crate::adc::AdcExt as _stm32h7xx_hal_adc_AdcExt;
+
 #[cfg(feature = "crc")]
 pub use crate::crc::CrcExt as _stm32h7xx_hal_crc_CrcExt;
 pub use crate::dac::DacExt as _stm32h7xx_hal_dac_DacExt;
@@ -27,6 +28,9 @@ pub use crate::sai::SaiPdmExt as _stm32h7xx_hal_spi_SaiPdmExt;
 #[cfg(feature = "sdmmc")]
 pub use crate::sdmmc::SdmmcExt as _stm32h7xx_hal_sdmmc_SdmmcExt;
 pub use crate::serial::SerialExt as _stm32h7xx_hal_serial_SerialExt;
+pub use crate::spi::SpiAll as _stm32h7xx_hal_spi_SpiAll;
+pub use crate::spi::SpiDisabled as _stm32h7xx_hal_spi_SpiDisabled;
+pub use crate::spi::SpiEnabled as _stm32h7xx_hal_spi_SpiEnabled;
 pub use crate::spi::SpiExt as _stm32h7xx_hal_spi_SpiExt;
 pub use crate::time::U32Ext as _stm32h7xx_hal_time_U32Ext;
 pub use crate::timer::TimerExt as _stm32h7xx_hal_timer_TimerExt;


### PR DESCRIPTION
# Background

SPIs didn't have proper traits, so it was hard/impossible to be generic overall SPis.

# Description

- Added `SpiEnabledExt` for enabled SPIs
- Added `SpiDisabledExt` for disabled SPIs
- Added `SpiAllExt` which `SpiEnabledExt` and `SpiDisabledExt` must implement.

# Questions
- These changes are breaking as people previously using the Spi will need to `use Spi{Enabled,Disabled,All}Ext`. We could also make the traits delegate to the previously existing implementations, but this might not be as clean in terms of hal code imo—and the version is `< 1.x.y` anyway. Thoughts?