### PR TITLE
Always enable the embedded-hal/unproven feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ targets = ["thumbv7em-none-eabihf"]
 
 [dependencies]
 fugit = "0.3.3"
-embedded-hal = "0.2.6"
+embedded-hal = { version = "0.2.6", features = ["unproven"] }
 embedded-dma = "0.1.2"
 cortex-m = "^0.7.4"
 defmt = { version = ">=0.2.0,<0.4", optional = true }
@@ -80,8 +80,7 @@ default-features = false
 features = ["medium-ethernet", "proto-ipv4", "proto-ipv6", "socket-raw"]
 
 [features]
-default = ["unproven", "rt"]
-unproven = ["embedded-hal/unproven"]
+default = ["rt"]
 device-selected = []
 revision_v = []
 rm0433 = []                     # aka. "single core" devices


### PR DESCRIPTION
The crate completely fails to build without this feature, remove it so that trying to build with --no-default-features gives a useful error message