### PR TITLE
Add glue to make embedded-sdmmc work nicely

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,12 @@ embedded-dma = "0.1.2"
 cortex-m = "^0.7.1"
 stm32h7 = "^0.14.0"
 void = { version = "1.0.2", default-features = false }
-cast = { version = "0.2.3", default-features = false }
+cast = { version = "0.3.0", default-features = false }
 nb = "1.0.0"
 paste = "1.0.1"
 bare-metal = "1.0.0"
-sdio-host = { version = "0.4", optional = true }
+sdio-host = { version = "0.5", optional = true }
+embedded-sdmmc = { version = "0.3", optional = true }
 stm32-fmc = { version = "0.2", optional = true }
 synopsys-usb-otg = { version = "^0.2.4", features = ["cortex-m"], optional = true }
 embedded-display-controller = { version = "^0.1.0", optional = true }
@@ -87,6 +88,7 @@ ltdc = ["embedded-display-controller"]
 quadspi = []
 fmc = ["stm32-fmc"]
 sdmmc = ["sdio-host"]
+sdmmc-fatfs = ["embedded-sdmmc", "sdmmc"]
 ethernet = ["smoltcp"]
 rtc = ["chrono"]
 crc = []
@@ -150,6 +152,10 @@ required-features = ["quadspi", "rm0433"]
 [[example]]
 name = "sdmmc"
 required-features = ["sdmmc", "rm0433"]
+
+[[example]]
+name = "sdmmc_fat"
+required-features = ["sdmmc", "sdmmc-fatfs", "stm32h747cm7"]
 
 [[example]]
 name = "ethernet-stm32h747i-disco"

--- a/examples/sdmmc_fat.rs
+++ b/examples/sdmmc_fat.rs
@@ -1,0 +1,105 @@
+#![no_main]
+#![no_std]
+
+use {
+    embedded_sdmmc::{Controller, VolumeIdx},
+    log,
+    stm32h7xx_hal::{pac, prelude::*, rcc},
+};
+
+#[macro_use]
+mod utilities;
+
+// This is just a placeholder TimeSource. In a real world application
+// one would probably use the RTC to provide time.
+pub struct TimeSource;
+
+impl embedded_sdmmc::TimeSource for TimeSource {
+    fn get_timestamp(&self) -> embedded_sdmmc::Timestamp {
+        embedded_sdmmc::Timestamp {
+            year_since_1970: 0,
+            zero_indexed_month: 0,
+            zero_indexed_day: 0,
+            hours: 0,
+            minutes: 0,
+            seconds: 0,
+        }
+    }
+}
+
+#[cortex_m_rt::entry]
+unsafe fn main() -> ! {
+    utilities::logger::init();
+
+    // Get peripherals
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = example_power!(pwr).freeze();
+
+    // Constrain and Freeze clock
+    let ccdr = dp
+        .RCC
+        .constrain()
+        .sys_ck(480.mhz())
+        .pll1_strategy(rcc::PllConfigStrategy::Iterative)
+        .pll1_q_ck(100.mhz())
+        .pll2_strategy(rcc::PllConfigStrategy::Iterative)
+        .pll3_strategy(rcc::PllConfigStrategy::Iterative)
+        .freeze(pwrcfg, &dp.SYSCFG);
+
+    // Get the delay provider.
+    let mut delay = cp.SYST.delay(ccdr.clocks);
+
+    let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
+    let gpiod = dp.GPIOD.split(ccdr.peripheral.GPIOD);
+
+    let mut sd = dp.SDMMC2.sdmmc(
+        (
+            gpiod.pd6.into_alternate_af11(),
+            gpiod.pd7.into_alternate_af11(),
+            gpiob.pb14.into_alternate_af9(),
+            gpiob.pb15.into_alternate_af9(),
+            gpiob.pb3.into_alternate_af9(),
+            gpiob.pb4.into_alternate_af9(),
+        ),
+        ccdr.peripheral.SDMMC2,
+        &ccdr.clocks,
+    );
+
+    // Loop until we have a card
+    loop {
+        // On most development boards this can be increased up to 50MHz. We choose a
+        // lower frequency here so that it should work even with flying leads
+        // connected to a SD card breakout.
+        match sd.init_card(2.mhz()) {
+            Ok(_) => break,
+            Err(err) => {
+                log::info!("Init err: {:?}", err);
+            }
+        }
+
+        log::info!("Waiting for card...");
+
+        delay.delay_ms(1000u32);
+    }
+
+    // See https://github.com/rust-embedded-community/embedded-sdmmc-rs for docs
+    // and more examples
+
+    let mut sd_fatfs = Controller::new(sd.sdmmc_block_device(), TimeSource);
+    let sd_fatfs_volume = sd_fatfs.get_volume(VolumeIdx(0)).unwrap();
+    let sd_fatfs_root_dir = sd_fatfs.open_root_dir(&sd_fatfs_volume).unwrap();
+    sd_fatfs
+        .iterate_dir(&sd_fatfs_volume, &sd_fatfs_root_dir, |entry| {
+            log::info!("{:?}", entry);
+        })
+        .unwrap();
+    sd_fatfs.close_dir(&sd_fatfs_volume, sd_fatfs_root_dir);
+
+    loop {
+        cortex_m::asm::nop()
+    }
+}

