### PR TITLE
Add inner and inner_mut functions to peripherals where it's easy to d…

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -858,6 +858,16 @@ macro_rules! adc_hal {
                         panic!("Cannot read linear calibration value when the ADC is disabled");
                     }
                 }
+
+                /// Returns a reference to the inner peripheral
+                pub fn inner(&self) -> &$ADC {
+                    &self.rb
+                }
+
+                /// Returns a mutable reference to the inner peripheral
+                pub fn inner_mut(&mut self) -> &mut $ADC {
+                    &mut self.rb
+                }
             }
 
             impl<WORD, PIN> OneShot<$ADC, WORD, PIN> for Adc<$ADC, Enabled>

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -133,6 +133,16 @@ impl Crc {
     pub fn get_idr(&self) -> u32 {
         self.reg.idr.read().idr().bits()
     }
+
+    /// Returns a reference to the inner peripheral
+    pub fn inner(&self) -> &CRC {
+        &self.reg
+    }
+
+    /// Returns a mutable reference to the inner peripheral
+    pub fn inner_mut(&mut self) -> &mut CRC {
+        &mut self.reg
+    }
 }
 
 #[macro_use]

--- a/src/fmc.rs
+++ b/src/fmc.rs
@@ -138,6 +138,18 @@ impl FmcExt for stm32::FMC {
     }
 }
 
+impl FMC {
+    /// Returns a reference to the inner peripheral
+    pub fn inner(&self) -> &stm32::FMC {
+        &self.fmc
+    }
+
+    /// Returns a mutable reference to the inner peripheral
+    pub fn inner_mut(&mut self) -> &mut stm32::FMC {
+        &mut self.fmc
+    }
+}
+
 unsafe impl FmcPeripheral for FMC {
     const REGISTERS: *const () = stm32::FMC::ptr() as *const ();
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -346,6 +346,11 @@ macro_rules! i2c {
                     &self.i2c
                 }
 
+                /// Returns a mutable reference to the inner peripheral
+                pub fn inner_mut(&mut self) -> &mut $I2CX {
+                    &mut self.i2c
+                }
+
                 /// Enable or disable the DMA mode for reception
                 pub fn rx_dma(&mut self, enable: bool) {
                     self.i2c.cr1.modify(|_,w| w.rxdmaen().bit(enable));

--- a/src/ltdc.rs
+++ b/src/ltdc.rs
@@ -99,6 +99,16 @@ impl Ltdc {
         // unsafe: clear write-one interrupt flag
         unsafe { (*LTDC::ptr()).icr.write(|w| w.crrif().set_bit()) };
     }
+
+    /// Returns a reference to the inner peripheral
+    pub fn inner(&self) -> &LTDC {
+        &self.ltdc
+    }
+
+    /// Returns a mutable reference to the inner peripheral
+    pub fn inner_mut(&mut self) -> &mut LTDC {
+        &mut self.ltdc
+    }
 }
 
 impl DisplayController for Ltdc {

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -310,6 +310,16 @@ impl Pwr {
         });
         while d3cr!(self.rb).read().vosrdy().bit_is_clear() {}
     }
+
+    /// Returns a reference to the inner peripheral
+    pub fn inner(&self) -> &PWR {
+        &self.rb
+    }
+
+    /// Returns a mutable reference to the inner peripheral
+    pub fn inner_mut(&mut self) -> &mut PWR {
+        &mut self.rb
+    }
 }
 
 /// Builder methods

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -96,6 +96,16 @@ impl Rng {
     pub fn release(self) -> RNG {
         self.rb
     }
+
+    /// Returns a reference to the inner peripheral
+    pub fn inner(&self) -> &RNG {
+        &self.rb
+    }
+
+    /// Returns a mutable reference to the inner peripheral
+    pub fn inner_mut(&mut self) -> &mut RNG {
+        &mut self.rb
+    }
 }
 
 impl core::iter::Iterator for Rng {

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -785,4 +785,14 @@ impl Rtc {
         // We're allowed to change this once after the LSE fails
         self.prec.kernel_clk_mux(backup::RtcClkSel::LSI);
     }
+
+    /// Returns a reference to the inner peripheral
+    pub fn inner(&self) -> &RTC {
+        &self.reg
+    }
+
+    /// Returns a mutable reference to the inner peripheral
+    pub fn inner_mut(&mut self) -> &mut RTC {
+        &mut self.reg
+    }
 }

--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -393,6 +393,16 @@ impl<S> Sdmmc<S> {
             _ => Err(Error::BadClock),
         }
     }
+
+    /// Returns a reference to the inner peripheral
+    pub fn inner(&self) -> &S {
+        &self.sdmmc
+    }
+
+    /// Returns a mutable reference to the inner peripheral
+    pub fn inner_mut(&mut self) -> &mut S {
+        &mut self.sdmmc
+    }
 }
 
 macro_rules! sdmmc {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -770,6 +770,16 @@ macro_rules! usart {
 
                     self.usart
                 }
+
+                /// Returns a reference to the inner peripheral
+                pub fn inner(&self) -> &$USARTX {
+                    &self.usart
+                }
+
+                /// Returns a mutable reference to the inner peripheral
+                pub fn inner_mut(&mut self) -> &mut $USARTX {
+                    &mut self.usart
+                }
             }
 
             impl SerialExt<$USARTX> for $USARTX {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -474,6 +474,16 @@ macro_rules! hal {
 
                     (self.tim, rec::$Rec { _marker: PhantomData })
                 }
+
+                /// Returns a reference to the inner peripheral
+                pub fn inner(&self) -> &$TIMX {
+                    &self.tim
+                }
+
+                /// Returns a mutable reference to the inner peripheral
+                pub fn inner_mut(&mut self) -> &mut $TIMX {
+                    &mut self.tim
+                }
             }
         )+
     }

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -89,6 +89,16 @@ impl SystemWindowWatchdog {
             }
         }
     }
+
+    /// Returns a reference to the inner peripheral
+    pub fn inner(&self) -> &WWDG {
+        &self.wwdg
+    }
+
+    /// Returns a mutable reference to the inner peripheral
+    pub fn inner_mut(&mut self) -> &mut WWDG {
+        &mut self.wwdg
+    }
 }
 
 impl Watchdog for SystemWindowWatchdog {


### PR DESCRIPTION
…o so

Where the registers are owned by a single struct and not shared amongst many channels, etc.