### PR TITLE
USART additions

### DIFF
--- a/examples/serial-advanced.rs
+++ b/examples/serial-advanced.rs
@@ -1,0 +1,53 @@
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::entry;
+#[macro_use]
+mod utilities;
+use log::info;
+
+use stm32h7xx_hal::{pac, prelude::*, serial::config::Config};
+
+use core::fmt::Write;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = example_power!(pwr).freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(160.mhz()).freeze(pwrcfg, &dp.SYSCFG);
+
+    // Acquire the GPIOC peripheral. This also enables the clock for
+    // GPIOC in the RCC register.
+    let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
+
+    let tx = gpioc.pc10.into_alternate_af7();
+    let rx = gpioc.pc11.into_alternate_af7();
+    let clk = gpioc.pc12.into_alternate_af7();
+
+    info!("");
+    info!("stm32h7xx-hal example - USART Advanced");
+    info!("");
+
+    // Configure the serial peripheral in synchronous mode
+    let config = Config::new(115_200.bps()).lastbitclockpulse(true);
+    let serial = dp
+        .USART3
+        .serial((tx, rx, clk), config, ccdr.peripheral.USART3, &ccdr.clocks)
+        .unwrap();
+
+    let (mut tx, _rx) = serial.split();
+
+    loop {
+        // core::fmt::Write is implemented for tx.
+        writeln!(tx, "Hello, world!").unwrap();
+    }
+}

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -411,6 +411,7 @@ pub trait SerialExt<USART>: Sized {
         config: impl Into<config::Config>,
         prec: Self::Rec,
         clocks: &CoreClocks,
+        synchronous: bool,
     ) -> Result<Serial<USART>, config::InvalidConfig>;
 
     #[deprecated(since = "0.7.0", note = "Deprecated in favour of .serial(..)")]
@@ -433,8 +434,9 @@ pub trait SerialExt<USART>: Sized {
         config: impl Into<config::Config>,
         prec: Self::Rec,
         clocks: &CoreClocks,
+        synchronous: bool,
     ) -> Result<Serial<USART>, config::InvalidConfig> {
-        self.serial_unchecked(config, prec, clocks)
+        self.serial_unchecked(config, prec, clocks, synchronous)
     }
 }
 
@@ -679,10 +681,11 @@ macro_rules! usart {
                 fn serial_unchecked(self,
                                    config: impl Into<config::Config>,
                                    prec: rec::$Rec,
-                                   clocks: &CoreClocks
+                                   clocks: &CoreClocks,
+                                   synchronous: bool,
                 ) -> Result<Serial<$USARTX>, config::InvalidConfig>
                 {
-                    Serial::$usartX(self, config, prec, clocks, false)
+                    Serial::$usartX(self, config, prec, clocks, synchronous)
                 }
             }
 


### PR DESCRIPTION
Follow on from #261 

* Add synchronous flag to serial_unchecked method
* Set synchronous bits on USART peripherals only, for others they are reserved
* Add builder methods for USART configuration fields
* Add an example of synchronous USART operation