### PR TITLE
Fix the rt feature for stm32h7 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * adc: Allow parallel execution of multiple ADCs through `start_conversion()`
 * Rename the PeripheralREC object for BDMA2 on 7B3, 7B0, 7A3 parts from BDMA to BDMA2
 * pac: Upgrade to stm32-rs v0.14.0
+* Add "rt" to the default features
 
 * ethernet: `ethernet::DesRing` and `ethernet::EthernetDMA` require generic
   constants to specify how many transmit / receive buffers to include in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = ["thumbv7em-none-eabihf"]
 embedded-hal = "0.2.6"
 embedded-dma = "0.1.2"
 cortex-m = "^0.7.1"
-stm32h7 = "^0.14.0"
+stm32h7 = { version = "^0.14.0", default-features = false }
 void = { version = "1.0.2", default-features = false }
 cast = { version = "0.3.0", default-features = false }
 nb = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ default-features = false
 features = ["ethernet", "proto-ipv4", "proto-ipv6", "socket-raw"]
 
 [features]
-default = ["unproven"]
+default = ["unproven", "rt"]
 unproven = ["embedded-hal/unproven"]
 device-selected = []
 revision_v = []


### PR DESCRIPTION
The stm32h7 crate includes 'rt' as a default feature for 0.14.0: https://docs.rs/crate/stm32h7/0.14.0/source/Cargo.toml