### PR TITLE
Add optional support for printing some types with defmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - stm32h7b0
           - stm32h735
     env:                        # Peripheral Feature flags
-      FLAGS: rt,xspi,sdmmc,sdmmc-fatfs,fmc,usb_hs,rtc,ethernet,ltdc,crc,rand
+      FLAGS: rt,xspi,sdmmc,sdmmc-fatfs,fmc,usb_hs,rtc,ethernet,ltdc,crc,rand,defmt
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ targets = ["thumbv7em-none-eabihf"]
 embedded-hal = "0.2.6"
 embedded-dma = "0.1.2"
 cortex-m = "^0.7.1"
+defmt = { version = ">=0.2.0,<0.4", optional = true }
 stm32h7 = { version = "^0.14.0", default-features = false }
 void = { version = "1.0.2", default-features = false }
 cast = { version = "0.3.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ readme = "README.md"
 exclude = [".gitignore"]
 
 [package.metadata.docs.rs]
-features = ["stm32h743v", "rt", "xspi", "sdmmc", "fmc", "usb_hs", "rtc", "ethernet", "ltdc", "crc", "rand"]
+features = ["stm32h743v", "rt", "xspi", "sdmmc", "fmc", "usb_hs", "rtc", "ethernet", "ltdc", "crc", "rand", "defmt"]
 targets = ["thumbv7em-none-eabihf"]
 
 [dependencies]

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -88,6 +88,7 @@ pub struct Adc<ADC, ED> {
 //
 // Refer to RM0433 Rev 6 - Chapter 24.4.13
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[allow(non_camel_case_types)]
 pub enum AdcSampleTime {
     /// 1.5 cycles sampling time
@@ -134,6 +135,7 @@ impl From<AdcSampleTime> for u8 {
 ///
 /// Only values in range of 0..=15 are allowed.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdcLshift(u8);
 
 impl AdcLshift {
@@ -155,6 +157,7 @@ impl AdcLshift {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdcCalOffset(u16);
 
 impl AdcCalOffset {
@@ -164,6 +167,7 @@ impl AdcCalOffset {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdcCalLinear([u32; 6]);
 
 impl AdcCalLinear {
@@ -325,6 +329,29 @@ pub trait AdcExt<ADC>: Sized {
 /// Stored ADC config can be restored using the `Adc::restore_cfg` method
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct StoredConfig(AdcSampleTime, Resolution, AdcLshift);
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for StoredConfig {
+    fn format(&self, fmt: defmt::Formatter) {
+        use stm32h7::stm32h743v::adc3::cfgr::RES_A;
+        let res = match self.1 {
+            RES_A::SIXTEENBIT => defmt::intern!("SIXTEENBIT"),
+            RES_A::FOURTEENBIT => defmt::intern!("FOURTEENBIT"),
+            RES_A::FOURTEENBITV => defmt::intern!("FOURTEENBITV"),
+            RES_A::TWELVEBIT => defmt::intern!("TWELVEBIT"),
+            RES_A::TWELVEBITV => defmt::intern!("TWELVEBITV"),
+            RES_A::TENBIT => defmt::intern!("TENBIT"),
+            RES_A::EIGHTBIT => defmt::intern!("EIGHTBIT"),
+        };
+        defmt::write!(
+            fmt,
+            "StoredConfig({:?}, {=istr}, {:?})",
+            self.0,
+            res,
+            self.2
+        )
+    }
+}
 
 /// Get and check the adc_ker_ck_input
 fn check_clock(prec: &impl AdcClkSelGetter, clocks: &CoreClocks) -> Hertz {

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -333,21 +333,11 @@ pub struct StoredConfig(AdcSampleTime, Resolution, AdcLshift);
 #[cfg(feature = "defmt")]
 impl defmt::Format for StoredConfig {
     fn format(&self, fmt: defmt::Formatter) {
-        use stm32h7::stm32h743v::adc3::cfgr::RES_A;
-        let res = match self.1 {
-            RES_A::SIXTEENBIT => defmt::intern!("SIXTEENBIT"),
-            RES_A::FOURTEENBIT => defmt::intern!("FOURTEENBIT"),
-            RES_A::FOURTEENBITV => defmt::intern!("FOURTEENBITV"),
-            RES_A::TWELVEBIT => defmt::intern!("TWELVEBIT"),
-            RES_A::TWELVEBITV => defmt::intern!("TWELVEBITV"),
-            RES_A::TENBIT => defmt::intern!("TENBIT"),
-            RES_A::EIGHTBIT => defmt::intern!("EIGHTBIT"),
-        };
         defmt::write!(
             fmt,
-            "StoredConfig({:?}, {=istr}, {:?})",
+            "StoredConfig({:?}, {:?}, {:?})",
             self.0,
-            res,
+            defmt::Debug2Format(&self.1),
             self.2
         )
     }

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -161,6 +161,7 @@ mod macros {
 /// A polynomial being even means that the least significant bit is `0`
 /// in the polynomial's normal representation.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Polynomial(Poly);
 
 impl Polynomial {
@@ -252,6 +253,7 @@ impl Default for Polynomial {
 
 /// Errors generated when trying to create invalid polynomials.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PolynomialError {
     /// Tried to create an even polynomial.
     /// The hardware CRC unit only supports odd polynomials.
@@ -274,6 +276,7 @@ impl fmt::Display for PolynomialError {
 
 /// Internal representation of a polynomial.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum Poly {
     /// 7-bit polynomial
     B7(u8),
@@ -291,6 +294,7 @@ enum Poly {
 /// 'reflection' it most likely wants [`BitReversal::Byte`] and output reversal
 /// enabled.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum BitReversal {
     /// Each input byte has its bits reversed. `0x1A2B3C4D` becomes `0x58D43CB2`.
@@ -303,6 +307,7 @@ pub enum BitReversal {
 
 /// CRC unit configuration.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     poly: Polynomial,
     initial: u32,

--- a/src/dma/bdma.rs
+++ b/src/dma/bdma.rs
@@ -87,6 +87,7 @@ impl Instance for BDMA2 {
 
 /// BDMA interrupts
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BdmaInterrupts {
     transfer_complete: bool,
     transfer_error: bool,
@@ -95,6 +96,7 @@ pub struct BdmaInterrupts {
 
 /// Contains the complete set of configuration for a DMA stream.
 #[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BdmaConfig {
     pub(crate) priority: config::Priority,
     pub(crate) memory_increment: bool,

--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -73,6 +73,7 @@ impl Instance for DMA2 {
 
 /// DMA interrupts
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DmaInterrupts {
     transfer_complete: bool,
     transfer_error: bool,
@@ -83,6 +84,7 @@ pub struct DmaInterrupts {
 
 /// Contains configuration for a DMA stream
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DmaConfig {
     pub(crate) priority: config::Priority,
     pub(crate) memory_increment: bool,

--- a/src/dma/mdma.rs
+++ b/src/dma/mdma.rs
@@ -94,6 +94,7 @@ impl Instance for MDMA {
 
 /// MDMA Stream Transfer Requests
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MdmaTransferRequest {
     Dma1Tcif0 = 0,
     Dma1Tcif1,
@@ -161,6 +162,7 @@ pub enum MdmaTransferRequest {
 
 /// MDMA Source/Destination sizes
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MdmaSize {
     /// Byte (8-bit)
     Byte = 0,
@@ -206,6 +208,7 @@ impl MdmaSize {
 
 /// MDMA increment mode
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MdmaIncrement {
     Fixed,
     /// Increment by one source/destination element each element
@@ -262,9 +265,20 @@ impl fmt::Debug for MdmaBurstSize {
         }
     }
 }
+#[cfg(feature = "defmt")]
+impl defmt::Format for MdmaBurstSize {
+    fn format(&self, fmt: defmt::Formatter) {
+        if self.0 > 0 {
+            defmt::write!(fmt, "{=u32}", 1 << self.0);
+        } else {
+            defmt::intern!("single").format(fmt);
+        }
+    }
+}
 
 /// MDMA Packing/Alignment mode
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MdmaPackingAlignment {
     /// Source data is packed/unpacked into the destination data size
     Packed,
@@ -292,6 +306,7 @@ impl Default for MdmaPackingAlignment {
 
 /// MDMA trigger mode
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MdmaTrigger {
     /// Each MDMA request triggers a buffer transfer
     Buffer = 0b00,
@@ -310,6 +325,7 @@ impl Default for MdmaTrigger {
 
 /// MDMA interrupts
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MdmaInterrupts {
     transfer_complete: bool,
     transfer_error: bool,
@@ -320,6 +336,7 @@ pub struct MdmaInterrupts {
 
 /// Contains the complete set of configuration for a MDMA stream.
 #[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MdmaConfig {
     pub(crate) priority: config::Priority,
     pub(crate) destination_increment: MdmaIncrement,

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -117,6 +117,7 @@ use traits::{
 
 /// Errors.
 #[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DMAError {
     /// DMA not ready to change buffers.
     NotReady,
@@ -128,6 +129,7 @@ pub enum DMAError {
 
 /// Possible DMA's directions.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DmaDirection {
     /// Memory to Memory transfer.
     MemoryToMemory,
@@ -139,6 +141,7 @@ pub enum DmaDirection {
 
 /// DMA from a peripheral to a memory location.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PeripheralToMemory;
 
 impl Direction for PeripheralToMemory {
@@ -153,6 +156,7 @@ impl Direction for PeripheralToMemory {
 
 /// DMA from one memory location to another memory location.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MemoryToMemory<T> {
     _data: PhantomData<T>,
 }
@@ -169,6 +173,7 @@ impl<T> Direction for MemoryToMemory<T> {
 
 /// DMA from a memory location to a peripheral.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MemoryToPeripheral;
 
 impl Direction for MemoryToPeripheral {
@@ -203,6 +208,7 @@ unsafe impl TargetAddress<Self> for MemoryToMemory<u32> {
 
 /// How full the DMA stream's fifo is.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum FifoLevel {
     /// 0 < fifo_level < 1/4.
     GtZeroLtQuarter,
@@ -236,6 +242,7 @@ impl From<u8> for FifoLevel {
 
 /// Which DMA buffer is in use.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum CurrentBuffer {
     /// The first buffer (m0ar).
     Buffer0 = 0,
@@ -264,6 +271,7 @@ pub mod config {
     /// priority over the stream with the higher number. For example, Stream 2
     /// takes priority over Stream 4.
     #[derive(Debug, Clone, Copy)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum Priority {
         /// Low priority.
         Low,
@@ -293,6 +301,7 @@ pub mod config {
 
     /// The level to fill the fifo to before performing the transaction.
     #[derive(Debug, Clone, Copy)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum FifoThreshold {
         /// 1/4 full.
         QuarterFull,
@@ -318,6 +327,7 @@ pub mod config {
     /// How burst transfers are done, requires fifo enabled. Check datasheet for
     /// valid combinations.
     #[derive(Debug, Clone, Copy)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum BurstMode {
         /// Single transfer, no burst.
         NoBurst,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -54,6 +54,7 @@ pub enum Stop {
 
 /// I2C error
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {
     /// Bus error
@@ -96,6 +97,7 @@ where
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct I2c<I2C> {
     i2c: I2C,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 extern crate paste;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Never {}
 
 #[cfg(not(feature = "device-selected"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,10 @@
 //! * [Cyclic Redundancy Check (CRC)](crate::crc) Feature gate `crc`
 //! * [Random Number Generator](crate::rng) ([rand_core::RngCore](rand_core::RngCore) is implemented under the `rand` feature gate)
 //! * [System Window Watchdog](crate::watchdog)
+//!
+//! Cargo Features
+//!
+//! * [`defmt`](https://defmt.ferrous-systems.com/) formatting for some types can be enabled with the feature `defmt`.
 
 #![cfg_attr(not(test), no_std)]
 #![allow(non_camel_case_types)]

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -277,6 +277,7 @@ pub struct ActiveLow;
 
 /// Whether a PWM signal is left-aligned, right-aligned, or center-aligned
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Alignment {
     Left,
     Right,

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -14,6 +14,7 @@ use crate::stm32::RNG;
 use crate::time::Hertz;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ErrorKind {
     ClockError = 0,
     SeedError = 1,

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -62,6 +62,7 @@ pub enum RtcClock {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 /// An error preventing the RTC from initializing
 pub enum InitError {
     RtcNotRunning,
@@ -70,6 +71,7 @@ pub enum InitError {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DstError {
     ClockNotInitialized,
     AlreadyDst,

--- a/src/sai/i2s.rs
+++ b/src/sai/i2s.rs
@@ -105,6 +105,7 @@ pub enum I2SSync {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum I2SError {
     NoChannelAvailable,
 }

--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -213,8 +213,9 @@ pins! {
 
 /// The signalling scheme used on the SDMMC bus
 #[non_exhaustive]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[allow(missing_docs)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Signalling {
     SDR12,
     SDR25,
@@ -232,6 +233,7 @@ impl Default for Signalling {
 #[non_exhaustive]
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     Timeout,
     SoftwareTimeout,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -49,7 +49,8 @@ use crate::time::Hertz;
 use crate::Never;
 
 /// Serial error
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {
     /// Framing error
@@ -64,6 +65,7 @@ pub enum Error {
 
 /// Interrupt event
 #[derive(Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Event {
     /// New data has been received
     Rxne,
@@ -208,6 +210,7 @@ pub mod config {
     }
 
     #[derive(Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct InvalidConfig;
 
     impl Default for Config {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -99,6 +99,7 @@ use crate::time::Hertz;
 
 /// SPI error
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {
     /// Overrun occurred
@@ -262,6 +263,7 @@ pub struct HardwareCS {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum HardwareCSMode {
     /// Handling the CS is left for the user to do in software
     Disabled,

--- a/src/time.rs
+++ b/src/time.rs
@@ -6,30 +6,37 @@ use cortex_m::peripheral::DWT;
 
 /// Bits per second
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Bps(pub u32);
 
 /// Hertz
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Hertz(pub u32);
 
 /// KiloHertz
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct KiloHertz(pub u32);
 
 /// MegaHertz
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MegaHertz(pub u32);
 
 /// MilliSeconds
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MilliSeconds(pub u32);
 
 /// MicroSeconds
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MicroSeconds(pub u32);
 
 /// NanoSeconds
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct NanoSeconds(pub u32);
 
 impl fmt::Display for Bps {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -183,6 +183,7 @@ pub trait TimerExt<TIM> {
 
 /// Hardware timers
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Timer<TIM> {
     clk: u32,
     tim: TIM,

--- a/src/xspi/mod.rs
+++ b/src/xspi/mod.rs
@@ -146,6 +146,7 @@ mod common {
 
     /// Represents operation modes of the XSPI interface.
     #[derive(Debug, Copy, Clone, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum XspiMode {
         /// Only a single IO line (IO0) is used for transmit and a separate line
         /// (IO1) is used for receive.
@@ -175,6 +176,7 @@ mod common {
     }
     /// Indicates an error with the XSPI peripheral.
     #[derive(Debug, Copy, Clone, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum XspiError {
         Busy,
         Underflow,
@@ -186,6 +188,7 @@ mod common {
 
     /// Instruction, Address or Alternate Byte word used by the XSPI interface
     #[derive(Debug, Copy, Clone, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum XspiWord {
         None,
         U8(u8),
@@ -225,6 +228,7 @@ mod common {
 
     /// Sampling mode for the XSPI interface
     #[derive(Debug, Copy, Clone, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum SamplingEdge {
         Falling,
         Rising,
@@ -232,6 +236,7 @@ mod common {
 
     /// Interrupt events
     #[derive(Copy, Clone, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum Event {
         /// FIFO Threashold
         FIFOThreashold,
@@ -243,6 +248,7 @@ mod common {
 
     /// Indicates a specific QUADSPI bank to use
     #[derive(Debug, Copy, Clone, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[cfg(any(feature = "rm0433", feature = "rm0399"))]
     pub enum Bank {
         One,


### PR DESCRIPTION
> `defmt` ("de format", short for "deferred formatting") is a highly efficient logging framework that targets resource-constrained devices, like microcontrollers.

https://defmt.ferrous-systems.com/

I've been maintaining this support in my fork for some time, it hasn't been burdensome. defmt has become popular enough that I think it is worthwhile to upstream this. Supporting defmt formatting in this library makes it easier to print error messages (don't need to use `defmt::Debug2Format`) and eliminates the code bloat of the `core::fmt` machinery. We could similarly move `Debug` derives behind a feature flag to help people who are trying to eliminate `core::fmt`, but I don't particularly care.