### PR TITLE
improve spi traits

### DIFF
--- a/src/dma/macros.rs
+++ b/src/dma/macros.rs
@@ -125,7 +125,7 @@ macro_rules! peripheral_target_instance {
             unsafe impl TargetAddress<M2P> for spi::Spi<$peripheral, spi::Disabled, $size> {
                 #[inline(always)]
                 fn address(&self) -> usize {
-                    use spi::SpiAll;
+                    use spi::HalSpi;
                     &self.inner().$txreg as *const _ as usize
                 }
 
@@ -137,7 +137,7 @@ macro_rules! peripheral_target_instance {
             unsafe impl TargetAddress<P2M> for spi::Spi<$peripheral, spi::Disabled, $size> {
                 #[inline(always)]
                 fn address(&self) -> usize {
-                    use spi::SpiAll;
+                    use spi::HalSpi;
                     &self.inner().$rxreg as *const _ as usize
                 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,9 +23,9 @@ pub use crate::sai::SaiPdmExt as _stm32h7xx_hal_spi_SaiPdmExt;
 #[cfg(feature = "sdmmc")]
 pub use crate::sdmmc::SdmmcExt as _stm32h7xx_hal_sdmmc_SdmmcExt;
 pub use crate::serial::SerialExt as _stm32h7xx_hal_serial_SerialExt;
-pub use crate::spi::SpiAll as _stm32h7xx_hal_spi_SpiAll;
-pub use crate::spi::SpiDisabled as _stm32h7xx_hal_spi_SpiDisabled;
-pub use crate::spi::SpiEnabled as _stm32h7xx_hal_spi_SpiEnabled;
+pub use crate::spi::HalDisabledSpi as _stm32h7xx_hal_spi_HalDisabledSpi;
+pub use crate::spi::HalEnabledSpi as _stm32h7xx_hal_spi_HalEnabledSpi;
+pub use crate::spi::HalSpi as _stm32h7xx_hal_spi_HalSpi;
 pub use crate::spi::SpiExt as _stm32h7xx_hal_spi_SpiExt;
 pub use crate::time::U32Ext as _stm32h7xx_hal_time_U32Ext;
 pub use crate::timer::TimerExt as _stm32h7xx_hal_timer_TimerExt;


### PR DESCRIPTION
- rename to SPI traits to possibly better names
  -  `SpiAll` -> `HalSpi`
  - `SpiEnabled` -> `HalEnabledSpi`
  - `SpiDisabled` -> `HalDisabledSpi`
 
- `reset` no longer needs to take ownership of the given SPI peripheral 