--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -1138,6 +1138,54 @@ macro_rules! sdmmc {
                     Ok(())
                 }
 
+                #[cfg(feature = "sdmmc-fatfs")]
+                pub fn sdmmc_block_device(self) -> SdmmcBlockDevice<Sdmmc<$SDMMCX>> {
+                    SdmmcBlockDevice {
+                        sdmmc: core::cell::RefCell::new(self)
+                    }
+                }
+
+            }
+
+            #[cfg(feature = "sdmmc-fatfs")]
+            impl embedded_sdmmc::BlockDevice for SdmmcBlockDevice<Sdmmc<$SDMMCX>> {
+                type Error = Error;
+
+                fn read(
+                    &self,
+                    blocks: &mut [embedded_sdmmc::Block],
+                    start_block_idx: embedded_sdmmc::BlockIdx,
+                    _reason: &str,
+                ) -> Result<(), Self::Error> {
+                    let start = start_block_idx.0;
+                    let mut sdmmc = self.sdmmc.borrow_mut();
+                    for block_idx in start..(start + blocks.len() as u32) {
+                        sdmmc.read_block(
+                            block_idx,
+                            &mut blocks[(block_idx - start) as usize].contents,
+                        )?;
+                    }
+                    Ok(())
+                }
+
+                fn write(
+                    &self,
+                    blocks: &[embedded_sdmmc::Block],
+                    start_block_idx: embedded_sdmmc::BlockIdx,
+                ) -> Result<(), Self::Error> {
+                    let start = start_block_idx.0;
+                    let mut sdmmc = self.sdmmc.borrow_mut();
+                    for block_idx in start..(start + blocks.len() as u32) {
+                        sdmmc.write_block(block_idx, &blocks[(block_idx - start) as usize].contents)?;
+                    }
+                    Ok(())
+                }
+
+                fn num_blocks(&self) -> Result<embedded_sdmmc::BlockCount, Self::Error> {
+                    let sdmmc = self.sdmmc.borrow_mut();
+                    Ok(embedded_sdmmc::BlockCount(sdmmc.card()?.size() as u32 / 512u32))
+                }
+
             }
         )+
     };
@@ -1232,5 +1280,17 @@ impl Cmd {
     /// App Command. Indicates that next command will be a app command
     const fn app_cmd(rca: u32) -> Cmd {
         Cmd::new(55, rca, Response::Short)
+    }
+}
+
+#[cfg(feature = "sdmmc-fatfs")]
+pub struct SdmmcBlockDevice<SDMMC> {
+    sdmmc: core::cell::RefCell<SDMMC>,
+}
+
+#[cfg(feature = "sdmmc-fatfs")]
+impl<SDMMC> SdmmcBlockDevice<SDMMC> {
+    pub fn free(self) -> SDMMC {
+        self.sdmmc.into_inner()
     }
 }


### PR DESCRIPTION
It would have been nice to implement `embedded:BlockDevice` directly on `Sdmmc<$SDMMCX>` but that is not possible since `BlockDevice` takes `&self` and the methods that already exist take `&mut self`.