### PR TITLE
remove release mode requirement from USB examples

### DIFF
--- a/examples/usb_passthrough.rs
+++ b/examples/usb_passthrough.rs
@@ -1,8 +1,6 @@
 //! Dual CDC-ACM serial port example using polling in a busy loop.
 //!
 //! Characters written to one serial port appear on both.
-//!
-//! Note: This example must be built in release mode to work reliably
 #![no_std]
 #![no_main]
 

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -1,6 +1,4 @@
 //! CDC-ACM serial port example using polling in a busy loop
-//!
-//! Note: This example must be built in release mode to work reliably
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
This was fixed in usb-device: https://github.com/mvirkkunen/usb-device/pull/41