### PR TITLE
RCC debug prints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ embedded-sdmmc = { version = "0.3", optional = true }
 stm32-fmc = { version = "0.2", optional = true }
 synopsys-usb-otg = { version = "^0.3.0", features = ["cortex-m"], optional = true }
 embedded-display-controller = { version = "^0.1.0", optional = true }
-log = { version = "0.4.14", optional = true}
+log = { version = "0.4.14", optional = true} # see also the dev-dependencies section
 
 [dependencies.smoltcp]
 version = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ embedded-sdmmc = { version = "0.3", optional = true }
 stm32-fmc = { version = "0.2", optional = true }
 synopsys-usb-otg = { version = "^0.3.0", features = ["cortex-m"], optional = true }
 embedded-display-controller = { version = "^0.1.0", optional = true }
+log = "0.4.14"
 
 [dependencies.smoltcp]
 version = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ readme = "README.md"
 exclude = [".gitignore"]
 
 [package.metadata.docs.rs]
-features = ["stm32h743v", "rt", "xspi", "sdmmc", "fmc", "usb_hs", "rtc", "ethernet", "ltdc", "crc", "rand", "defmt"]
+features = ["stm32h743v", "rt", "xspi", "sdmmc", "fmc", "usb_hs", "rtc", "ethernet", "ltdc", "crc", "rand", "defmt", "log"]
 targets = ["thumbv7em-none-eabihf"]
 
 [dependencies]
@@ -41,7 +41,7 @@ embedded-sdmmc = { version = "0.3", optional = true }
 stm32-fmc = { version = "0.2", optional = true }
 synopsys-usb-otg = { version = "^0.3.0", features = ["cortex-m"], optional = true }
 embedded-display-controller = { version = "^0.1.0", optional = true }
-log = "0.4.14"
+log = { version = "0.4.14", optional = true}
 
 [dependencies.smoltcp]
 version = "0.8.0"

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -974,9 +974,14 @@ impl Rcc {
         });
         while syscfg.cccsr.read().ready().bit_is_clear() {}
 
