### PR TITLE
Update sdio-host

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,11 +180,11 @@ required-features = ["xspi", "rm0468"]
 
 [[example]]
 name = "sdmmc"
-required-features = ["sdmmc", "rm0433"]
+required-features = ["sdmmc"]
 
 [[example]]
 name = "sdmmc_fat"
-required-features = ["sdmmc", "sdmmc-fatfs", "stm32h747cm7"]
+required-features = ["sdmmc", "sdmmc-fatfs"]
 
 [[example]]
 name = "ethernet-stm32h747i-disco"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ cast = { version = "0.3.0", default-features = false }
 nb = "1.0.0"
 paste = "1.0.1"
 bare-metal = "1.0.0"
-sdio-host = { version = "0.5", optional = true }
+sdio-host = { version = "0.7", optional = true }
 embedded-sdmmc = { version = "0.3", optional = true }
 stm32-fmc = { version = "0.2", optional = true }
 synopsys-usb-otg = { version = "^0.3.0", features = ["cortex-m"], optional = true }

--- a/examples/sdmmc.rs
+++ b/examples/sdmmc.rs
@@ -12,6 +12,7 @@ mod utilities;
 
 use cortex_m_rt::entry;
 use stm32h7xx_hal::gpio::Speed;
+use stm32h7xx_hal::sdmmc::{SdCard, Sdmmc};
 use stm32h7xx_hal::{pac, prelude::*};
 
 use log::info;
@@ -84,7 +85,7 @@ fn main() -> ! {
     let _cd = gpioi.pi8.into_pull_up_input();
 
     // Create SDMMC
-    let mut sdmmc = dp.SDMMC1.sdmmc(
+    let mut sdmmc: Sdmmc<_, SdCard> = dp.SDMMC1.sdmmc(
         (clk, cmd, d0, d1, d2, d3),
         ccdr.peripheral.SDMMC1,
         &ccdr.clocks,
@@ -97,7 +98,7 @@ fn main() -> ! {
 
     // Loop until we have a card
     loop {
-        match sdmmc.init_card(bus_frequency) {
+        match sdmmc.init(bus_frequency) {
             Ok(_) => break,
             Err(err) => {
                 info!("Init err: {:?}", err);
@@ -150,7 +151,7 @@ fn main() -> ! {
     let end = pac::DWT::cycle_count();
     let duration = (end - start) as f32 / ccdr.clocks.c_ck().0 as f32;
 
-    info!("Read 100 blocks at {} bytes/s", 5120. / duration);
+    info!("Read 10 blocks at {} bytes/s", 5120. / duration);
     info!("");
 
     // Write 10 blocks

--- a/examples/sdmmc_fat.rs
+++ b/examples/sdmmc_fat.rs
@@ -4,6 +4,7 @@
 use {
     embedded_sdmmc::{Controller, VolumeIdx},
     log,
+    stm32h7xx_hal::sdmmc::{SdCard, Sdmmc},
     stm32h7xx_hal::{pac, prelude::*, rcc},
 };
 
@@ -56,7 +57,7 @@ unsafe fn main() -> ! {
     let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
     let gpiod = dp.GPIOD.split(ccdr.peripheral.GPIOD);
 
-    let mut sd = dp.SDMMC2.sdmmc(
+    let mut sd: Sdmmc<_, SdCard> = dp.SDMMC2.sdmmc(
         (
             gpiod.pd6.into_alternate(),
             gpiod.pd7.into_alternate(),
@@ -74,7 +75,7 @@ unsafe fn main() -> ! {
         // On most development boards this can be increased up to 50MHz. We choose a
         // lower frequency here so that it should work even with flying leads
         // connected to a SD card breakout.
-        match sd.init_card(2.mhz()) {
+        match sd.init(2.mhz()) {
             Ok(_) => break,
             Err(err) => {
                 log::info!("Init err: {:?}", err);

--- a/examples/sdmmc_fat.rs
+++ b/examples/sdmmc_fat.rs
@@ -44,7 +44,7 @@ unsafe fn main() -> ! {
     let ccdr = dp
         .RCC
         .constrain()
-        .sys_ck(480.mhz())
+        .sys_ck(200.mhz())
         .pll1_strategy(rcc::PllConfigStrategy::Iterative)
         .pll1_q_ck(100.mhz())
         .pll2_strategy(rcc::PllConfigStrategy::Iterative)


### PR DESCRIPTION
* Update [sdio-host](https://crates.io/crates/sdio-host) to the latest version
* Add eMMC support from sdio-host
* Build examples for all families

Tested again on a STM32H747I-DISCO development board with a SanDisk Extreme 32 GB SDHC UHS-I card