### PR TITLE
Expose PinMode as public

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -65,7 +65,7 @@ use core::marker::PhantomData;
 use crate::rcc::ResetEnable;
 
 mod convert;
-use convert::PinMode;
+pub use convert::PinMode;
 mod partially_erased;
 pub use partially_erased::{PEPin, PartiallyErasedPin};
 mod erased;

--- a/src/gpio/convert.rs
+++ b/src/gpio/convert.rs
@@ -424,7 +424,7 @@ impl<'a, const P: char, const N: u8, ORIG: PinMode> Drop
 
 /// Marker trait for valid pin modes (type state).
 ///
-/// It can not be implemented by outside types.
+/// This trait is sealed and cannot be implemented by outside types
 pub trait PinMode: crate::Sealed {
     // These constants are used to implement the pin configuration code.
     // They are not part of public API.


### PR DESCRIPTION
With the new GPIO API it is not possible anymore to create a generic
functions that would turn a Pin into PushPull unless the current mode of
the Pin is hardcoded.

This used to work:

```
 pub struct LedUser(pub gpio::gpioc::PC7<gpio::Output<gpio::PushPull>>);

 impl LedUser {
     pub fn new<Mode>(pin: gpio::gpioc::PC7<Mode>) -> Self {
         LedUser(pin.into_push_pull_output())
     }
 }
```

Now it fails due to:

```
error[E0599]: the method `into_push_pull_output` exists for struct `stm32h7xx_hal::gpio::Pin<'C', 7_u8, Mode>`, but its trait bounds were not satisfied
  --> src/led.rs:29:21
   |
29 |         LedUser(pin.into_push_pull_output())
   |                     ^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `stm32h7xx_hal::gpio::Pin<'C', 7_u8, Mode>` due to unsatisfied trait bounds                
   |
   = note: the following trait bounds were not satisfied:
           `Mode: stm32h7xx_hal::gpio::convert::PinMode`
```

I would like to set <Mode: PinMode>, but for that, PinMode needs to be
made public.

Signed-off-by: Petr Horacek <hrck@protonmail.com>