### PR TITLE
Remove `INSERT AFTER .bss` to fix infinite loop on boot when zeroing …

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -60,4 +60,4 @@ SECTIONS {
     *(.sram4 .sram4.*);
     . = ALIGN(4);
     } > SRAM4
-} INSERT AFTER .bss;
+};


### PR DESCRIPTION
…bss.

Fixes #263.