### PR TITLE
Replace crate::Never with core::convert::Infallible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * **Breaking**: Use const-generics for `GPIO`, add `DynamicPin`, `ErasedPin`,
   inherent impls for `embedded-hal` like methods by-default, default modes [#334]
+* Replace crate::Never with core::convert::Infallible
+
 * pwr: Add backup domain voltage regulator control [#303][303]
 * MSRV increased to 1.59
 * flash: added flash implementation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,6 @@
 
 extern crate paste;
 
-#[derive(Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Never {}
-
 #[cfg(not(feature = "device-selected"))]
 compile_error!(
     "This crate requires one of the following device features enabled:

--- a/src/sai/pdm.rs
+++ b/src/sai/pdm.rs
@@ -24,11 +24,8 @@ use crate::stm32::SAI1;
 #[cfg(not(feature = "rm0455"))]
 use crate::stm32::SAI4;
 
-use crate::time::Hertz;
-
-use crate::Never;
-
 use crate::gpio::{self, Alternate};
+use crate::time::Hertz;
 
 /// Trait for a valid combination of SAI PDM pins
 pub trait PulseDensityPins<SAI> {
@@ -198,7 +195,7 @@ macro_rules! hal {
             }
             impl Sai<$SAIX, Pdm> {
                 /// Read a single data word (one 'slot')
-                pub fn read_data(&mut self) -> nb::Result<u32, Never> {
+                pub fn read_data(&mut self) -> nb::Result<u32, core::convert::Infallible> {
                     while self.interface.invalid_countdown > 0 {
                         // Check for words to read
                         if self.rb.cha.sr.read().freq().bit_is_clear() {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -30,7 +30,6 @@ use crate::stm32::usart1::cr1::{M0_A as M0, PCE_A as PCE, PS_A as PS};
 use crate::stm32::{UART4, UART5, UART7, UART8};
 use crate::stm32::{USART1, USART2, USART3, USART6};
 use crate::time::Hertz;
-use crate::Never;
 
 /// Serial error
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -898,16 +897,16 @@ macro_rules! usart {
             }
 
             impl serial::Write<u8> for Serial<$USARTX> {
-                type Error = Never;
+                type Error = core::convert::Infallible;
 
-                fn flush(&mut self) -> nb::Result<(), Never> {
+                fn flush(&mut self) -> nb::Result<(), Self::Error> {
                     let mut tx: Tx<$USARTX> = Tx {
                         _usart: PhantomData,
                     };
                     tx.flush()
                 }
 
-                fn write(&mut self, byte: u8) -> nb::Result<(), Never> {
+                fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
                     let mut tx: Tx<$USARTX> = Tx {
                         _usart: PhantomData,
                     };
@@ -926,9 +925,9 @@ macro_rules! usart {
                 // framing errors (which only occur in SmartCard
                 // mode); neither of these apply to our hardware
                 // configuration
-                type Error = Never;
+                type Error = core::convert::Infallible;
 
-                fn flush(&mut self) -> nb::Result<(), Never> {
+                fn flush(&mut self) -> nb::Result<(), Self::Error> {
                     // NOTE(unsafe) atomic read with no side effects
                     let isr = unsafe { (*$USARTX::ptr()).isr.read() };
 
@@ -939,7 +938,7 @@ macro_rules! usart {
                     }
                 }
 
-                fn write(&mut self, byte: u8) -> nb::Result<(), Never> {
+                fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
                     // NOTE(unsafe) atomic read with no side effects
                     let isr = unsafe { (*$USARTX::ptr()).isr.read() };
 


### PR DESCRIPTION
There's only a few remaining uses of crate::Never