### PR TITLE
Add #[must_use] annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 * spi: add DuplexFailed error
 * spi: Fix arithmetic error in spi divider calculation
+* qei: Include REC in the `free()` method
 
 ## [v0.11.0] 2021-12-18
 

--- a/examples/prec_kernel_clocks.rs
+++ b/examples/prec_kernel_clocks.rs
@@ -11,7 +11,7 @@ use stm32h7xx_hal::{pac, prelude::*};
 
 fn enable_fdcan(rec: rec::Fdcan) {
     // Enable and set individual kernel clock to PLL1 Q CK
-    rec.enable().kernel_clk_mux(rec::FdcanClkSel::PLL1_Q);
+    let _ = rec.enable().kernel_clk_mux(rec::FdcanClkSel::PLL1_Q);
 
     // rec is dropped here, and can never be changed again
 }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -389,7 +389,7 @@ pub fn adc12(
     adc2.power_down();
 
     // Reset peripheral
-    prec.reset();
+    let _ = prec.reset(); // drop, can be recreated by free method
 
     // Power Up, Preconfigure and Calibrate
     adc1.power_up(delay);
@@ -475,7 +475,7 @@ macro_rules! adc_hal {
                     adc.power_down();
 
                     // Reset peripheral
-                    prec.reset();
+                    let _ = prec.reset(); // drop, can be recreated by free method
 
                     // Power Up, Preconfigure and Calibrate
                     adc.power_up(delay);

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -72,7 +72,7 @@ where
     PINS: Pins<DAC>,
 {
     // Enable DAC clocks and reset
-    prec.enable().reset();
+    let _ = prec.enable().reset(); // drop, can be recreated by free method
 
     #[allow(clippy::uninit_assumed_init)]
     unsafe {

--- a/src/dma/bdma.rs
+++ b/src/dma/bdma.rs
@@ -237,7 +237,7 @@ pub struct StreamsTuple<T>(
 impl<I: Instance> StreamsTuple<I> {
     /// Splits the DMA peripheral into streams.
     pub fn new(_regs: I, prec: I::Rec) -> Self {
-        prec.enable().reset();
+        let _ = prec.enable().reset(); // drop
         Self(
             Stream0 { _dma: PhantomData },
             Stream1 { _dma: PhantomData },

--- a/src/dma/bdma.rs
+++ b/src/dma/bdma.rs
@@ -122,24 +122,28 @@ impl DoubleBufferedConfig for BdmaConfig {
 impl BdmaConfig {
     /// Set the priority.
     #[inline(always)]
+    #[must_use]
     pub fn priority(mut self, priority: config::Priority) -> Self {
         self.priority = priority;
         self
     }
     /// Set the memory_increment.
     #[inline(always)]
+    #[must_use]
     pub fn memory_increment(mut self, memory_increment: bool) -> Self {
         self.memory_increment = memory_increment;
         self
     }
     /// Set the peripheral_increment.
     #[inline(always)]
+    #[must_use]
     pub fn peripheral_increment(mut self, peripheral_increment: bool) -> Self {
         self.peripheral_increment = peripheral_increment;
         self
     }
     /// Set the transfer_complete_interrupt.
     #[inline(always)]
+    #[must_use]
     pub fn transfer_complete_interrupt(
         mut self,
         transfer_complete_interrupt: bool,
@@ -149,6 +153,7 @@ impl BdmaConfig {
     }
     /// Set the half_transfer_interrupt.
     #[inline(always)]
+    #[must_use]
     pub fn half_transfer_interrupt(
         mut self,
         half_transfer_interrupt: bool,
@@ -158,6 +163,7 @@ impl BdmaConfig {
     }
     /// Set the transfer_error_interrupt.
     #[inline(always)]
+    #[must_use]
     pub fn transfer_error_interrupt(
         mut self,
         transfer_error_interrupt: bool,
@@ -167,6 +173,7 @@ impl BdmaConfig {
     }
     /// Set the double_buffer.
     #[inline(always)]
+    #[must_use]
     pub fn double_buffer(mut self, double_buffer: bool) -> Self {
         self.double_buffer = double_buffer;
         self

--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -138,6 +138,7 @@ impl DoubleBufferedConfig for DmaConfig {
 impl DmaConfig {
     /// Set the priority.
     #[inline(always)]
+    #[must_use]
     pub fn priority(mut self, priority: config::Priority) -> Self {
         self.priority = priority;
         self
@@ -145,18 +146,21 @@ impl DmaConfig {
 
     /// Set the memory_increment.
     #[inline(always)]
+    #[must_use]
     pub fn memory_increment(mut self, memory_increment: bool) -> Self {
         self.memory_increment = memory_increment;
         self
     }
     /// Set the peripheral_increment.
     #[inline(always)]
+    #[must_use]
     pub fn peripheral_increment(mut self, peripheral_increment: bool) -> Self {
         self.peripheral_increment = peripheral_increment;
         self
     }
     /// Set the transfer_complete_interrupt.
     #[inline(always)]
+    #[must_use]
     pub fn transfer_complete_interrupt(
         mut self,
         transfer_complete_interrupt: bool,
@@ -166,6 +170,7 @@ impl DmaConfig {
     }
     /// Set the half_transfer_interrupt.
     #[inline(always)]
+    #[must_use]
     pub fn half_transfer_interrupt(
         mut self,
         half_transfer_interrupt: bool,
@@ -175,6 +180,7 @@ impl DmaConfig {
     }
     /// Set the transfer_error_interrupt.
     #[inline(always)]
+    #[must_use]
     pub fn transfer_error_interrupt(
         mut self,
         transfer_error_interrupt: bool,
@@ -184,6 +190,7 @@ impl DmaConfig {
     }
     /// Set the direct_mode_error_interrupt.
     #[inline(always)]
+    #[must_use]
     pub fn direct_mode_error_interrupt(
         mut self,
         direct_mode_error_interrupt: bool,
@@ -193,24 +200,28 @@ impl DmaConfig {
     }
     /// Set the fifo_error_interrupt.
     #[inline(always)]
+    #[must_use]
     pub fn fifo_error_interrupt(mut self, fifo_error_interrupt: bool) -> Self {
         self.fifo_error_interrupt = fifo_error_interrupt;
         self
     }
     /// Set the circular_buffer.
     #[inline(always)]
+    #[must_use]
     pub fn circular_buffer(mut self, circular_buffer: bool) -> Self {
         self.circular_buffer = circular_buffer;
         self
     }
     /// Set the double_buffer.
     #[inline(always)]
+    #[must_use]
     pub fn double_buffer(mut self, double_buffer: bool) -> Self {
         self.double_buffer = double_buffer;
         self
     }
     /// Set the fifo_threshold.
     #[inline(always)]
+    #[must_use]
     pub fn fifo_threshold(
         mut self,
         fifo_threshold: config::FifoThreshold,
@@ -220,18 +231,21 @@ impl DmaConfig {
     }
     /// Set the fifo_enable.
     #[inline(always)]
+    #[must_use]
     pub fn fifo_enable(mut self, fifo_enable: bool) -> Self {
         self.fifo_enable = fifo_enable;
         self
     }
     /// Set the memory_burst.
     #[inline(always)]
+    #[must_use]
     pub fn memory_burst(mut self, memory_burst: config::BurstMode) -> Self {
         self.memory_burst = memory_burst;
         self
     }
     /// Set the peripheral_burst.
     #[inline(always)]
+    #[must_use]
     pub fn peripheral_burst(
         mut self,
         peripheral_burst: config::BurstMode,

--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -317,7 +317,7 @@ impl<I: Instance> StreamsTuple<I> {
     /// the other DMA2/1 if is has transfers are enabled. See
     /// <https://github.com/stm32-rs/stm32h7xx-hal/issues/228>
     pub fn new(_regs: I, prec: I::Rec) -> Self {
-        prec.enable();
+        let _ = prec.enable(); // drop
         Self(
             Stream0 { _dma: PhantomData },
             Stream1 { _dma: PhantomData },

--- a/src/dma/mdma.rs
+++ b/src/dma/mdma.rs
@@ -360,12 +360,14 @@ pub struct MdmaConfig {
 impl MdmaConfig {
     /// Set the priority
     #[inline(always)]
+    #[must_use]
     pub fn priority(mut self, priority: config::Priority) -> Self {
         self.priority = priority;
         self
     }
     /// Set the destination increment
     #[inline(always)]
+    #[must_use]
     pub fn destination_increment(
         mut self,
         destination_increment: MdmaIncrement,
@@ -375,12 +377,14 @@ impl MdmaConfig {
     }
     /// Set the source increment
     #[inline(always)]
+    #[must_use]
     pub fn source_increment(mut self, source_increment: MdmaIncrement) -> Self {
         self.source_increment = source_increment;
         self
     }
     /// Set the destination burst size
     #[inline(always)]
+    #[must_use]
     pub fn destination_burst_size(
         mut self,
         destination_burst_size: impl Into<MdmaBurstSize>,
@@ -390,6 +394,7 @@ impl MdmaConfig {
     }
     /// Set the source burst size
     #[inline(always)]
+    #[must_use]
     pub fn source_burst_size(
         mut self,
         source_burst_size: impl Into<MdmaBurstSize>,
@@ -400,6 +405,7 @@ impl MdmaConfig {
     /// Sets a hardware transfer request line. Unlike DMA1/DMA2, it is valid to
     /// use the same hardware transfer request line for multiple streams
     #[inline(always)]
+    #[must_use]
     pub fn hardware_transfer_request(
         mut self,
         transfer_request: MdmaTransferRequest,
@@ -409,6 +415,7 @@ impl MdmaConfig {
     }
     /// Sets a software-triggered transfer request line. This is the default
     #[inline(always)]
+    #[must_use]
     pub fn software_transfer_request(mut self) -> Self {
         self.transfer_request = None;
         self
@@ -416,6 +423,7 @@ impl MdmaConfig {
     /// Sets the trigger mode. If the trigger mode is `Buffer`, then the MDMA
     /// must be repeatedly triggered to complete a block transfer.
     #[inline(always)]
+    #[must_use]
     pub fn trigger_mode(mut self, trigger: MdmaTrigger) -> Self {
         self.trigger_mode = trigger;
         self
@@ -434,6 +442,7 @@ impl MdmaConfig {
     /// If the number of bytes in the block is not a multiple of the buffer
     /// length, then the final buffer will be shorter than the others.
     #[inline(always)]
+    #[must_use]
     pub fn buffer_length(mut self, bytes: u8) -> Self {
         debug_assert!(
             bytes <= 128,
@@ -446,6 +455,7 @@ impl MdmaConfig {
     /// Set the MDMA packing and alignment. When the source and destination have
     /// the same storage type, this has no effect
     #[inline(always)]
+    #[must_use]
     pub fn packing_alignment(mut self, packing: MdmaPackingAlignment) -> Self {
         self.packing_alignment = packing;
         self
@@ -453,6 +463,7 @@ impl MdmaConfig {
     /// Set word endianness exchange. Applies when the destination is
     /// 64-bit. Otherwise don't care
     #[inline(always)]
+    #[must_use]
     pub fn word_endianness_exchange(mut self, exchange: bool) -> Self {
         self.word_endianness_exchange = exchange;
         self
@@ -460,6 +471,7 @@ impl MdmaConfig {
     /// Set half word endianness exchange. Applies when the destination is a
     /// 64,32-bit. Otherwise don't care
     #[inline(always)]
+    #[must_use]
     pub fn half_word_endianness_exchange(mut self, exchange: bool) -> Self {
         self.half_word_endianness_exchange = exchange;
         self
@@ -467,12 +479,14 @@ impl MdmaConfig {
     /// Set byte endianness exchange. Applies when the destination is
     /// 64,32,16-bit. Otherwise don't care
     #[inline(always)]
+    #[must_use]
     pub fn byte_endianness_exchange(mut self, exchange: bool) -> Self {
         self.byte_endianness_exchange = exchange;
         self
     }
     /// Set the transfer_complete_interrupt
     #[inline(always)]
+    #[must_use]
     pub fn transfer_complete_interrupt(
         mut self,
         transfer_complete_interrupt: bool,
@@ -482,6 +496,7 @@ impl MdmaConfig {
     }
     /// Set the transfer_error_interrupt
     #[inline(always)]
+    #[must_use]
     pub fn transfer_error_interrupt(
         mut self,
         transfer_error_interrupt: bool,
@@ -491,6 +506,7 @@ impl MdmaConfig {
     }
     /// Set the buffer_transfer_complete_interrupt
     #[inline(always)]
+    #[must_use]
     pub fn buffer_transfer_complete_interrupt(
         mut self,
         buffer_transfer_complete_interrupt: bool,
@@ -501,6 +517,7 @@ impl MdmaConfig {
     }
     /// Set the block_transfer_complete_interrupt
     #[inline(always)]
+    #[must_use]
     pub fn block_transfer_complete_interrupt(
         mut self,
         block_transfer_complete_interrupt: bool,
@@ -511,6 +528,7 @@ impl MdmaConfig {
     }
     /// Set the block_repeat_transfer_complete_interrupt
     #[inline(always)]
+    #[must_use]
     pub fn block_repeat_transfer_complete_interrupt(
         mut self,
         block_repeat_transfer_complete_interrupt: bool,

--- a/src/dma/mdma.rs
+++ b/src/dma/mdma.rs
@@ -644,7 +644,7 @@ pub struct StreamsTuple<T>(
 impl<I: Instance> StreamsTuple<I> {
     /// Splits the DMA peripheral into streams.
     pub fn new(_regs: I, prec: I::Rec) -> Self {
-        prec.enable().reset();
+        let _ = prec.enable().reset(); // drop
         Self(
             Stream0 { _dma: PhantomData },
             Stream1 { _dma: PhantomData },

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -286,7 +286,7 @@ macro_rules! i2c {
                 ) -> Self where
                     F: Into<Hertz>,
                 {
-                    prec.enable().reset();
+                    let _ = prec.enable().reset(); // drop, can be recreated by free method
 
                     let freq: u32 = frequency.into().0;
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1195,6 +1195,7 @@ macro_rules! tim_hal {
 
                 /// Set the PWM frequency; will overwrite the previous prescaler and period
                 /// The requested frequency will be rounded to the nearest achievable frequency; the actual frequency may be higher or lower than requested.
+                #[must_use]
                 pub fn frequency<T: Into<Hertz>>(mut self, freq: T) -> Self {
                     self.count = CountSettings::Frequency( freq.into() );
 
@@ -1202,6 +1203,7 @@ macro_rules! tim_hal {
                 }
 
                 /// Set the prescaler; PWM count runs at base_frequency/(prescaler+1)
+                #[must_use]
                 pub fn prescaler(mut self, prescaler: u16) -> Self {
                     let period = match self.count {
                         CountSettings::Frequency(_) => 65535,
@@ -1214,6 +1216,7 @@ macro_rules! tim_hal {
                 }
 
                 /// Set the period; PWM count runs from 0 to period, repeating every (period+1) counts
+                #[must_use]
                 pub fn period(mut self, period: $typ) -> Self {
                     let prescaler = match self.count {
                         CountSettings::Frequency(_) => 0,
@@ -1229,6 +1232,7 @@ macro_rules! tim_hal {
                 // Timers with complementary and deadtime and faults
                 $(
                     /// Set the deadtime for complementary PWM channels of this timer
+                    #[must_use]
                     pub fn with_deadtime<T: Into<NanoSeconds>>(mut self, deadtime: T) -> Self {
                         // $bdtr is an Ident that only exists for timers with deadtime, so we can use it as a variable name to
                         // only implement this method for timers that support deadtime.
@@ -1240,7 +1244,8 @@ macro_rules! tim_hal {
                     }
                 )*
 
-                pub fn left_aligned( mut self ) -> Self {
+                #[must_use]
+                pub fn left_aligned(mut self) -> Self {
                     self.alignment = Alignment::Left;
 
                     self
@@ -1248,7 +1253,8 @@ macro_rules! tim_hal {
 
                 // Timers with advanced counting options, including center aligned and right aligned PWM
                 $(
-                    pub fn center_aligned( mut self ) -> Self {
+                    #[must_use]
+                    pub fn center_aligned(mut self) -> Self {
                         // $cms is an Ident that only exists for timers with center/right aligned PWM, so we can use it as a variable name to
                         // only implement this method for timers that support center/right aligned PWM.
                         let $cms = Alignment::Center;
@@ -1258,7 +1264,8 @@ macro_rules! tim_hal {
                         self
                     }
 
-                    pub fn right_aligned( mut self ) -> Self {
+                    #[must_use]
+                    pub fn right_aligned(mut self) -> Self {
                         self.alignment = Alignment::Right;
 
                         self

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1026,7 +1026,7 @@ macro_rules! tim_hal {
             where
                 PINS: Pins<$TIMX, T, U>,
             {
-                prec.enable().reset();
+                let _ = prec.enable().reset(); // drop
 
                 let clk = $TIMX::get_clk(clocks)
                     .expect(concat!(stringify!($TIMX), ": Input clock not running!"));
@@ -1070,7 +1070,7 @@ macro_rules! tim_hal {
                 where
                     PINS: Pins<Self, CHANNEL, COMP>
                 {
-                    prec.enable().reset();
+                    let _ = prec.enable().reset(); // drop
 
                     let clk = $TIMX::get_clk(clocks)
                         .expect(concat!(stringify!($TIMX), ": Input clock not running!"))
@@ -1627,7 +1627,7 @@ macro_rules! lptim_hal {
             where
                 PINS: Pins<$TIMX, T, U>,
             {
-                prec.enable().reset();
+                let _ = prec.enable().reset(); // drop
 
                 let clk = $TIMX::get_clk(clocks)
                     .expect(concat!(stringify!($TIMX), ": Input clock not running!"))

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -173,6 +173,7 @@ macro_rules! supply_configuration_setter {
     ($($config:ident: $name:ident, $doc:expr,)*) => {
         $(
             #[doc=$doc]
+            #[must_use]
             pub fn $name(mut self) -> Self {
                 self.supply_configuration = SupplyConfiguration::$config;
                 self
@@ -355,6 +356,7 @@ impl Pwr {
         feature = "revision_v",
         any(feature = "rm0433", feature = "rm0399", feature = "rm0468")
     ))]
+    #[must_use]
     pub fn vos0(mut self, _: &SYSCFG) -> Self {
         self.target_vos = VoltageScale::Scale0;
         self
@@ -382,6 +384,7 @@ impl Pwr {
     ///
     /// The backup domain voltage regulator maintains the contents of backup SRAM
     /// in Standby and VBAT modes.
+    #[must_use]
     pub fn backup_regulator(mut self) -> Self {
         self.backup_regulator = true;
         self

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -192,8 +192,8 @@ macro_rules! tim_hal {
                 }
 
                 /// Releases the TIM peripheral
-                pub fn release(self) -> $TIM {
-                    self.tim
+                pub fn release(self) -> ($TIM, rec::$Rec) {
+                    (self.tim, rec::$Rec { _marker: core::marker::PhantomData })
                 }
             }
 

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -160,7 +160,7 @@ macro_rules! tim_hal {
                 pub fn $tim(tim: $TIM, prec: rec::$Rec) -> Self
                 {
                     // enable and reset peripheral to a clean slate
-                    prec.enable().reset();
+                    let _ = prec.enable().reset(); // drop
 
                     // Configure TxC1 and TxC2 as captures
                     tim.ccmr1_output().write(|w| unsafe {

--- a/src/rcc/mco.rs
+++ b/src/rcc/mco.rs
@@ -152,6 +152,7 @@ macro_rules! mco1_setters {
                 /// This only enables the signal within the RCC block, it does
                 /// not enable the MCO1 output pin itself (use the GPIO for
                 /// that).
+                #[must_use]
                 pub fn $mco_setter<F>(mut self, freq: F) -> Self
                 where
                     F: Into<Hertz>,
@@ -183,6 +184,7 @@ macro_rules! mco2_setters {
                 /// This only enables the signal within the RCC block, it does
                 /// not enable the MCO2 output pin itself (use the GPIO for
                 /// that).
+                #[must_use]
                 pub fn $mco_setter<F>(mut self, freq: F) -> Self
                 where
                     F: Into<Hertz>,

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -272,6 +272,7 @@ macro_rules! pclk_setter {
         $(
             /// Set the peripheral clock frequency for APB
             /// peripherals.
+            #[must_use]
             pub fn $name<F>(mut self, freq: F) -> Self
             where
                 F: Into<Hertz>,
@@ -289,6 +290,7 @@ macro_rules! pll_setter {
         $(
             $(
                 /// Set the target clock frequency for PLL output
+                #[must_use]
                 pub fn $name<F>(mut self, freq: F) -> Self
                 where
                     F: Into<Hertz>,
@@ -307,6 +309,7 @@ macro_rules! pll_strategy_setter {
         $(
             /// Set the PLL divider strategy to be used when the PLL
             /// is configured
+            #[must_use]
             pub fn $name(mut self, strategy: PllConfigStrategy) -> Self
             {
                 self.config.$pll.strategy = strategy;
@@ -320,6 +323,7 @@ impl Rcc {
     /// Uses HSE (external oscillator) instead of HSI (internal RC
     /// oscillator) as the clock source. Will result in a hang if an
     /// external oscillator is not connected or it fails to start.
+    #[must_use]
     pub fn use_hse<F>(mut self, freq: F) -> Self
     where
         F: Into<Hertz>,
@@ -330,12 +334,14 @@ impl Rcc {
 
     /// Use an external clock signal rather than a crystal oscillator,
     /// bypassing the XTAL driver.
+    #[must_use]
     pub fn bypass_hse(mut self) -> Self {
         self.config.bypass_hse = true;
         self
     }
 
     /// Set input frequency to the SCGU
+    #[must_use]
     pub fn sys_ck<F>(mut self, freq: F) -> Self
     where
         F: Into<Hertz>,
@@ -345,6 +351,7 @@ impl Rcc {
     }
 
     /// Set input frequency to the SCGU - ALIAS
+    #[must_use]
     pub fn sysclk<F>(mut self, freq: F) -> Self
     where
         F: Into<Hertz>,
@@ -354,6 +361,7 @@ impl Rcc {
     }
 
     /// Set peripheral clock frequency
+    #[must_use]
     pub fn per_ck<F>(mut self, freq: F) -> Self
     where
         F: Into<Hertz>,
@@ -366,6 +374,7 @@ impl Rcc {
     /// are several gated versions `rcc_hclk[1-4]` for different power domains,
     /// and the AXI bus clock is called `rcc_aclk`. However they are all the
     /// same frequency.
+    #[must_use]
     pub fn hclk<F>(mut self, freq: F) -> Self
     where
         F: Into<Hertz>,

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -68,10 +68,13 @@ use cortex_m::interrupt;
 /// A trait for Resetting, Enabling and Disabling a single peripheral
 pub trait ResetEnable {
     /// Enable this peripheral
+    #[allow(clippy::return_self_not_must_use)]
     fn enable(self) -> Self;
     /// Disable this peripheral
+    #[allow(clippy::return_self_not_must_use)]
     fn disable(self) -> Self;
     /// Reset this peripheral
+    #[allow(clippy::return_self_not_must_use)]
     fn reset(self) -> Self;
 }
 
@@ -269,6 +272,7 @@ macro_rules! peripheral_reset_and_enable_control_generator {
             $( #[ $pmeta ] )*
             impl $p {
                 /// Set Low Power Mode for peripheral
+                #[allow(clippy::return_self_not_must_use)]
                 pub fn low_power(self, lpm: LowPowerMode) -> Self {
                     // unsafe: Owned exclusive access to this bitfield
                     interrupt::free(|_| {
@@ -335,6 +339,7 @@ macro_rules! peripheral_reset_and_enable_control_generator {
             impl $p {
                 $(      // Individual kernel clocks
                     #[inline(always)]
+                    #[allow(clippy::return_self_not_must_use)]
                     /// Modify the kernel clock for
                     #[doc=$clk_doc "."]
                     /// See RM0433 Rev 7 Section 8.5.8.

--- a/src/rcc/rec.rs
+++ b/src/rcc/rec.rs
@@ -57,6 +57,17 @@
 //! // Can't set group kernel clock (it would also affect I2C3)
 //! // ccdr.peripheral.kernel_i2c123_clk_mux(I2c123ClkSel::HSI_KER);
 //! ```
+//!
+//! # REC object
+//!
+//! There is a REC object for each peripheral. For example:
+//!
+//! ```
+//! let rec_object = ccdr.peripheral.FDCAN;
+//! ```
+//!
+//! If REC object is dropped by user code, then the Reset or Enable state of
+//! this peripheral cannot be modified for the lifetime of the program.
 #![deny(missing_docs)]
 
 use core::marker::PhantomData;

--- a/src/sai/i2s.rs
+++ b/src/sai/i2s.rs
@@ -193,18 +193,21 @@ impl I2SChanConfig {
     }
 
     /// Set synchronization type, defaults to Master
+    #[must_use]
     pub fn set_sync_type(mut self, sync_type: I2SSync) -> Self {
         self.sync_type = sync_type;
         self
     }
 
     /// Set the clock strobing edge
+    #[must_use]
     pub fn set_clock_strobe(mut self, clock_strobe: I2SClockStrobe) -> Self {
         self.clock_strobe = clock_strobe;
         self
     }
 
     /// Set the number of slots, this is an advanced configuration.
+    #[must_use]
     pub fn set_slots(mut self, slots: u8) -> Self {
         assert!(slots <= 16);
         self.slots = slots;
@@ -212,6 +215,7 @@ impl I2SChanConfig {
     }
 
     /// Set the offset of the first data bit
+    #[must_use]
     pub fn set_first_bit_offset(mut self, first_bit_offset: u8) -> Self {
         // 5 bits or less
         assert!(first_bit_offset < 0b10_0000);
@@ -220,12 +224,14 @@ impl I2SChanConfig {
     }
 
     ///  Sets when the frame sync is asserted
+    #[must_use]
     pub fn set_frame_sync_before(mut self, frame_sync_before: bool) -> Self {
         self.frame_sync_before = frame_sync_before;
         self
     }
 
     /// Set frame sync to active high, defaults to active low
+    #[must_use]
     pub fn set_frame_sync_active_high(
         mut self,
         frame_sync_active_high: bool,
@@ -237,24 +243,28 @@ impl I2SChanConfig {
     /// Enable oversampling
     ///
     /// Note: the clock frequency must be doubled when enabled
+    #[must_use]
     pub fn set_oversampling(mut self, oversampling: bool) -> Self {
         self.oversampling = oversampling;
         self
     }
 
     /// Disable master clock generator
+    #[must_use]
     pub fn disable_master_clock(mut self) -> Self {
         self.master_clock_disabled = true;
         self
     }
 
     /// Sets the protocol to MSB or LSB
+    #[must_use]
     pub fn set_protocol(mut self, protocol: I2SProtocol) -> Self {
         self.protocol = protocol;
         self
     }
 
     /// Set the mono mode bit, default is to use stereo
+    #[must_use]
     pub fn set_mono_mode(mut self, mono_mode: bool) -> Self {
         self.mono_mode = mono_mode;
         self
@@ -265,6 +275,7 @@ impl I2SChanConfig {
     /// * true - repeat the last values
     ///
     /// Only meaningful in Tx mode when slots <= 2 and mute is enabled
+    #[must_use]
     pub fn set_mute_repeat(mut self, mute_repeat: bool) -> Self {
         if self.dir == I2SDir::Rx || self.slots > 2 {
             panic!("This only has meaning in I2S::Tx mode when slots <= 2");
@@ -278,6 +289,7 @@ impl I2SChanConfig {
     ///
     /// The value set is compared to the number of consecutive mute frames detected in
     /// reception. When the number of mute frames is equal to this value, the Muted even will be generated
+    #[must_use]
     pub fn set_mute_counter(mut self, mute_counter: u8) -> Self {
         if self.dir == I2SDir::Tx {
             panic!("This only has meaning in I2S::Rx mode");
@@ -289,12 +301,14 @@ impl I2SChanConfig {
     }
 
     /// Set the tristate to release the SD output line (HI-Z) at the end of the last data bit
+    #[must_use]
     pub fn set_tristate(mut self, tristate: bool) -> Self {
         self.tristate = tristate;
         self
     }
 
     /// Set the frame size. If None it will be automatically calculated
+    #[must_use]
     pub fn set_frame_size(mut self, frame_size: Option<u8>) -> Self {
         if let Some(frame_size) = frame_size {
             assert!(frame_size >= 8);
@@ -322,6 +336,7 @@ impl I2sUsers {
         }
     }
 
+    #[must_use]
     pub fn add_slave(mut self, slave: I2SChanConfig) -> Self {
         self.slave.replace(slave);
         self

--- a/src/sai/mod.rs
+++ b/src/sai/mod.rs
@@ -194,7 +194,7 @@ macro_rules! sai_hal {
                 /// Low level RCC initialisation
                 fn sai_rcc_init(&mut self, prec: rec::$Rec)
                 {
-                    prec.enable().reset();
+                    let _ = prec.enable().reset(); // drop, can be recreated by free method
                 }
 
                 /// Access to the current master channel

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -144,13 +144,11 @@ pub mod config {
             }
         }
 
-        #[must_use]
         pub fn baudrate(mut self, baudrate: impl Into<Hertz>) -> Self {
             self.baudrate = baudrate.into();
             self
         }
 
-        #[must_use]
         pub fn parity_none(mut self) -> Self {
             self.parity = Parity::ParityNone;
             self
@@ -160,7 +158,6 @@ pub mod config {
         ///
         /// Note that parity bits are included in the serial word length, so if parity is used word length will be set
         /// to 9.
-        #[must_use]
         pub fn parity_even(mut self) -> Self {
             self.parity = Parity::ParityEven;
             self
@@ -170,39 +167,33 @@ pub mod config {
         ///
         /// Note that parity bits are included in the serial word length, so if parity is used word length will be set
         /// to 9.
-        #[must_use]
         pub fn parity_odd(mut self) -> Self {
             self.parity = Parity::ParityOdd;
             self
         }
 
         /// Specify the number of stop bits
-        #[must_use]
         pub fn stopbits(mut self, stopbits: StopBits) -> Self {
             self.stopbits = stopbits;
             self
         }
         /// Specify the bit order
-        #[must_use]
         pub fn bitorder(mut self, bitorder: BitOrder) -> Self {
             self.bitorder = bitorder;
             self
         }
         /// Specify the clock phase. Only applies to USART peripherals
-        #[must_use]
         pub fn clockphase(mut self, clockphase: ClockPhase) -> Self {
             self.clockphase = clockphase;
             self
         }
         /// Specify the clock polarity. Only applies to USART peripherals
-        #[must_use]
         pub fn clockpolarity(mut self, clockpolarity: ClockPolarity) -> Self {
             self.clockpolarity = clockpolarity;
             self
         }
         /// Specify if the last bit transmitted in each word has a corresponding
         /// clock pulse in the SCLK pin. Only applies to USART peripherals
-        #[must_use]
         pub fn lastbitclockpulse(mut self, lastbitclockpulse: bool) -> Self {
             self.lastbitclockpulse = lastbitclockpulse;
             self

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -144,11 +144,13 @@ pub mod config {
             }
         }
 
+        #[must_use]
         pub fn baudrate(mut self, baudrate: impl Into<Hertz>) -> Self {
             self.baudrate = baudrate.into();
             self
         }
 
+        #[must_use]
         pub fn parity_none(mut self) -> Self {
             self.parity = Parity::ParityNone;
             self
@@ -158,6 +160,7 @@ pub mod config {
         ///
         /// Note that parity bits are included in the serial word length, so if parity is used word length will be set
         /// to 9.
+        #[must_use]
         pub fn parity_even(mut self) -> Self {
             self.parity = Parity::ParityEven;
             self
@@ -167,33 +170,39 @@ pub mod config {
         ///
         /// Note that parity bits are included in the serial word length, so if parity is used word length will be set
         /// to 9.
+        #[must_use]
         pub fn parity_odd(mut self) -> Self {
             self.parity = Parity::ParityOdd;
             self
         }
 
         /// Specify the number of stop bits
+        #[must_use]
         pub fn stopbits(mut self, stopbits: StopBits) -> Self {
             self.stopbits = stopbits;
             self
         }
         /// Specify the bit order
+        #[must_use]
         pub fn bitorder(mut self, bitorder: BitOrder) -> Self {
             self.bitorder = bitorder;
             self
         }
         /// Specify the clock phase. Only applies to USART peripherals
+        #[must_use]
         pub fn clockphase(mut self, clockphase: ClockPhase) -> Self {
             self.clockphase = clockphase;
             self
         }
         /// Specify the clock polarity. Only applies to USART peripherals
+        #[must_use]
         pub fn clockpolarity(mut self, clockpolarity: ClockPolarity) -> Self {
             self.clockpolarity = clockpolarity;
             self
         }
         /// Specify if the last bit transmitted in each word has a corresponding
         /// clock pulse in the SCLK pin. Only applies to USART peripherals
+        #[must_use]
         pub fn lastbitclockpulse(mut self, lastbitclockpulse: bool) -> Self {
             self.lastbitclockpulse = lastbitclockpulse;
             self

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -199,6 +199,7 @@ impl Config {
     /// Note:
     /// * This function updates the HAL peripheral to treat the pin provided in the MISO parameter
     /// as the MOSI pin and the pin provided in the MOSI parameter as the MISO pin.
+    #[must_use]
     pub fn swap_mosi_miso(mut self) -> Self {
         self.swap_miso_mosi = true;
         self
@@ -208,6 +209,7 @@ impl Config {
     ///
     /// This also affects the way data is sent using [HardwareCSMode].
     /// By default the hardware cs is disabled.
+    #[must_use]
     pub fn hardware_cs(mut self, hardware_cs: HardwareCS) -> Self {
         self.hardware_cs = hardware_cs;
         self
@@ -217,12 +219,14 @@ impl Config {
     ///
     /// Note:
     /// * This value is converted to a number of spi peripheral clock ticks and at most 15 of those.
+    #[must_use]
     pub fn inter_word_delay(mut self, inter_word_delay: f32) -> Self {
         self.inter_word_delay = inter_word_delay;
         self
     }
 
     /// Select the communication mode of the SPI bus.
+    #[must_use]
     pub fn communication_mode(mut self, mode: CommunicationMode) -> Self {
         self.communication_mode = mode;
         self

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -707,7 +707,7 @@ macro_rules! spi {
                         CONFIG: Into<Config>,
                     {
                         // Enable clock for SPI
-                        prec.enable();
+                        let _ = prec.enable(); // drop, can be recreated by free method
 
                         // Disable SS output
                         spi.cfg2.write(|w| w.ssoe().disabled());

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -302,7 +302,7 @@ macro_rules! hal {
                 pub fn $timX(tim: $TIMX, prec: rec::$Rec, clocks: &CoreClocks) -> Self
                 {
                     // enable and reset peripheral to a clean state
-                    prec.enable().reset();
+                    let _ = prec.enable().reset(); // drop, can be recreated by free method
 
                     let clk = $TIMX::get_clk(clocks)
                         .expect(concat!(stringify!($TIMX), ": Input clock not running!")).0;
@@ -591,7 +591,7 @@ macro_rules! lptim_hal {
                     T: Into<Hertz>,
                 {
                     // enable and reset peripheral to a clean state
-                    prec.enable().reset();
+                    let _ = prec.enable().reset(); // drop, can be recreated by free method
 
                     let clk = $TIMX::get_clk(clocks)
                         .expect(concat!(stringify!($TIMX), ": Input clock not running!")).0;
@@ -633,7 +633,7 @@ macro_rules! lptim_hal {
                     T: Into<Hertz>,
                 {
                     // enable and reset peripheral to a clean state
-                    prec.enable().reset();
+                    let _ = prec.enable().reset(); // drop, can be recreated by free method
 
                     let clk = $TIMX::get_clk(clocks)
                         .expect(concat!(stringify!($TIMX), ": Input clock not running!")).0;


### PR DESCRIPTION
Use of this attribute was [expanded in the standard library](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html#more-must_use-in-the-standard-library) in Rust 1.58, and there is now a [clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use[](https://github.com/richardeoin)).

Silence the lint for REC methods, since dropping the REC is intended.
Also silence the lint for GPIO modifiers (set_speed) since these are also often dropped.