### PR TITLE
Change DMA to have a non-static requirement

### DIFF
--- a/examples/dma.rs
+++ b/examples/dma.rs
@@ -20,7 +20,7 @@ use stm32h7xx_hal::dma::{
 
 use log::info;
 
-// DMA1/DMA2 cannot interact with our stack. Instead, buffers for use with the
+// DMA1/DMA2 cannot interact with our stack (using the example memory.x configuration). Instead, buffers for use with the
 // DMA must be placed somewhere that DMA1/DMA2 can access.
 //
 // The runtime does not initialise these SRAM banks.

--- a/examples/serial-dma.rs
+++ b/examples/serial-dma.rs
@@ -26,7 +26,7 @@ use stm32h7xx_hal::dma::{
 
 use log::info;
 
-// DMA1/DMA2 cannot interact with our stack. Instead, buffers for use with the
+// DMA1/DMA2 cannot interact with our stack (using the example memory.x configuration). Instead, buffers for use with the
 // DMA must be placed somewhere that DMA1/DMA2 can access. In this case we use
 // AXI SRAM.
 //

--- a/examples/spi-dma-rtic.rs
+++ b/examples/spi-dma-rtic.rs
@@ -22,7 +22,7 @@ use stm32h7xx_hal as hal;
 // The number of bytes to transfer.
 const BUFFER_SIZE: usize = 100;
 
-// DMA1/DMA2 cannot interact with our stack. Instead, buffers for use with the
+// DMA1/DMA2 cannot interact with our stack (using the example memory.x configuration). Instead, buffers for use with the
 // DMA must be placed somewhere that DMA1/DMA2 can access. In this case we use
 // AXI SRAM.
 //

--- a/examples/spi-dma.rs
+++ b/examples/spi-dma.rs
@@ -26,7 +26,7 @@ use stm32h7xx_hal::dma::{
 
 use log::info;
 
-// DMA1/DMA2 cannot interact with our stack. Instead, buffers for use with the
+// DMA1/DMA2 cannot interact with our stack (using the example memory.x configuration). Instead, buffers for use with the
 // DMA must be placed somewhere that DMA1/DMA2 can access. In this case we use
 // AXI SRAM.
 //

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -93,7 +93,7 @@ use core::{
     ptr,
     sync::atomic::{fence, Ordering},
 };
-use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
+use embedded_dma::{ReadBuffer, StaticWriteBuffer, WriteBuffer};
 
 #[macro_use]
 mod macros;
@@ -743,8 +743,8 @@ macro_rules! db_transfer_def {
     };
 }
 
-db_transfer_def!(DBTransfer, init, StaticWriteBuffer, write_buffer, mut;);
-db_transfer_def!(ConstDBTransfer, init_const, StaticReadBuffer, read_buffer;
+db_transfer_def!(DBTransfer, init, WriteBuffer, write_buffer, mut;);
+db_transfer_def!(ConstDBTransfer, init_const, ReadBuffer, read_buffer;
                  assert!(DIR::direction() != DmaDirection::PeripheralToMemory));
 
 impl<STREAM, CONFIG, PERIPHERAL, DIR, BUF, TXFRT>


### PR DESCRIPTION
# Background

Even though it is mentioned in the comments of some of the examples, the memory accessed by DMA does not necessarily need to be on the stack. If we defined `memory.x` to have our stack somewhere where DMA can access, we can pass in a stack buffer just fine. 

# Changes
- Update comments referencing stack requirement
- Change `Static{Read,Write}Buffer -> Static{Read,Write}Buffer`