### PR TITLE
Fix intermittent flash programming error.

### DIFF
--- a/src/flash.rs
+++ b/src/flash.rs
@@ -461,9 +461,6 @@ impl Flash {
             // to go low before checking if it's set and then clearing it.
             // Anything aside from this exact progression results in errors.
             while regs.sr.read().eop().bit_is_clear() {}
-            if regs.sr.read().eop().bit_is_set() {
-                regs.sr.modify(|_, w| w.eop().set_bit()); // Clear
-            }
         }
 
         // 7. Cleanup by clearing the PG bit

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -457,6 +457,10 @@ impl Flash {
 
             // 6. Check that EOP flag is set in the FLASH_SR register (meaning that the programming
             // operation has succeed), and clear it by software.
+            // The reference does not mention this, but it seems that this must wait for the EOP flag
+            // to go low before checking if it's set and then clearing it.
+            // Anything aside from this exact progression results in errors.
+            while regs.sr.read().eop().bit_is_clear() {}
             if regs.sr.read().eop().bit_is_set() {
                 regs.sr.modify(|_, w| w.eop().set_bit()); // Clear
             }


### PR DESCRIPTION
Writing flash sectors fails after a couple of writes without waiting for the EOP flag in the FLASH_SR# register to go low after each write. The reference doesn't mention that this is necessary, but it fails without this on my STM32H743IIT6 devboard.