### PR TITLE
fix: flash bank impl visibility

### DIFF
--- a/src/flash.rs
+++ b/src/flash.rs
@@ -137,21 +137,21 @@ pub enum Bank {
 ))]
 impl Bank {
     /// The start address of the bank
-    fn start_address(&self) -> usize {
+    pub fn start_address(&self) -> usize {
         match *self {
             Bank::UserBank1 => BANK1_ADDR_START,
             Bank::UserBank2 => BANK2_ADDR_START,
         }
     }
     /// The end address of the bank
-    fn end_address(&self) -> usize {
+    pub fn end_address(&self) -> usize {
         match *self {
             Bank::UserBank1 => BANK1_ADDR_END,
             Bank::UserBank2 => BANK2_ADDR_END,
         }
     }
     /// The address of a given sector of a bank
-    fn sector_address(&self, sector: usize) -> usize {
+    pub fn sector_address(&self, sector: usize) -> usize {
         if sector > self.num_sectors() {
             panic!("Sector outside of bank range");
         }

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -151,6 +151,10 @@ impl Bank {
         }
     }
     /// The address of a given sector of a bank
+    ///
+    /// # Panics
+    ///
+    /// Panics if the sector is out of range for this bank
     pub fn sector_address(&self, sector: usize) -> usize {
         if sector > self.num_sectors() {
             panic!("Sector outside of bank range");


### PR DESCRIPTION
Adjusts the visibility of various Flash `Bank` methods which will help users determine memory locations of sectors etc. 

For example if the user is writing a bootloader beginning at Bank 1, Sector 6, and they need to know the address to jump to, this will allow them easily.