### PR TITLE
Prototype of implementing SAI DMA on ChannelA/B compound types

### DIFF
--- a/examples/sai_dma_passthru.rs
+++ b/examples/sai_dma_passthru.rs
@@ -118,7 +118,7 @@ fn main() -> ! {
     let mut dma1_str0: dma::Transfer<_, _, dma::MemoryToPeripheral, _, _> =
         dma::Transfer::init(
             dma1_streams.0,
-            unsafe { pac::Peripherals::steal().SAI1 },
+            unsafe { pac::Peripherals::steal().SAI1.dma_ch_b() }, // Channel B
             tx_buffer,
             None,
             dma_config,
@@ -133,7 +133,7 @@ fn main() -> ! {
     let mut dma1_str1: dma::Transfer<_, _, dma::PeripheralToMemory, _, _> =
         dma::Transfer::init(
             dma1_streams.1,
-            unsafe { pac::Peripherals::steal().SAI1 },
+            unsafe { pac::Peripherals::steal().SAI1.dma_ch_a() }, // Channel A
             rx_buffer,
             None,
             dma_config,
@@ -204,7 +204,7 @@ fn main() -> ! {
 
     type TransferDma1Str1 = dma::Transfer<
         dma::dma::Stream1<stm32::DMA1>,
-        stm32::SAI1,
+        sai::dma::ChannelA<stm32::SAI1>,
         dma::PeripheralToMemory,
         &'static mut [u32; DMA_BUFFER_LENGTH],
         dma::DBTransfer,

--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -13,7 +13,7 @@ use crate::{
     i2c::I2c,
     pac::{self, DMA1, DMA2, DMAMUX1},
     rcc::{rec, rec::ResetEnable},
-    serial, spi,
+    sai, serial, spi,
 };
 
 use core::ops::Deref;
@@ -936,16 +936,107 @@ peripheral_target_address!(
 );
 
 peripheral_target_address!(
+    // implementation on PAC types, fixed output Channel A and input Channel B
     (pac::SAI1, cha.dr, u32, M2P, DMAReq::SAI1A_DMA),
     (pac::SAI1, chb.dr, u32, P2M, DMAReq::SAI1B_DMA),
+    // implementation on compound types (either Channel A or Channel B)
+    (
+        sai::dma::ChannelA<pac::SAI1>,
+        cha.dr,
+        u32,
+        P2M,
+        DMAReq::SAI1A_DMA
+    ),
+    (
+        sai::dma::ChannelA<pac::SAI1>,
+        cha.dr,
+        u32,
+        M2P,
+        DMAReq::SAI1A_DMA
+    ),
+    (
+        sai::dma::ChannelB<pac::SAI1>,
+        chb.dr,
+        u32,
+        P2M,
+        DMAReq::SAI1B_DMA
+    ),
+    (
+        sai::dma::ChannelB<pac::SAI1>,
+        chb.dr,
+        u32,
+        M2P,
+        DMAReq::SAI1B_DMA
+    ),
 );
 #[cfg(not(feature = "rm0468"))]
 peripheral_target_address!(
+    // implementation on PAC types, fixed output Channel A and input Channel B
     (pac::SAI2, cha.dr, u32, M2P, DMAReq::SAI2A_DMA),
     (pac::SAI2, chb.dr, u32, P2M, DMAReq::SAI2B_DMA),
+    // implementation on compound types (either Channel A or Channel B)
+    (
+        sai::dma::ChannelA<pac::SAI2>,
+        cha.dr,
+        u32,
+        P2M,
+        DMAReq::SAI2A_DMA
+    ),
+    (
+        sai::dma::ChannelA<pac::SAI2>,
+        cha.dr,
+        u32,
+        M2P,
+        DMAReq::SAI2A_DMA
+    ),
+    (
+        sai::dma::ChannelB<pac::SAI2>,
+        chb.dr,
+        u32,
+        P2M,
+        DMAReq::SAI2B_DMA
+    ),
+    (
+        sai::dma::ChannelB<pac::SAI2>,
+        chb.dr,
+        u32,
+        M2P,
+        DMAReq::SAI2B_DMA
+    ),
+
 );
 #[cfg(any(feature = "rm0433", feature = "rm0399"))]
 peripheral_target_address!(
+    // implementation on PAC types, fixed output Channel A and input Channel B
     (pac::SAI3, cha.dr, u32, M2P, DMAReq::SAI3_A_DMA),
     (pac::SAI3, chb.dr, u32, P2M, DMAReq::SAI3_B_DMA),
+    // implementation on compound types (either Channel A or Channel B)
+    (
+        sai::dma::ChannelA<pac::SAI3>,
+        cha.dr,
+        u32,
+        P2M,
+        DMAReq::SAI3_A_DMA
+    ),
+    (
+        sai::dma::ChannelA<pac::SAI3>,
+        cha.dr,
+        u32,
+        M2P,
+        DMAReq::SAI3_A_DMA
+    ),
+    (
+        sai::dma::ChannelB<pac::SAI3>,
+        chb.dr,
+        u32,
+        P2M,
+        DMAReq::SAI3_B_DMA
+    ),
+    (
+        sai::dma::ChannelB<pac::SAI3>,
+        chb.dr,
+        u32,
+        M2P,
+        DMAReq::SAI3_B_DMA
+    ),
 );

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -19,6 +19,8 @@ pub use crate::pwr::PwrExt as _stm32h7xx_hal_pwr_PwrExt;
 pub use crate::rcc::RccExt as _stm32h7xx_hal_rcc_RccExt;
 pub use crate::rng::RngCore as _stm32h7xx_hal_rng_RngCore;
 pub use crate::rng::RngExt as _stm32h7xx_hal_rng_RngExt;
+pub use crate::sai::SaiDmaExt as _stm32h7xx_hal_spi_SaiDmaExt;
+pub use crate::sai::SaiI2sExt as _stm32h7xx_hal_spi_SaiI2sExt;
 pub use crate::sai::SaiPdmExt as _stm32h7xx_hal_spi_SaiPdmExt;
 #[cfg(feature = "sdmmc")]
 pub use crate::sdmmc::SdmmcExt as _stm32h7xx_hal_sdmmc_SdmmcExt;

--- a/src/sai/dma.rs
+++ b/src/sai/dma.rs
@@ -1,0 +1,72 @@
+//! # Serial Audio Interface - DMA
+
+use crate::stm32::SAI1;
+#[cfg(feature = "rm0455")]
+use crate::stm32::SAI2;
+#[cfg(feature = "rm0468")]
+use crate::stm32::SAI4;
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
+use crate::stm32::{SAI2, SAI3, SAI4};
+
+/// Marker for Channel A
+pub struct ChannelA<SAI>(SAI);
+
+/// Marker for Channel B
+pub struct ChannelB<SAI>(SAI);
+
+/// Trait to extend SAI peripherals
+pub trait SaiDmaExt<SAI>: Sized {
+    fn dma_ch_a(self) -> ChannelA<SAI>;
+    fn dma_ch_b(self) -> ChannelB<SAI>;
+}
+
+macro_rules! i2s_dma {
+    ( $($SAIX:ident, $_Rec:ident: [$_i2s_saiX_ch_a:ident, $_i2s_saiX_ch_b:ident]),+ ) => {
+        $(
+            impl SaiDmaExt<$SAIX> for $SAIX {
+                fn dma_ch_a(
+                    self,
+                ) -> ChannelA<$SAIX> {
+                    ChannelA(self)
+                }
+                fn dma_ch_b(
+                    self,
+                ) -> ChannelB<$SAIX> {
+                    ChannelB(self)
+                }
+            }
+            impl core::ops::Deref for ChannelA<$SAIX> {
+                type Target = $SAIX;
+
+                fn deref(&self) -> &Self::Target {
+                    &self.0
+                }
+            }
+            impl core::ops::Deref for ChannelB<$SAIX> {
+                type Target = $SAIX;
+
+                fn deref(&self) -> &Self::Target {
+                    &self.0
+                }
+            }
+        )+
+    }
+}
+
+i2s_dma! {
+    SAI1, Sai1: [i2s_sai1_ch_a, i2s_sai1_ch_b]
+}
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
+i2s_dma! {
+    SAI2, Sai2: [i2s_sai2_ch_a, i2s_sai2_ch_b],
+    SAI3, Sai3: [i2s_sai3_ch_a, i2s_sai3_ch_b],
+    SAI4, Sai4: [i2s_sai4_ch_a, i2s_sai4_ch_b]
+}
+#[cfg(feature = "rm0455")]
+i2s_dma! {
+    SAI2, Sai2: [i2s_sai2_ch_a, i2s_sai2_ch_b]
+}
+#[cfg(feature = "rm0468")]
+i2s_dma! {
+    SAI4, Sai4: [i4s_sai4_ch_a, i4s_sai4_ch_b]
+}

--- a/src/sai/mod.rs
+++ b/src/sai/mod.rs
@@ -33,6 +33,9 @@ use crate::time::Hertz;
 
 const CLEAR_ALL_FLAGS_BITS: u32 = 0b0111_0111;
 
+pub mod dma;
+pub use dma::SaiDmaExt;
+
 mod pdm;
 pub use pdm::SaiPdmExt;
 mod i2s;


### PR DESCRIPTION
Implement as wrapper type instead, which allows us to pretend this is a smart pointer type and make use of [deref coercion](https://doc.rust-lang.org/std/ops/trait.Deref.html)

This is actually backwards compatible, so the old fixed mapping (write on channel A, read on channel B) still works