### PR TITLE
Correct flash word check

### DIFF
--- a/src/flash.rs
+++ b/src/flash.rs
@@ -421,7 +421,7 @@ impl Flash {
         if sector > bank.num_sectors() {
             panic!("Sector out of bounds")
         }
-        if data.len() % 256 != 0 || start % 256 != 0 {
+        if data.len() % 32 != 0 || start % 32 != 0 {
             panic!(
                 "data length and start offset must be a multiple of a 32 byte (256b) 'flash word'"
             );


### PR DESCRIPTION
The check was accidentally done with the bit size instead of the byte size.
Later in the function the correct value of 32 is used in the chunks_exact function.