### PR TITLE
Convert ResetMode to own witness pin and track past pin mode

### DIFF
--- a/examples/gpio_with_input.rs
+++ b/examples/gpio_with_input.rs
@@ -1,0 +1,58 @@
+//! Demonstrates the use of the GPIO method `with_input` (and similar methods)
+//!
+//! https://docs.rs/stm32h7xx-hal/latest/stm32h7xx_hal/gpio/struct.Pin.html#method.with_input
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::entry;
+
+use stm32h7xx_hal::{pac, prelude::*};
+
+use log::info;
+
+#[macro_use]
+mod utilities;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = example_power!(pwr).freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(100.MHz()).freeze(pwrcfg, &dp.SYSCFG);
+
+    info!("");
+    info!("stm32h7xx-hal example - GPIO with_input");
+    info!("");
+
+    let gpioe = dp.GPIOE.split(ccdr.peripheral.GPIOE);
+
+    // Configure PE1 as output.
+    let mut led = gpioe.pe1.into_push_pull_output();
+
+    // Get the delay provider.
+    let mut delay = cp.SYST.delay(ccdr.clocks);
+
+    loop {
+        loop {
+            led.set_high();
+            delay.delay_ms(100_u16);
+
+            led.set_low();
+            delay.delay_ms(100_u16);
+
+            let is_high = led.with_input(|x| x.is_high());
+            info!("LED pin high? {}", is_high);
+        }
+    }
+}


### PR DESCRIPTION
Previously when resetting it would assume the pin was in the ORIG pin mode and try to convert it to the ORIG pin mode, which the if statements in mode blocked. Now by tracking the witness pin and the original MODE the reset can properly set the mode register bits.

By fixing ResetMode it allows for the `with_<mode>` methods to work and set the MODER bits. Fixes #358.

Since I've fairly new to heavy generics and microcontroller level optimization, it would be really great if someone could double-check that this doesn't break anything the previous implementation upheld! Thank you!