### PR TITLE
Example README update

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,66 @@
 Examples
 ======
 
+## Parts with a SMPS
+
+For these parts, the program needs to know more about the power supply
+scheme in order to successfully transition from Run* mode to Run mode. For
+an explaination of Run* mode, see RM0433 Rev 7 Section 6.6.1 "System/D3
+domain modes".
+
+For your own code, see the
+[documentation](https://docs.rs/stm32h7xx-hal/latest/stm32h7xx_hal/pwr/index.html#smps)
+for the builder methods on `pwr`. However to make things easier for the
+examples, there are feature flags that set common power configurations.
+
+Flag | Situation | Applicable Boards (non-exhaustive)
+---|---|---
+`example-smps` | Board uses Internal SMPS | Any Nucleo with `-Q` suffix
+`example-ldo` | Board uses LDO, internal SMPS unconnected |
+none | Parts without internal SMPS |
+
+The results of using the wrong power configuration for your hardware are
+undefined(!). If you can still access the debug port, load a simple example
+with the correct power configuration and power cycle the board.
+
+## Logging
+
+Example specific features have been defined to enable different logging outputs for the examples.
+If no logging feature is selected logging will be disabled and the panic handler will be halt.
+Supported logging methods are:
+
+### RTT (Real Time Trace)
+
+Compile with the feature log-rtt
+
+```
+cargo build --features=stm32h750v,rt,log-rtt --examples
+```
+
+### Semihosting
+
+Compile with the feature log-semihost. Note this method of logging is very slow.
+
+```
+cargo build --features=stm32h750v,rt,log-semihost --examples
+```
+
+
+### ITM (Instrumentation Trace Macrocell)
+Compile with the feature log-itm
+
+```
+cargo build --features=stm32h750v,rt,log-itm --examples
+```
+
+Note that you may need to configure your debugger to output ITM, and/or
+configure the ITM yourself. See [ITM.md](ITM.md)
+
+If you select this feature flag, then the call to `logger::init()` internally
+configures the ITM peripheral. If you also interact with the ITM peripheral
+yourself, you should be aware that it has already been configured.
+
+
 ## Starting your own project
 
 Although you can compile the provided examples directly, for your own project it
@@ -52,62 +112,3 @@ is contained within the [examples folder](https://github.com/stm32-rs/stm32h7xx-
 
 8. Flashing the MCU typically works differently for different boards. You can
    usually find instructions in the board specific crates or BSPs.
-
-## Logging
-
-Example specific features have been defined to enable different logging outputs for the examples.
-If no logging feature is selected logging will be disabled and the panic handler will be halt.
-Supported logging methods are:
-
-### RTT (Real Time Trace)
-
-Compile with the feature log-rtt
-
-```
-cargo build --features=stm32h750v,rt,log-rtt --examples
-```
-
-### Semihosting
-
-Compile with the feature log-semihost. Note this method of logging is very slow.
-
-```
-cargo build --features=stm32h750v,rt,log-semihost --examples
-```
-
-
-### ITM (Instrumentation Trace Macrocell)
-Compile with the feature log-itm
-
-```
-cargo build --features=stm32h750v,rt,log-itm --examples
-```
-
-Note that you may need to configure your debugger to output ITM, and/or
-configure the ITM yourself. See [ITM.md](ITM.md)
-
-If you select this feature flag, then the call to `logger::init()` internally
-configures the ITM peripheral. If you also interact with the ITM peripheral
-yourself, you should be aware that it has already been configured.
-
-## Parts with a SMPS
-
-For these parts, the program needs to know more about the power supply
-scheme in order to successfully transition from Run* mode to Run mode. For
-an explaination of Run* mode, see RM0433 Rev 7 Section 6.6.1 "System/D3
-domain modes".
-
-For your own code, see the
-[documentation](https://docs.rs/stm32h7xx-hal/latest/stm32h7xx_hal/pwr/index.html#smps)
-for the builder methods on `pwr`. However to make things easier for the
-examples, there are feature flags that set common power configurations.
-
-Flag | Situation | Applicable Boards (non-exhaustive)
----|---|---
-`example-smps` | Board uses Internal SMPS | Any Nucleo with `-Q` suffix
-`example-ldo` | Board uses LDO, internal SMPS unconnected |
-none | Parts without internal SMPS |
-
-The results of using the wrong power configuration for your hardware are
-undefined(!). If you can still access the debug port, load a simple example
-with the correct power configuration and power cycle the board.

--- a/examples/README.md
+++ b/examples/README.md
@@ -61,7 +61,7 @@ configures the ITM peripheral. If you also interact with the ITM peripheral
 yourself, you should be aware that it has already been configured.
 
 
-## Starting your own project
+# Starting your own project
 
 Although you can compile the provided examples directly, for your own project it
 is recommended to make a new binary crate or start one based on existing board

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,31 +1,70 @@
 Examples
 ======
 
-## Parts with a SMPS
+## Getting started
 
-For these parts, the program needs to know more about the power supply
-scheme in order to successfully transition from Run* mode to Run mode. For
-an explaination of Run* mode, see RM0433 Rev 7 Section 6.6.1 "System/D3
-domain modes".
+You can compile the provided examples directly, but it is recommended to create
+a new binary crate or one based on existing board specficic example or BSP crates.
+This is because most examples will require tweaks to work for your particular board.
+You then can copy the examples into your binary crate and make any necessary adjustments.
 
-For your own code, see the
-[documentation](https://docs.rs/stm32h7xx-hal/latest/stm32h7xx_hal/pwr/index.html#smps)
-for the builder methods on `pwr`. However to make things easier for the
-examples, there are feature flags that set common power configurations.
+These board specific crates usually also supply files which make
+development on the board easier. They might also contain board specific code or adaptions that
+might be required to make the examples work for your particular board.
 
-Flag | Situation | Applicable Boards (non-exhaustive)
----|---|---
-`example-smps` | Board uses Internal SMPS | Any Nucleo with `-Q` suffix
-`example-ldo` | Board uses LDO, internal SMPS unconnected |
-none | Parts without internal SMPS |
+The hello world of embedded development is usually to blinky a LED. This example
+is contained within the [examples folder](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/blinky.rs).
 
-The results of using the wrong power configuration for your hardware are
-undefined(!). If you can still access the debug port, load a simple example
-with the correct power configuration and power cycle the board.
+1. Make sure you have the required Rust cross-compiler installed. If you have not
+   done this yet, you can run the following command to install it
+
+   ```sh
+   rustup target add thumbv7em-none-eabihf
+   ```
+
+2. Create a new binary crate with `cargo init`
+3. To ensure that `cargo build` cross-compiles, it is recommended to create
+   a `.cargo/config.toml` file. You can use the `config.toml` provided
+   in the [`cortex-m-quickstart`](https://github.com/rust-embedded/cortex-m-quickstart/blob/master/.cargo/config.toml)
+   repository and uncomment `target = "thumbv7em-none-eabihf"`.
+4. Copy the `memory.x` file into your project. This file contains information
+   required by the linker.
+5. Copy the `blinky.rs` file to the `src/main.rs` in your binaray crate and copy the `utilities`
+   folder to your `src` folder as well. The utilities
+   folder contains common code used by all examples, e.g. for logger initialization.
+6. For `blinky.rs`, you also need to add some dependencies to your `Cargo.toml`. If
+   you are doing this for another example or you'd like to use another logger, you
+   might need different dependencies. Make sure to replace the configuration
+   feature `stm32h743v` according to your used board:
+
+   ```toml
+   [dependencies]
+   cortex-m-rt = "0.6.12"
+   cortex-m = "0.7.1"
+   log = "0.4.11"
+   embedded-hal = "0.2.6"
+   panic-halt = "0.2"
+   cfg-if = "1.0.0"
+
+   [dependencies.stm32h7xx-hal]
+   version = "0.10"
+   features = ["stm32h743v"]
+   ```
+
+7. Build the application with
+
+   ```sh
+   cargo build
+   ```
+
+8. Flashing the board might work differently for different boards and there is usually
+   more than one way. You can usually find instructions in the board specific crates or BSPs.
 
 ## Logging
 
-Example specific features have been defined to enable different logging outputs for the examples. If no logging feature is selected logging will be disabled and the panic handler will be halt. Supported logging methods are:
+Example specific features have been defined to enable different logging outputs for the examples.
+If no logging feature is selected logging will be disabled and the panic handler will be halt.
+Supported logging methods are:
 
 ### RTT (Real Time Trace)
 
@@ -57,3 +96,25 @@ configure the ITM yourself. See [ITM.md](ITM.md)
 If you select this feature flag, then the call to `logger::init()` internally
 configures the ITM peripheral. If you also interact with the ITM peripheral
 yourself, you should be aware that it has already been configured.
+
+## Parts with a SMPS
+
+For these parts, the program needs to know more about the power supply
+scheme in order to successfully transition from Run* mode to Run mode. For
+an explaination of Run* mode, see RM0433 Rev 7 Section 6.6.1 "System/D3
+domain modes".
+
+For your own code, see the
+[documentation](https://docs.rs/stm32h7xx-hal/latest/stm32h7xx_hal/pwr/index.html#smps)
+for the builder methods on `pwr`. However to make things easier for the
+examples, there are feature flags that set common power configurations.
+
+Flag | Situation | Applicable Boards (non-exhaustive)
+---|---|---
+`example-smps` | Board uses Internal SMPS | Any Nucleo with `-Q` suffix
+`example-ldo` | Board uses LDO, internal SMPS unconnected |
+none | Parts without internal SMPS |
+
+The results of using the wrong power configuration for your hardware are
+undefined(!). If you can still access the debug port, load a simple example
+with the correct power configuration and power cycle the board.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,18 +1,19 @@
 Examples
 ======
 
-## Getting started
+## Starting your own project
 
-You can compile the provided examples directly, but it is recommended to create
-a new binary crate or one based on existing board specficic example or BSP crates.
-This is because most examples will require tweaks to work for your particular board.
-You then can copy the examples into your binary crate and make any necessary adjustments.
+Although you can compile the provided examples directly, for your own project it
+is recommended to make a new binary crate or start one based on existing board
+specific examples / BSPs. Most examples will require tweaks to work for your
+particular board. You should copy the examples into your binary crate and make
+any necessary adjustments.
 
-These board specific crates usually also supply files which make
-development on the board easier. They might also contain board specific code or adaptions that
-might be required to make the examples work for your particular board.
+If you can find a suitable BSP, these usually also supply files which make
+development easier. They might also contain board specific code or adaptions
+required to make the examples work for your particular board.
 
-The hello world of embedded development is usually to blinky a LED. This example
+The hello world of embedded development is usually to blink a LED. This example
 is contained within the [examples folder](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/blinky.rs).
 
 1. Make sure you have the required Rust cross-compiler installed. If you have not
@@ -24,18 +25,15 @@ is contained within the [examples folder](https://github.com/stm32-rs/stm32h7xx-
 
 2. Create a new binary crate with `cargo init`
 3. To ensure that `cargo build` cross-compiles, it is recommended to create
-   a `.cargo/config.toml` file. You can use the `config.toml` provided
-   in the [`cortex-m-quickstart`](https://github.com/rust-embedded/cortex-m-quickstart/blob/master/.cargo/config.toml)
+   a `.cargo/config.toml` file. You can use the [`config.toml` provided
+   in the cortex-m-quickstart](https://github.com/rust-embedded/cortex-m-quickstart/blob/master/.cargo/config.toml)
    repository and uncomment `target = "thumbv7em-none-eabihf"`.
-4. Copy the `memory.x` file into your project. This file contains information
-   required by the linker.
-5. Copy the `blinky.rs` file to the `src/main.rs` in your binaray crate and copy the `utilities`
-   folder to your `src` folder as well. The utilities
-   folder contains common code used by all examples, e.g. for logger initialization.
-6. For `blinky.rs`, you also need to add some dependencies to your `Cargo.toml`. If
-   you are doing this for another example or you'd like to use another logger, you
-   might need different dependencies. Make sure to replace the configuration
-   feature `stm32h743v` according to your used board:
+4. Copy `memory.x` into your project. This file contains information required by
+   the linker.
+5. Copy `blinky.rs` to the `src/main.rs` in your binary crate and remove
+   references to the `utilities` module.
+6. Add a dependency on the HAL in `Cargo.toml`. Make sure to replace
+   the configuration feature `stm32h743v` to match the part you are using:
 
    ```toml
    [dependencies]
@@ -57,8 +55,8 @@ is contained within the [examples folder](https://github.com/stm32-rs/stm32h7xx-
    cargo build
    ```
 
-8. Flashing the board might work differently for different boards and there is usually
-   more than one way. You can usually find instructions in the board specific crates or BSPs.
+8. Flashing the MCU typically works differently for different boards. You can
+   usually find instructions in the board specific crates or BSPs.
 
 ## Logging
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,18 +36,13 @@ is contained within the [examples folder](https://github.com/stm32-rs/stm32h7xx-
    the configuration feature `stm32h743v` to match the part you are using:
 
    ```toml
-   [dependencies]
-   cortex-m-rt = "0.6.12"
-   cortex-m = "0.7.1"
-   log = "0.4.11"
-   embedded-hal = "0.2.6"
-   panic-halt = "0.2"
-   cfg-if = "1.0.0"
-
    [dependencies.stm32h7xx-hal]
-   version = "0.10"
+   version = "^0"
    features = ["stm32h743v"]
    ```
+
+   You should also add dependencies for the other crates you need, such as
+   `cortex-m-rt` or `embedded-hal`.
 
 7. Build the application with
 


### PR DESCRIPTION
I think it makes more sense to give users instructions on how to  build the example applications in their own binary crate. This is how some other HAL crates did it. This PR restructures the `README.md` file a bit and provides complete instructions on how to create a new binary crate and build the blinky example in it.