### PR TITLE
Improve error diagnostics when kernel clocks are stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 * Rename the PeripheralREC object for BDMA2 on 7B3, 7B0, 7A3 parts from BDMA to BDMA2
 * pac: Upgrade to stm32-rs v0.14.0
 * Add "rt" to the default features
+* **Breaking**: `qspi` flag renamed to `xspi`
+* **Breaking**: SAI `sai_[ab]_ker_ck` methods now return `Hertz` rather than
+  `Option<Hertz>` and if the clock is stopped they panic with a message.
 
 * ethernet: `ethernet::DesRing` and `ethernet::EthernetDMA` require generic
   constants to specify how many transmit / receive buffers to include in

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -330,12 +330,17 @@ pub struct StoredConfig(AdcSampleTime, Resolution, AdcLshift);
 fn check_clock(prec: &impl AdcClkSelGetter, clocks: &CoreClocks) -> Hertz {
     // Select Kernel Clock
     let adc_clock = match prec.get_kernel_clk_mux() {
-        Some(rec::AdcClkSel::PLL2_P) => clocks.pll2_p_ck(),
-        Some(rec::AdcClkSel::PLL3_R) => clocks.pll3_r_ck(),
-        Some(rec::AdcClkSel::PER) => clocks.per_ck(),
+        Some(rec::AdcClkSel::PLL2_P) => {
+            clocks.pll2_p_ck().expect("ADC: PLL2_P must be enabled")
+        }
+        Some(rec::AdcClkSel::PLL3_R) => {
+            clocks.pll3_r_ck().expect("ADC: PLL3_R must be enabled")
+        }
+        Some(rec::AdcClkSel::PER) => {
+            clocks.per_ck().expect("ADC: PER clock must be enabled")
+        }
         _ => unreachable!(),
-    }
-    .expect("adc_ker_ck_input is not running!");
+    };
 
     // Check against datasheet requirements
     assert!(

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1052,7 +1052,7 @@ macro_rules! tim_hal {
                 prec.enable().reset();
 
                 let clk = $TIMX::get_clk(clocks)
-                    .expect("$TIMX: Input clock not running!");
+                    .expect(concat!(stringify!($TIMX), ": Input clock not running!"));
 
                 let (period, prescale) = match $bits {
                     16 => calculate_frequency_16bit(clk, freq, Alignment::Left),
@@ -1096,7 +1096,7 @@ macro_rules! tim_hal {
                     prec.enable().reset();
 
                     let clk = $TIMX::get_clk(clocks)
-                        .expect("$TIMX: Input clock not running!")
+                        .expect(concat!(stringify!($TIMX), ": Input clock not running!"))
                         .0;
 
                     PwmBuilder {
@@ -1646,7 +1646,8 @@ macro_rules! lptim_hal {
                 prec.enable().reset();
 
                 let clk = $TIMX::get_clk(clocks)
-                    .expect("$TIMX: Input clock not running").0;
+                    .expect(concat!(stringify!($TIMX), ": Input clock not running!"))
+                    .0;
                 let freq = freq.0;
                 let reload = clk / freq;
                 assert!(reload < 128 * (1 << 16));

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1052,7 +1052,7 @@ macro_rules! tim_hal {
                 prec.enable().reset();
 
                 let clk = $TIMX::get_clk(clocks)
-                    .expect("Timer input clock not running!");
+                    .expect("$TIMX: Input clock not running!");
 
                 let (period, prescale) = match $bits {
                     16 => calculate_frequency_16bit(clk, freq, Alignment::Left),
@@ -1096,7 +1096,7 @@ macro_rules! tim_hal {
                     prec.enable().reset();
 
                     let clk = $TIMX::get_clk(clocks)
-                        .expect("Timer input clock not running!")
+                        .expect("$TIMX: Input clock not running!")
                         .0;
 
                     PwmBuilder {
@@ -1645,7 +1645,8 @@ macro_rules! lptim_hal {
             {
                 prec.enable().reset();
 
-                let clk = $TIMX::get_clk(clocks).unwrap().0;
+                let clk = $TIMX::get_clk(clocks)
+                    .expect("$TIMX: Input clock not running").0;
                 let freq = freq.0;
                 let reload = clk / freq;
                 assert!(reload < 128 * (1 << 16));

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -38,7 +38,9 @@ impl KerClk for RNG {
                 clocks.pll1_q_ck().expect("RNG: PLL1_Q must be enabled")
             }
             RngClkSel::LSE => unimplemented!(),
-            RngClkSel::LSI => unimplemented!(),
+            RngClkSel::LSI => {
+                clocks.lsi_ck().expect("RNG: LSI must be enabled")
+            }
         }
     }
 }

--- a/src/sai/i2s.rs
+++ b/src/sai/i2s.rs
@@ -467,7 +467,9 @@ macro_rules! i2s {
                         (ker_ck_a.0) / (audio_freq.0 * clock_ratio);
                     let mclk_div: u8 = mclk_div
                         .try_into()
-                        .expect("$SAIX A: Kernel clock is out of range for required MCLK");
+                        .expect(concat!(stringify!($SAIX),
+                                        " A: Kernel clock is out of range for required MCLK"
+                        ));
 
                     // Configure SAI peripheral
                     let mut per_sai = Sai {
@@ -532,7 +534,10 @@ macro_rules! i2s {
                         (ker_ck_a.0) / (audio_freq.0 * clock_ratio);
                     let mclk_div: u8 = mclk_div
                         .try_into()
-                        .expect("$SAIX B: Kernel clock is out of range for required MCLK");
+                        .expect(concat!(stringify!($SAIX),
+                                        " B: Kernel clock is out of range for required MCLK"
+                        ));
+
 
                     // Configure SAI peripheral
                     let mut per_sai = Sai {

--- a/src/sai/i2s.rs
+++ b/src/sai/i2s.rs
@@ -457,8 +457,7 @@ macro_rules! i2s {
                     }
 
                     // Clock config
-                    let ker_ck_a = $SAIX::sai_a_ker_ck(&prec, clocks)
-                        .expect("SAI kernel clock must run!");
+                    let ker_ck_a = $SAIX::sai_a_ker_ck(&prec, clocks);
                     let clock_ratio = if users.master.oversampling {
                         512
                     } else {
@@ -468,7 +467,7 @@ macro_rules! i2s {
                         (ker_ck_a.0) / (audio_freq.0 * clock_ratio);
                     let mclk_div: u8 = mclk_div
                         .try_into()
-                        .expect("SAI kernel clock is out of range for required MCLK");
+                        .expect("$SAIX A: Kernel clock is out of range for required MCLK");
 
                     // Configure SAI peripheral
                     let mut per_sai = Sai {
@@ -523,8 +522,7 @@ macro_rules! i2s {
                     }
 
                     // Clock config
-                    let ker_ck_a = $SAIX::sai_b_ker_ck(&prec, clocks)
-                        .expect("SAI kernel clock must run!");
+                    let ker_ck_a = $SAIX::sai_b_ker_ck(&prec, clocks);
                     let clock_ratio = if users.master.oversampling {
                         512
                     } else {
@@ -534,7 +532,7 @@ macro_rules! i2s {
                         (ker_ck_a.0) / (audio_freq.0 * clock_ratio);
                     let mclk_div: u8 = mclk_div
                         .try_into()
-                        .expect("SAI kernel clock is out of range for required MCLK");
+                        .expect("$SAIX B: Kernel clock is out of range for required MCLK");
 
                     // Configure SAI peripheral
                     let mut per_sai = Sai {

--- a/src/sai/mod.rs
+++ b/src/sai/mod.rs
@@ -45,8 +45,18 @@ pub use i2s::{
 pub trait GetClkSAI {
     type Rec: ResetEnable;
 
-    fn sai_a_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Option<Hertz>;
-    fn sai_b_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Option<Hertz>;
+    /// Return the kernel clock for the SAI - A
+    ///
+    /// # Panics
+    ///
+    /// Panics if the kernel clock is not running
+    fn sai_a_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Hertz;
+    /// Return the kernel clock for the SAI - B
+    ///
+    /// # Panics
+    ///
+    /// Panics if the kernel clock is not running
+    fn sai_b_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Hertz;
 }
 
 // Return kernel clocks for this SAI
@@ -59,24 +69,40 @@ macro_rules! impl_sai_ker_ck {
                 type Rec = rec::$Rec;
 
                 /// Current kernel clock - A
-                fn sai_a_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Option<Hertz> {
+                fn sai_a_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Hertz {
                     match prec.$get_mux_A() {
-                        Some(rec::$AccessA::PLL1_Q) => clocks.pll1_q_ck(),
-                        Some(rec::$AccessA::PLL2_P) => clocks.pll2_p_ck(),
-                        Some(rec::$AccessA::PLL3_P) => clocks.pll3_p_ck(),
+                        Some(rec::$AccessA::PLL1_Q) => {
+                            clocks.pll1_q_ck().expect("$SAIX A: PLL1_Q must be enabled")
+                        }
+                        Some(rec::$AccessA::PLL2_P) => {
+                            clocks.pll2_p_ck().expect("$SAIX A: PLL2_P must be enabled")
+                        }
+                        Some(rec::$AccessA::PLL3_P) => {
+                            clocks.pll3_p_ck().expect("$SAIX A: PLL3_P must be enabled")
+                        }
                         Some(rec::$AccessA::I2S_CKIN) => unimplemented!(),
-                        Some(rec::$AccessA::PER) => clocks.per_ck(),
+                        Some(rec::$AccessA::PER) => {
+                            clocks.per_ck().expect("$SAIX A: PER clock must be enabled")
+                        }
                         _ => unreachable!(),
                     }
                 }
                 /// Current kernel clock - B
-                fn sai_b_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Option<Hertz> {
+                fn sai_b_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Hertz {
                     match prec.$get_mux_B() {
-                        Some(rec::$AccessB::PLL1_Q) => clocks.pll1_q_ck(),
-                        Some(rec::$AccessB::PLL2_P) => clocks.pll2_p_ck(),
-                        Some(rec::$AccessB::PLL3_P) => clocks.pll3_p_ck(),
+                        Some(rec::$AccessB::PLL1_Q) => {
+                            clocks.pll1_q_ck().expect("$SAIX B: PLL1_Q must be enabled")
+                        }
+                        Some(rec::$AccessB::PLL2_P) => {
+                            clocks.pll2_p_ck().expect("$SAIX B: PLL2_P must be enabled")
+                        }
+                        Some(rec::$AccessB::PLL3_P) => {
+                            clocks.pll3_p_ck().expect("$SAIX B: PLL3_P must be enabled")
+                        }
                         Some(rec::$AccessB::I2S_CKIN) => unimplemented!(),
-                        Some(rec::$AccessB::PER) => clocks.per_ck(),
+                        Some(rec::$AccessB::PER) => {
+                            clocks.per_ck().expect("$SAIX B: PER clock must be enabled")
+                        }
                         _ => unreachable!(),
                     }
                 }

--- a/src/sai/mod.rs
+++ b/src/sai/mod.rs
@@ -72,17 +72,25 @@ macro_rules! impl_sai_ker_ck {
                 fn sai_a_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Hertz {
                     match prec.$get_mux_A() {
                         Some(rec::$AccessA::PLL1_Q) => {
-                            clocks.pll1_q_ck().expect("$SAIX A: PLL1_Q must be enabled")
+                            clocks.pll1_q_ck().expect(
+                                concat!(stringify!($SAIX), " A: PLL1_Q must be enabled")
+                            )
                         }
                         Some(rec::$AccessA::PLL2_P) => {
-                            clocks.pll2_p_ck().expect("$SAIX A: PLL2_P must be enabled")
+                            clocks.pll2_p_ck().expect(
+                                concat!(stringify!($SAIX), " A: PLL2_P must be enabled")
+                            )
                         }
                         Some(rec::$AccessA::PLL3_P) => {
-                            clocks.pll3_p_ck().expect("$SAIX A: PLL3_P must be enabled")
+                            clocks.pll3_p_ck().expect(
+                                concat!(stringify!($SAIX), " A: PLL3_P must be enabled")
+                            )
                         }
                         Some(rec::$AccessA::I2S_CKIN) => unimplemented!(),
                         Some(rec::$AccessA::PER) => {
-                            clocks.per_ck().expect("$SAIX A: PER clock must be enabled")
+                            clocks.per_ck().expect(
+                                concat!(stringify!($SAIX), " A: PER clock must be enabled")
+                            )
                         }
                         _ => unreachable!(),
                     }
@@ -91,17 +99,25 @@ macro_rules! impl_sai_ker_ck {
                 fn sai_b_ker_ck(prec: &Self::Rec, clocks: &CoreClocks) -> Hertz {
                     match prec.$get_mux_B() {
                         Some(rec::$AccessB::PLL1_Q) => {
-                            clocks.pll1_q_ck().expect("$SAIX B: PLL1_Q must be enabled")
+                            clocks.pll1_q_ck().expect(
+                                concat!(stringify!($SAIX), " B: PLL1_Q must be enabled")
+                            )
                         }
                         Some(rec::$AccessB::PLL2_P) => {
-                            clocks.pll2_p_ck().expect("$SAIX B: PLL2_P must be enabled")
+                            clocks.pll2_p_ck().expect(
+                                concat!(stringify!($SAIX), " B: PLL2_P must be enabled")
+                            )
                         }
                         Some(rec::$AccessB::PLL3_P) => {
-                            clocks.pll3_p_ck().expect("$SAIX B: PLL3_P must be enabled")
+                            clocks.pll3_p_ck().expect(
+                                concat!(stringify!($SAIX), " B: PLL3_P must be enabled")
+                            )
                         }
                         Some(rec::$AccessB::I2S_CKIN) => unimplemented!(),
                         Some(rec::$AccessB::PER) => {
-                            clocks.per_ck().expect("$SAIX B: PER clock must be enabled")
+                            clocks.per_ck().expect(
+                                concat!(stringify!($SAIX), " B: PER clock must be enabled")
+                            )
                         }
                         _ => unreachable!(),
                     }

--- a/src/sai/pdm.rs
+++ b/src/sai/pdm.rs
@@ -253,7 +253,10 @@ macro_rules! hal {
                     let ker_ck_a = $SAIX::sai_a_ker_ck(&prec, clocks);
                     let kernel_clock_divider: u8 = (ker_ck_a.0 / mclk_a_hz)
                         .try_into()
-                        .expect("$SAIX: Kernel clock is out of range for required MCLK");
+                        .expect(concat!(stringify!($SAIX),
+                                        ": Kernel clock is out of range for required MCLK"
+                        ));
+
 
                     // Configure SAI peripeheral
                     let mut s = Sai {

--- a/src/sai/pdm.rs
+++ b/src/sai/pdm.rs
@@ -250,11 +250,10 @@ macro_rules! hal {
                     let mclk_a_hz = sck_a_hz; // For NODIV = 1, SCK_a = MCLK_a
 
                     // Calculate divider
-                    let ker_ck_a =
-                        $SAIX::sai_a_ker_ck(&prec, clocks).expect("SAI kernel clock must run!");
+                    let ker_ck_a = $SAIX::sai_a_ker_ck(&prec, clocks);
                     let kernel_clock_divider: u8 = (ker_ck_a.0 / mclk_a_hz)
                         .try_into()
-                        .expect("SAI kernel clock is out of range for required MCLK");
+                        .expect("$SAIX: Kernel clock is out of range for required MCLK");
 
                     // Configure SAI peripeheral
                     let mut s = Sai {

--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -454,10 +454,14 @@ macro_rules! sdmmc {
 
                     let hclk = clocks.hclk();
                     let ker_ck = match prec.get_kernel_clk_mux() {
-                        rec::SdmmcClkSel::PLL1_Q => clocks.pll1_q_ck(),
-                        rec::SdmmcClkSel::PLL2_R => clocks.pll2_r_ck(),
-                    }
-                    .expect("sdmmc_ker_ck not running!");
+                        rec::SdmmcClkSel::PLL1_Q => {
+                            clocks.pll1_q_ck().expect("SDMMC: PLL1_Q must be enabled")
+                        }
+                        rec::SdmmcClkSel::PLL2_R => {
+                            clocks.pll2_r_ck().expect("SDMMC: PLL2_R must be enabled")
+                        }
+                    };
+
 
                     // For tuning the phase of the receive sampling clock, a
                     // DLYB block can be connected between sdmmc_io_in_ck and

--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -455,10 +455,14 @@ macro_rules! sdmmc {
                     let hclk = clocks.hclk();
                     let ker_ck = match prec.get_kernel_clk_mux() {
                         rec::SdmmcClkSel::PLL1_Q => {
-                            clocks.pll1_q_ck().expect("SDMMC: PLL1_Q must be enabled")
+                            clocks.pll1_q_ck().expect(
+                                concat!(stringify!($SDMMCX), ": PLL1_Q must be enabled")
+                            )
                         }
                         rec::SdmmcClkSel::PLL2_R => {
-                            clocks.pll2_r_ck().expect("SDMMC: PLL2_R must be enabled")
+                            clocks.pll2_r_ck().expect(
+                                concat!(stringify!($SDMMCX), ": PLL2_R must be enabled")
+                            )
                         }
                     };
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -514,10 +514,7 @@ macro_rules! usart {
                     prec.enable().reset();
 
                     // Get kernel clock
-	                let usart_ker_ck = match Self::kernel_clk(clocks) {
-                        Some(ker_hz) => ker_hz.0,
-                        _ => panic!("$USARTX kernel clock not running!")
-                    };
+	                let usart_ker_ck = Self::kernel_clk_unwrap(clocks).0;
 
                     // Prescaler not used for now
                     let usart_ker_ck_presc = usart_ker_ck;
@@ -954,7 +951,7 @@ macro_rules! usart_sel {
             impl Serial<$USARTX> {
                 /// Returns the frequency of the current kernel clock for
                 #[doc=$doc]
-                fn kernel_clk(clocks: &CoreClocks) -> Option<Hertz> {
+                pub fn kernel_clk(clocks: &CoreClocks) -> Option<Hertz> {
                     // unsafe: read only
                     let ccip = unsafe { (*stm32::RCC::ptr()).$ccip.read() };
 
@@ -964,6 +961,34 @@ macro_rules! usart_sel {
                         Some($SEL::PLL3_Q) => clocks.pll3_q_ck(),
                         Some($SEL::HSI_KER) => clocks.hsi_ck(),
                         Some($SEL::CSI_KER) => clocks.csi_ck(),
+                        Some($SEL::LSE) => unimplemented!(),
+                        _ => unreachable!(),
+                    }
+                }
+                /// Returns the frequency of the current kernel clock for
+                #[doc=$doc]
+                ///
+                /// # Panics
+                ///
+                /// Panics if the kernel clock is not running
+                pub fn kernel_clk_unwrap(clocks: &CoreClocks) -> Hertz {
+                    // unsafe: read only
+                    let ccip = unsafe { (*stm32::RCC::ptr()).$ccip.read() };
+
+                    match ccip.$sel().variant() {
+                        Some($SEL::$PCLK) => clocks.$pclk(),
+                        Some($SEL::PLL2_Q) => {
+                            clocks.pll2_q_ck().expect("$USARTX: PLL2_Q must be enabled")
+                        }
+                        Some($SEL::PLL3_Q) => {
+                            clocks.pll3_q_ck().expect("$USARTX: PLL3_Q must be enabled")
+                        }
+                        Some($SEL::HSI_KER) => {
+                            clocks.hsi_ck().expect("$USARTX: HSI clock must be enabled")
+                        }
+                        Some($SEL::CSI_KER) => {
+                            clocks.csi_ck().expect("$USARTX: CSI clock must be enabled")
+                        }
                         Some($SEL::LSE) => unimplemented!(),
                         _ => unreachable!(),
                     }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -978,16 +978,24 @@ macro_rules! usart_sel {
                     match ccip.$sel().variant() {
                         Some($SEL::$PCLK) => clocks.$pclk(),
                         Some($SEL::PLL2_Q) => {
-                            clocks.pll2_q_ck().expect("$USARTX: PLL2_Q must be enabled")
+                            clocks.pll2_q_ck().expect(
+                                concat!(stringify!($USARTX), ": PLL2_Q must be enabled")
+                            )
                         }
                         Some($SEL::PLL3_Q) => {
-                            clocks.pll3_q_ck().expect("$USARTX: PLL3_Q must be enabled")
+                            clocks.pll3_q_ck().expect(
+                                concat!(stringify!($USARTX), ": PLL3_Q must be enabled")
+                            )
                         }
                         Some($SEL::HSI_KER) => {
-                            clocks.hsi_ck().expect("$USARTX: HSI clock must be enabled")
+                            clocks.hsi_ck().expect(
+                                concat!(stringify!($USARTX), ": HSI clock must be enabled")
+                            )
                         }
                         Some($SEL::CSI_KER) => {
-                            clocks.csi_ck().expect("$USARTX: CSI clock must be enabled")
+                            clocks.csi_ck().expect(
+                                concat!(stringify!($USARTX), ": CSI clock must be enabled")
+                            )
                         }
                         Some($SEL::LSE) => unimplemented!(),
                         _ => unreachable!(),

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -300,7 +300,7 @@ macro_rules! hal {
                     prec.enable().reset();
 
                     let clk = $TIMX::get_clk(clocks)
-                        .expect("$TIMX: Input clock not running!").0;
+                        .expect(concat!(stringify!($TIMX), ": Input clock not running!")).0;
 
                     Timer {
                         clk,
@@ -591,7 +591,7 @@ macro_rules! lptim_hal {
                     prec.enable().reset();
 
                     let clk = $TIMX::get_clk(clocks)
-                        .expect("Timer input clock not running!").0;
+                        .expect(concat!(stringify!($TIMX), ": Input clock not running!")).0;
 
                     let mut timer = LpTimer {
                         clk,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -300,7 +300,7 @@ macro_rules! hal {
                     prec.enable().reset();
 
                     let clk = $TIMX::get_clk(clocks)
-                        .expect("Timer input clock not running!").0;
+                        .expect("$TIMX: Input clock not running!").0;
 
                     Timer {
                         clk,

--- a/src/xspi/mod.rs
+++ b/src/xspi/mod.rs
@@ -448,13 +448,19 @@ mod common {
                 match ccipr.$ccip().variant() {
                     ccipr::[< $ccip:upper _A >]::RCC_HCLK3 => clocks.hclk(),
                     ccipr::[< $ccip:upper _A >]::PLL1_Q => {
-                        clocks.pll1_q_ck().expect("$peripheral: PLL1_Q must be enabled")
+                        clocks.pll1_q_ck().expect(
+                            concat!(stringify!($peripheral), ": PLL1_Q must be enabled")
+                        )
                     }
                     ccipr::[< $ccip:upper _A >]::PLL2_R => {
-                        clocks.pll2_r_ck().expect("$peripheral: PLL2_R must be enabled")
+                        clocks.pll2_r_ck().expect(
+                            concat!(stringify!($peripheral), ": PLL2_R must be enabled")
+                        )
                     }
                     ccipr::[< $ccip:upper _A >]::PER => {
-                        clocks.per_ck().expect("$peripheral: PER clock must be enabled")
+                        clocks.per_ck().expect(
+                            concat!(stringify!($peripheral), ": PER clock must be enabled")
+                        )
                     }
                 }
             }

--- a/src/xspi/octospi.rs
+++ b/src/xspi/octospi.rs
@@ -435,10 +435,7 @@ macro_rules! octospi_impl {
                 // Disable OCTOSPI before configuring it.
                 regs.cr.write(|w| w.en().clear_bit());
 
-                let spi_kernel_ck = match Self::get_clock(clocks) {
-                    Some(freq_hz) => freq_hz.0,
-                    _ => panic!("OCTOSPI kernel clock not running!"),
-                };
+                let spi_kernel_ck = Self::kernel_clk_unwrap(clocks).0;
 
                 while regs.sr.read().busy().bit_is_set() {}
 

--- a/src/xspi/octospi.rs
+++ b/src/xspi/octospi.rs
@@ -530,10 +530,7 @@ macro_rules! octospi_impl {
                 // Disable OCTOSPI before configuring it.
                 regs.cr.write(|w| w.en().clear_bit());
 
-                let spi_kernel_ck = match Self::get_clock(clocks) {
-                    Some(freq_hz) => freq_hz.0,
-                    _ => panic!("OCTOSPI kernel clock not running!"),
-                };
+                let spi_kernel_ck = Self::kernel_clk_unwrap(clocks).0;
 
                 // Configure clock
                 let hyperbus: HyperbusConfig = hyperbus.into();

--- a/src/xspi/qspi.rs
+++ b/src/xspi/qspi.rs
@@ -204,10 +204,7 @@ impl Qspi<stm32::QUADSPI> {
         // Disable QUADSPI before configuring it.
         regs.cr.write(|w| w.en().clear_bit());
 
-        let spi_kernel_ck = match Self::get_clock(clocks) {
-            Some(freq_hz) => freq_hz.0,
-            _ => panic!("QSPI kernel clock not running!"),
-        };
+        let spi_kernel_ck = Self::kernel_clk_unwrap(clocks).0;
 
         while regs.sr.read().busy().bit_is_set() {}
 


### PR DESCRIPTION
* More helpful panic messages that name the consumer and the stopped clock
* Expose more of these methods in the public API
* Standardise around `kernel_clk`/`kernel_clk_unwrap` naming (excluding timers)