+        // This section prints the final register configuration for the main RCC registers:
+        // - System Clock and PLL Source MUX
+        // - PLL configuration
+        // - System Prescalers
+        // Does not include peripheral/MCO/RTC clock MUXes
         #[cfg(feature = "log")]
         {
-            debug!("--- RCC register settings (selection)");
+            debug!("--- RCC register settins");
 
             let cfgr = rcc.cfgr.read();
             debug!(
@@ -987,67 +992,70 @@ impl Rcc {
             let d1cfgr = rcc.d1cfgr.read();
             debug!(
                 "D1CFGR register ->   D1CPRE: {:?}  HPRE: {:?}  D1PPRE: {:?}",
-                d1cfgr.d1cpre().bits(),
-                d1cfgr.hpre().bits(),
-                d1cfgr.d1ppre().bits(),
+                d1cfgr.d1cpre().variant().unwrap(),
+                d1cfgr.hpre().variant().unwrap(),
+                d1cfgr.d1ppre().variant().unwrap(),
             );
 
             let d2cfgr = rcc.d2cfgr.read();
             debug!(
                 "D2CFGR register ->   D2PPRE1: {:?}  D2PPRE1: {:?}",
-                d2cfgr.d2ppre1().bits(),
-                d2cfgr.d2ppre2().bits(),
+                d2cfgr.d2ppre1().variant().unwrap(),
+                d2cfgr.d2ppre2().variant().unwrap(),
             );
 
             let d3cfgr = rcc.d3cfgr.read();
-            debug!("D3CFGR register ->   D3PPRE: {:?}", d3cfgr.d3ppre().bits(),);
+            debug!(
+                "D3CFGR register ->   D3PPRE: {:?}",
+                d3cfgr.d3ppre().variant().unwrap(),
+            );
 
             let pllckselr = rcc.pllckselr.read();
             debug!(
-            "PLLCKSELR register ->   PLLSRC: {:?}  DIVM1: {:?}  DIVM2: {:?}  DIVM3: {:?}",
-            pllckselr.pllsrc().variant(),
-            pllckselr.divm1().bits(),
-            pllckselr.divm2().bits(),
-            pllckselr.divm3().bits(),
-        );
+                "PLLCKSELR register ->   PLLSRC: {:?}  DIVM1: {:?}  DIVM2: {:?}  DIVM3: {:?}",
+                pllckselr.pllsrc().variant(),
+                pllckselr.divm1().bits(),
+                pllckselr.divm2().bits(),
+                pllckselr.divm3().bits(),
+            );
 
             let pllcfgr = rcc.pllcfgr.read();
             debug!(
-            "PLLCKSELR register (PLL1) ->   PLL1FRACEN: {:?}  PLL1VCOSEL: {:?}  PLL1RGE: {:?}  DIVP1EN: {:?}  DIVQ1EN: {:?}  DIVR1EN: {:?}",
-            pllcfgr.pll1fracen().variant(),
-            pllcfgr.pll1vcosel().variant(),
-            pllcfgr.pll1rge().variant(),
-            pllcfgr.divp1en().variant(),
-            pllcfgr.divq1en().variant(),
-            pllcfgr.divr1en().variant(),
-        );
+                "PLLCKSELR register (PLL1) ->   PLL1FRACEN: {:?}  PLL1VCOSEL: {:?}  PLL1RGE: {:?}  DIVP1EN: {:?}  DIVQ1EN: {:?}  DIVR1EN: {:?}",
+                pllcfgr.pll1fracen().variant(),
+                pllcfgr.pll1vcosel().variant(),
+                pllcfgr.pll1rge().variant(),
+                pllcfgr.divp1en().variant(),
+                pllcfgr.divq1en().variant(),
+                pllcfgr.divr1en().variant(),
+            );
             debug!(
-            "PLLCKSELR register (PLL2) ->   PLL2FRACEN: {:?}  PLL2VCOSEL: {:?}  PLL2RGE: {:?}  DIVP2EN: {:?}  DIVQ2EN: {:?}  DIVR2EN: {:?}",
-            pllcfgr.pll2fracen().variant(),
-            pllcfgr.pll2vcosel().variant(),
-            pllcfgr.pll2rge().variant(),
-            pllcfgr.divp2en().variant(),
-            pllcfgr.divq2en().variant(),
-            pllcfgr.divr2en().variant(),
-        );
+                "PLLCKSELR register (PLL2) ->   PLL2FRACEN: {:?}  PLL2VCOSEL: {:?}  PLL2RGE: {:?}  DIVP2EN: {:?}  DIVQ2EN: {:?}  DIVR2EN: {:?}",
+                pllcfgr.pll2fracen().variant(),
+                pllcfgr.pll2vcosel().variant(),
+                pllcfgr.pll2rge().variant(),
+                pllcfgr.divp2en().variant(),
+                pllcfgr.divq2en().variant(),
+                pllcfgr.divr2en().variant(),
+            );
             debug!(
-            "PLLCKSELR register (PLL3) ->   PLL3FRACEN: {:?}  PLL3VCOSEL: {:?}  PLL3RGE: {:?}  DIVP3EN: {:?}  DIVQ3EN: {:?}  DIVR3EN: {:?}",
-            pllcfgr.pll3fracen().variant(),
-            pllcfgr.pll3vcosel().variant(),
-            pllcfgr.pll3rge().variant(),
-            pllcfgr.divp3en().variant(),
-            pllcfgr.divq3en().variant(),
-            pllcfgr.divr3en().variant(),
-        );
+                "PLLCKSELR register (PLL3) ->   PLL3FRACEN: {:?}  PLL3VCOSEL: {:?}  PLL3RGE: {:?}  DIVP3EN: {:?}  DIVQ3EN: {:?}  DIVR3EN: {:?}",
+                pllcfgr.pll3fracen().variant(),
+                pllcfgr.pll3vcosel().variant(),
+                pllcfgr.pll3rge().variant(),
+                pllcfgr.divp3en().variant(),
+                pllcfgr.divq3en().variant(),
+                pllcfgr.divr3en().variant(),
+            );
 
             let pll1divr = rcc.pll1divr.read();
             debug!(
-            "PLL1DIVR register ->   DIVN1: {:?}  DIVP1: {:?}  DIVQ1: {:?}  DIVR1: {:?}",
-            pll1divr.divn1().bits(),
-            pll1divr.divp1().bits(),
-            pll1divr.divq1().bits(),
-            pll1divr.divr1().bits(),
-        );
+                "PLL1DIVR register ->   DIVN1: {:?}  DIVP1: {:?}  DIVQ1: {:?}  DIVR1: {:?}",
+                pll1divr.divn1().bits() + 1,
+                pll1divr.divp1().bits() + 1,
+                pll1divr.divq1().bits() + 1,
+                pll1divr.divr1().bits() + 1,
+            );
 
             let pll1fracr = rcc.pll1fracr.read();
             debug!(
@@ -1057,12 +1065,12 @@ impl Rcc {
 
             let pll2divr = rcc.pll2divr.read();
             debug!(
-            "PLL2DIVR register ->   DIVN2: {:?}  DIVP2: {:?}  DIVQ2: {:?}  DIVR2: {:?}",
-            pll2divr.divn2().bits(),
-            pll2divr.divp2().bits(),
-            pll2divr.divq2().bits(),
-            pll2divr.divr2().bits(),
-        );
+                "PLL2DIVR register ->   DIVN2: {:?}  DIVP2: {:?}  DIVQ2: {:?}  DIVR2: {:?}",
+                pll2divr.divn2().bits() + 1,
+                pll2divr.divp2().bits() + 1,
+                pll2divr.divq2().bits() + 1,
+                pll2divr.divr2().bits() + 1,
+            );
 
             let pll2fracr = rcc.pll2fracr.read();
             debug!(
@@ -1072,12 +1080,12 @@ impl Rcc {
 
             let pll3divr = rcc.pll3divr.read();
             debug!(
-            "PLL3DIVR register ->   DIVN3: {:?}  DIVP3: {:?}  DIVQ3: {:?}  DIVR3: {:?}",
-            pll3divr.divn3().bits(),
-            pll3divr.divp3().bits(),
-            pll3divr.divq3().bits(),
-            pll3divr.divr3().bits(),
-        );
+                "PLL3DIVR register ->   DIVN3: {:?}  DIVP3: {:?}  DIVQ3: {:?}  DIVR3: {:?}",
+                pll3divr.divn3().bits() + 1,
+                pll3divr.divp3().bits() + 1,
+                pll3divr.divq3().bits() + 1,
+                pll3divr.divr3().bits() + 1,
+            );
 
             let pll3fracr = rcc.pll3fracr.read();
             debug!(

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -985,13 +985,13 @@ impl Rcc {
 
             let cfgr = rcc.cfgr.read();
             debug!(
-                "CFGR register ->   SWS (System Clock Mux): {:?}",
+                "CFGR register: SWS (System Clock Mux)={:?}",
                 cfgr.sws().variant().unwrap()
             );
 
             let d1cfgr = rcc.d1cfgr.read();
             debug!(
-                "D1CFGR register ->   D1CPRE: {:?}  HPRE: {:?}  D1PPRE: {:?}",
+                "D1CFGR register: D1CPRE={:?} HPRE={:?} D1PPRE={:?}",
                 d1cfgr.d1cpre().variant().unwrap(),
                 d1cfgr.hpre().variant().unwrap(),
                 d1cfgr.d1ppre().variant().unwrap(),
@@ -999,20 +999,20 @@ impl Rcc {
 
             let d2cfgr = rcc.d2cfgr.read();
             debug!(
-                "D2CFGR register ->   D2PPRE1: {:?}  D2PPRE1: {:?}",
+                "D2CFGR register: D2PPRE1={:?} D2PPRE1={:?}",
                 d2cfgr.d2ppre1().variant().unwrap(),
                 d2cfgr.d2ppre2().variant().unwrap(),
             );
 
             let d3cfgr = rcc.d3cfgr.read();
             debug!(
-                "D3CFGR register ->   D3PPRE: {:?}",
+                "D3CFGR register: D3PPRE={:?}",
                 d3cfgr.d3ppre().variant().unwrap(),
             );
 
             let pllckselr = rcc.pllckselr.read();
             debug!(
-                "PLLCKSELR register ->   PLLSRC: {:?}  DIVM1: {:?}  DIVM2: {:?}  DIVM3: {:?}",
+                "PLLCKSELR register: PLLSRC={:?} DIVM1={:#x} DIVM2={:#x} DIVM3={:#x}",
                 pllckselr.pllsrc().variant(),
                 pllckselr.divm1().bits(),
                 pllckselr.divm2().bits(),
@@ -1021,7 +1021,7 @@ impl Rcc {
 
             let pllcfgr = rcc.pllcfgr.read();
             debug!(
-                "PLLCKSELR register (PLL1) ->   PLL1FRACEN: {:?}  PLL1VCOSEL: {:?}  PLL1RGE: {:?}  DIVP1EN: {:?}  DIVQ1EN: {:?}  DIVR1EN: {:?}",
+                "PLLCKSELR register (PLL1): PLL1FRACEN={:?} PLL1VCOSEL={:?} PLL1RGE={:?} DIVP1EN={:?} DIVQ1EN={:?} DIVR1EN={:?}",
                 pllcfgr.pll1fracen().variant(),
                 pllcfgr.pll1vcosel().variant(),
                 pllcfgr.pll1rge().variant(),
@@ -1030,7 +1030,7 @@ impl Rcc {
                 pllcfgr.divr1en().variant(),
             );
             debug!(
-                "PLLCKSELR register (PLL2) ->   PLL2FRACEN: {:?}  PLL2VCOSEL: {:?}  PLL2RGE: {:?}  DIVP2EN: {:?}  DIVQ2EN: {:?}  DIVR2EN: {:?}",
+                "PLLCKSELR register (PLL2): PLL2FRACEN={:?} PLL2VCOSEL={:?} PLL2RGE={:?} DIVP2EN={:?} DIVQ2EN={:?} DIVR2EN={:?}",
                 pllcfgr.pll2fracen().variant(),
                 pllcfgr.pll2vcosel().variant(),
                 pllcfgr.pll2rge().variant(),
@@ -1039,7 +1039,7 @@ impl Rcc {
                 pllcfgr.divr2en().variant(),
             );
             debug!(
-                "PLLCKSELR register (PLL3) ->   PLL3FRACEN: {:?}  PLL3VCOSEL: {:?}  PLL3RGE: {:?}  DIVP3EN: {:?}  DIVQ3EN: {:?}  DIVR3EN: {:?}",
+                "PLLCKSELR register (PLL3): PLL3FRACEN={:?} PLL3VCOSEL={:?} PLL3RGE={:?} DIVP3EN={:?} DIVQ3EN={:?} DIVR3EN={:?}",
                 pllcfgr.pll3fracen().variant(),
                 pllcfgr.pll3vcosel().variant(),
                 pllcfgr.pll3rge().variant(),
@@ -1050,46 +1050,46 @@ impl Rcc {
 
             let pll1divr = rcc.pll1divr.read();
             debug!(
-                "PLL1DIVR register ->   DIVN1: {:?}  DIVP1: {:?}  DIVQ1: {:?}  DIVR1: {:?}",
-                pll1divr.divn1().bits() + 1,
-                pll1divr.divp1().bits() + 1,
-                pll1divr.divq1().bits() + 1,
-                pll1divr.divr1().bits() + 1,
+                "PLL1DIVR register: DIVN1={:#x} DIVP1={:#x} DIVQ1={:#x} DIVR1={:#x}",
+                pll1divr.divn1().bits(),
+                pll1divr.divp1().bits(),
+                pll1divr.divq1().bits(),
+                pll1divr.divr1().bits(),
             );
 
             let pll1fracr = rcc.pll1fracr.read();
             debug!(
-                "PLL1FRACR register ->   FRACN1: {:?}",
+                "PLL1FRACR register: FRACN1={:#x}",
                 pll1fracr.fracn1().bits(),
             );
 
             let pll2divr = rcc.pll2divr.read();
             debug!(
-                "PLL2DIVR register ->   DIVN2: {:?}  DIVP2: {:?}  DIVQ2: {:?}  DIVR2: {:?}",
-                pll2divr.divn2().bits() + 1,
-                pll2divr.divp2().bits() + 1,
-                pll2divr.divq2().bits() + 1,
-                pll2divr.divr2().bits() + 1,
+                "PLL2DIVR register: DIVN2={:#x} DIVP2={:#x} DIVQ2={:#x} DIVR2={:#x}",
+                pll2divr.divn2().bits(),
+                pll2divr.divp2().bits(),
+                pll2divr.divq2().bits(),
+                pll2divr.divr2().bits(),
             );
 
             let pll2fracr = rcc.pll2fracr.read();
             debug!(
-                "PLL2FRACR register ->   FRACN2: {:?}",
+                "PLL2FRACR register: FRACN2={:#x}",
                 pll2fracr.fracn2().bits(),
             );
 
             let pll3divr = rcc.pll3divr.read();
             debug!(
-                "PLL3DIVR register ->   DIVN3: {:?}  DIVP3: {:?}  DIVQ3: {:?}  DIVR3: {:?}",
-                pll3divr.divn3().bits() + 1,
-                pll3divr.divp3().bits() + 1,
-                pll3divr.divq3().bits() + 1,
-                pll3divr.divr3().bits() + 1,
+                "PLL3DIVR register: DIVN3={:#x} DIVP3={:#x} DIVQ3={:#x} DIVR3={:#x}",
+                pll3divr.divn3().bits(),
+                pll3divr.divp3().bits(),
+                pll3divr.divq3().bits(),
+                pll3divr.divr3().bits(),
             );
 
             let pll3fracr = rcc.pll3fracr.read();
             debug!(
-                "PLL3FRACR register ->   FRACN3: {:?}",
+                "PLL3FRACR register: FRACN3={:#x}",
                 pll3fracr.fracn3().bits(),
             );
         }

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -981,7 +981,7 @@ impl Rcc {
         // Does not include peripheral/MCO/RTC clock MUXes
         #[cfg(feature = "log")]
         {
-            debug!("--- RCC register settins");
+            debug!("--- RCC register settings");
 
             let cfgr = rcc.cfgr.read();
             debug!(

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -150,6 +150,7 @@ use crate::stm32::rcc::cfgr::TIMPRE_A as TIMPRE;
 use crate::stm32::rcc::pllckselr::PLLSRC_A as PLLSRC;
 use crate::stm32::{RCC, SYSCFG};
 use crate::time::Hertz;
+use log::debug;
 
 #[cfg(feature = "rm0455")]
 use crate::stm32::rcc::cdcfgr1::HPRE_A as HPRE;
@@ -971,6 +972,10 @@ impl Rcc {
             w.en().set_bit().cs().clear_bit().hslv().clear_bit()
         });
         while syscfg.cccsr.read().ready().bit_is_clear() {}
+
+        debug!("--- RCC register settings");
+        debug!("PLLCFGR: {:#x}", rcc.pllcfgr.read().bits());
+
 
         // Return frozen clock configuration
         Ccdr {

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -150,12 +150,13 @@ use crate::stm32::rcc::cfgr::TIMPRE_A as TIMPRE;
 use crate::stm32::rcc::pllckselr::PLLSRC_A as PLLSRC;
 use crate::stm32::{RCC, SYSCFG};
 use crate::time::Hertz;
-use log::debug;
 
 #[cfg(feature = "rm0455")]
 use crate::stm32::rcc::cdcfgr1::HPRE_A as HPRE;
 #[cfg(not(feature = "rm0455"))]
 use crate::stm32::rcc::d1cfgr::HPRE_A as HPRE;
+#[cfg(feature = "log")]
+use log::debug;
 
 #[cfg(feature = "rm0455")]
 use crate::stm32::rcc::cdccipr::CKPERSEL_A as CKPERSEL;
@@ -973,34 +974,36 @@ impl Rcc {
         });
         while syscfg.cccsr.read().ready().bit_is_clear() {}
 
-        debug!("--- RCC register settings (selection)");
+        #[cfg(feature = "log")]
+        {
+            debug!("--- RCC register settings (selection)");
 
-        let cfgr = rcc.cfgr.read();
-        debug!(
-            "CFGR register ->   SWS (System Clock Mux): {:?}",
-            cfgr.sws().variant().unwrap()
-        );
+            let cfgr = rcc.cfgr.read();
+            debug!(
+                "CFGR register ->   SWS (System Clock Mux): {:?}",
+                cfgr.sws().variant().unwrap()
+            );
 
-        let d1cfgr = rcc.d1cfgr.read();
-        debug!(
-            "D1CFGR register ->   D1CPRE: {:?}  HPRE: {:?}  D1PPRE: {:?}",
-            d1cfgr.d1cpre().bits(),
-            d1cfgr.hpre().bits(),
-            d1cfgr.d1ppre().bits(),
-        );
+            let d1cfgr = rcc.d1cfgr.read();
+            debug!(
+                "D1CFGR register ->   D1CPRE: {:?}  HPRE: {:?}  D1PPRE: {:?}",
+                d1cfgr.d1cpre().bits(),
+                d1cfgr.hpre().bits(),
+                d1cfgr.d1ppre().bits(),
+            );
 
-        let d2cfgr = rcc.d2cfgr.read();
-        debug!(
-            "D2CFGR register ->   D2PPRE1: {:?}  D2PPRE1: {:?}",
-            d2cfgr.d2ppre1().bits(),
-            d2cfgr.d2ppre2().bits(),
-        );
+            let d2cfgr = rcc.d2cfgr.read();
+            debug!(
+                "D2CFGR register ->   D2PPRE1: {:?}  D2PPRE1: {:?}",
+                d2cfgr.d2ppre1().bits(),
+                d2cfgr.d2ppre2().bits(),
+            );
 
-        let d3cfgr = rcc.d3cfgr.read();
-        debug!("D3CFGR register ->   D3PPRE: {:?}", d3cfgr.d3ppre().bits(),);
+            let d3cfgr = rcc.d3cfgr.read();
+            debug!("D3CFGR register ->   D3PPRE: {:?}", d3cfgr.d3ppre().bits(),);
 
-        let pllckselr = rcc.pllckselr.read();
-        debug!(
+            let pllckselr = rcc.pllckselr.read();
+            debug!(
             "PLLCKSELR register ->   PLLSRC: {:?}  DIVM1: {:?}  DIVM2: {:?}  DIVM3: {:?}",
             pllckselr.pllsrc().variant(),
             pllckselr.divm1().bits(),
@@ -1008,8 +1011,8 @@ impl Rcc {
             pllckselr.divm3().bits(),
         );
 
-        let pllcfgr = rcc.pllcfgr.read();
-        debug!(
+            let pllcfgr = rcc.pllcfgr.read();
+            debug!(
             "PLLCKSELR register (PLL1) ->   PLL1FRACEN: {:?}  PLL1VCOSEL: {:?}  PLL1RGE: {:?}  DIVP1EN: {:?}  DIVQ1EN: {:?}  DIVR1EN: {:?}",
             pllcfgr.pll1fracen().variant(),
             pllcfgr.pll1vcosel().variant(),
@@ -1018,7 +1021,7 @@ impl Rcc {
             pllcfgr.divq1en().variant(),
             pllcfgr.divr1en().variant(),
         );
-        debug!(
+            debug!(
             "PLLCKSELR register (PLL2) ->   PLL2FRACEN: {:?}  PLL2VCOSEL: {:?}  PLL2RGE: {:?}  DIVP2EN: {:?}  DIVQ2EN: {:?}  DIVR2EN: {:?}",
             pllcfgr.pll2fracen().variant(),
             pllcfgr.pll2vcosel().variant(),
@@ -1027,7 +1030,7 @@ impl Rcc {
             pllcfgr.divq2en().variant(),
             pllcfgr.divr2en().variant(),
         );
-        debug!(
+            debug!(
             "PLLCKSELR register (PLL3) ->   PLL3FRACEN: {:?}  PLL3VCOSEL: {:?}  PLL3RGE: {:?}  DIVP3EN: {:?}  DIVQ3EN: {:?}  DIVR3EN: {:?}",
             pllcfgr.pll3fracen().variant(),
             pllcfgr.pll3vcosel().variant(),
@@ -1037,8 +1040,8 @@ impl Rcc {
             pllcfgr.divr3en().variant(),
         );
 
-        let pll1divr = rcc.pll1divr.read();
-        debug!(
+            let pll1divr = rcc.pll1divr.read();
+            debug!(
             "PLL1DIVR register ->   DIVN1: {:?}  DIVP1: {:?}  DIVQ1: {:?}  DIVR1: {:?}",
             pll1divr.divn1().bits(),
             pll1divr.divp1().bits(),
@@ -1046,14 +1049,14 @@ impl Rcc {
             pll1divr.divr1().bits(),
         );
 
-        let pll1fracr = rcc.pll1fracr.read();
-        debug!(
-            "PLL1FRACR register ->   FRACN1: {:?}",
-            pll1fracr.fracn1().bits(),
-        );
+            let pll1fracr = rcc.pll1fracr.read();
+            debug!(
+                "PLL1FRACR register ->   FRACN1: {:?}",
+                pll1fracr.fracn1().bits(),
+            );
 
-        let pll2divr = rcc.pll2divr.read();
-        debug!(
+            let pll2divr = rcc.pll2divr.read();
+            debug!(
             "PLL2DIVR register ->   DIVN2: {:?}  DIVP2: {:?}  DIVQ2: {:?}  DIVR2: {:?}",
             pll2divr.divn2().bits(),
             pll2divr.divp2().bits(),
@@ -1061,14 +1064,14 @@ impl Rcc {
             pll2divr.divr2().bits(),
         );
 
-        let pll2fracr = rcc.pll2fracr.read();
-        debug!(
-            "PLL2FRACR register ->   FRACN2: {:?}",
-            pll2fracr.fracn2().bits(),
-        );
+            let pll2fracr = rcc.pll2fracr.read();
+            debug!(
+                "PLL2FRACR register ->   FRACN2: {:?}",
+                pll2fracr.fracn2().bits(),
+            );
 
-        let pll3divr = rcc.pll3divr.read();
-        debug!(
+            let pll3divr = rcc.pll3divr.read();
+            debug!(
             "PLL3DIVR register ->   DIVN3: {:?}  DIVP3: {:?}  DIVQ3: {:?}  DIVR3: {:?}",
             pll3divr.divn3().bits(),
             pll3divr.divp3().bits(),
@@ -1076,11 +1079,12 @@ impl Rcc {
             pll3divr.divr3().bits(),
         );
 
-        let pll3fracr = rcc.pll3fracr.read();
-        debug!(
-            "PLL3FRACR register ->   FRACN3: {:?}",
-            pll3fracr.fracn3().bits(),
-        );
+            let pll3fracr = rcc.pll3fracr.read();
+            debug!(
+                "PLL3FRACR register ->   FRACN3: {:?}",
+                pll3fracr.fracn3().bits(),
+            );
+        }
 
         // Return frozen clock configuration
         Ccdr {

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -973,9 +973,114 @@ impl Rcc {
         });
         while syscfg.cccsr.read().ready().bit_is_clear() {}
 
-        debug!("--- RCC register settings");
-        debug!("PLLCFGR: {:#x}", rcc.pllcfgr.read().bits());
+        debug!("--- RCC register settings (selection)");
 
+        let cfgr = rcc.cfgr.read();
+        debug!(
+            "CFGR register ->   SWS (System Clock Mux): {:?}",
+            cfgr.sws().variant().unwrap()
+        );
+
+        let d1cfgr = rcc.d1cfgr.read();
+        debug!(
+            "D1CFGR register ->   D1CPRE: {:?}  HPRE: {:?}  D1PPRE: {:?}",
+            d1cfgr.d1cpre().bits(),
+            d1cfgr.hpre().bits(),
+            d1cfgr.d1ppre().bits(),
+        );
+
+        let d2cfgr = rcc.d2cfgr.read();
+        debug!(
+            "D2CFGR register ->   D2PPRE1: {:?}  D2PPRE1: {:?}",
+            d2cfgr.d2ppre1().bits(),
+            d2cfgr.d2ppre2().bits(),
+        );
+
+        let d3cfgr = rcc.d3cfgr.read();
+        debug!("D3CFGR register ->   D3PPRE: {:?}", d3cfgr.d3ppre().bits(),);
+
+        let pllckselr = rcc.pllckselr.read();
+        debug!(
+            "PLLCKSELR register ->   PLLSRC: {:?}  DIVM1: {:?}  DIVM2: {:?}  DIVM3: {:?}",
+            pllckselr.pllsrc().variant(),
+            pllckselr.divm1().bits(),
+            pllckselr.divm2().bits(),
+            pllckselr.divm3().bits(),
+        );
+
+        let pllcfgr = rcc.pllcfgr.read();
+        debug!(
+            "PLLCKSELR register (PLL1) ->   PLL1FRACEN: {:?}  PLL1VCOSEL: {:?}  PLL1RGE: {:?}  DIVP1EN: {:?}  DIVQ1EN: {:?}  DIVR1EN: {:?}",
+            pllcfgr.pll1fracen().variant(),
+            pllcfgr.pll1vcosel().variant(),
+            pllcfgr.pll1rge().variant(),
+            pllcfgr.divp1en().variant(),
+            pllcfgr.divq1en().variant(),
+            pllcfgr.divr1en().variant(),
+        );
+        debug!(
+            "PLLCKSELR register (PLL2) ->   PLL2FRACEN: {:?}  PLL2VCOSEL: {:?}  PLL2RGE: {:?}  DIVP2EN: {:?}  DIVQ2EN: {:?}  DIVR2EN: {:?}",
+            pllcfgr.pll2fracen().variant(),
+            pllcfgr.pll2vcosel().variant(),
+            pllcfgr.pll2rge().variant(),
+            pllcfgr.divp2en().variant(),
+            pllcfgr.divq2en().variant(),
+            pllcfgr.divr2en().variant(),
+        );
+        debug!(
+            "PLLCKSELR register (PLL3) ->   PLL3FRACEN: {:?}  PLL3VCOSEL: {:?}  PLL3RGE: {:?}  DIVP3EN: {:?}  DIVQ3EN: {:?}  DIVR3EN: {:?}",
+            pllcfgr.pll3fracen().variant(),
+            pllcfgr.pll3vcosel().variant(),
+            pllcfgr.pll3rge().variant(),
+            pllcfgr.divp3en().variant(),
+            pllcfgr.divq3en().variant(),
+            pllcfgr.divr3en().variant(),
+        );
+
+        let pll1divr = rcc.pll1divr.read();
+        debug!(
+            "PLL1DIVR register ->   DIVN1: {:?}  DIVP1: {:?}  DIVQ1: {:?}  DIVR1: {:?}",
+            pll1divr.divn1().bits(),
+            pll1divr.divp1().bits(),
+            pll1divr.divq1().bits(),
+            pll1divr.divr1().bits(),
+        );
+
+        let pll1fracr = rcc.pll1fracr.read();
+        debug!(
+            "PLL1FRACR register ->   FRACN1: {:?}",
+            pll1fracr.fracn1().bits(),
+        );
+
+        let pll2divr = rcc.pll2divr.read();
+        debug!(
+            "PLL2DIVR register ->   DIVN2: {:?}  DIVP2: {:?}  DIVQ2: {:?}  DIVR2: {:?}",
+            pll2divr.divn2().bits(),
+            pll2divr.divp2().bits(),
+            pll2divr.divq2().bits(),
+            pll2divr.divr2().bits(),
+        );
+
+        let pll2fracr = rcc.pll2fracr.read();
+        debug!(
+            "PLL2FRACR register ->   FRACN2: {:?}",
+            pll2fracr.fracn2().bits(),
+        );
+
+        let pll3divr = rcc.pll3divr.read();
+        debug!(
+            "PLL3DIVR register ->   DIVN3: {:?}  DIVP3: {:?}  DIVQ3: {:?}  DIVR3: {:?}",
+            pll3divr.divn3().bits(),
+            pll3divr.divp3().bits(),
+            pll3divr.divq3().bits(),
+            pll3divr.divr3().bits(),
+        );
+
+        let pll3fracr = rcc.pll3fracr.read();
+        debug!(
+            "PLL3FRACR register ->   FRACN3: {:?}",
+            pll3fracr.fracn3().bits(),
+        );
 
         // Return frozen clock configuration
         Ccdr {


### PR DESCRIPTION
I'm thinking about how to implement RCC debug prints https://github.com/stm32-rs/stm32h7xx-hal/issues/314 in the cleanest fashion. 

There is a lot going on in the RCC setup and a complete feedback about all the exact register settings is a substantial amount of information that is not easily made human readable. 
I think what would make sense is to give feedback corresponding to the Clock Configuration in CubeMX:
![Screenshot from 2022-02-16 12-36-19](https://user-images.githubusercontent.com/17088194/154256988-7b1cbf24-2b81-46b8-a087-e5388fb11f0c.png)
That would be all the MUX settings, prescalers, dividers and the PLL-frac.

I could have one compact codeblock at the end of the freeze function where I read the necessary registers again and give the formatted debug info (currently its just printing raw reg bits). 
https://github.com/stm32-rs/stm32h7xx-hal/blob/d924165915c74f34e8b1610934afc20e133b10e5/src/rcc/mod.rs#L976-L977

The other option would be to sprinkle in the debug statements within the macros that setup PLLs etc. This would not necessitate reading the registers again but the code would be less clean.

Lastly I want to ask if using the log crate like this is OK or if we would rather use [defmt](https://crates.io/crates/defmt)? 