### PR TITLE
Add initialization argument for ADC frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 * flash: Use Ordering fence to prevent inconsistency errors when writing to flash sector [#382]
+* **Breaking** Require frequency when initialising adc, use this to set the prescaler [#379]
+* adc: fix internal channel allocations for RM0468 parts [#379]
 * flash: Rewrite `write_sector` to correctly write data in 256 bit chunks [#371]
 * iwdt: Added HAL implementation. Changed the name of the other implementation to `system_watchdog` [#376]
 * pac: Upgrade to stm32-rs v0.15.1 [#370]
@@ -307,3 +309,4 @@
 [#361]: https://github.com/stm32-rs/stm32h7xx-hal/pull/361
 [#371]: https://github.com/stm32-rs/stm32h7xx-hal/pull/371
 [#370]: https://github.com/stm32-rs/stm32h7xx-hal/pull/370
+[#379]: https://github.com/stm32-rs/stm32h7xx-hal/pull/379

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -54,6 +54,7 @@ fn main() -> ! {
     // Setup ADC
     let mut adc1 = adc::Adc::adc1(
         dp.ADC1,
+        4.MHz(),
         &mut delay,
         ccdr.peripheral.ADC12,
         &ccdr.clocks,

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -32,15 +32,12 @@ fn main() -> ! {
     let rcc = dp.RCC.constrain();
 
     // We need to configure a clock for adc_ker_ck_input. The default
-    // adc_ker_ck_input is pll2_p_ck, but we will use per_ck. Here we
-    // set per_ck to 4MHz.
+    // adc_ker_ck_input is pll2_p_ck, but we will use per_ck. per_ck is sourced
+    // from the 64MHz HSI
     //
     // adc_ker_ck_input is then divided by the ADC prescaler to give f_adc. The
-    // maximum f_adc is 50MHz in VOS0 or 25MHz in VOS1
-    let mut ccdr = rcc
-        .sys_ck(100.MHz())
-        .per_ck(4.MHz())
-        .freeze(pwrcfg, &dp.SYSCFG);
+    // maximum f_adc is 50MHz
+    let mut ccdr = rcc.sys_ck(100.MHz()).freeze(pwrcfg, &dp.SYSCFG);
 
     // Switch adc_ker_ck_input multiplexer to per_ck
     ccdr.peripheral.kernel_adc_clk_mux(AdcClkSel::Per);

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -35,8 +35,8 @@ fn main() -> ! {
     // adc_ker_ck_input is pll2_p_ck, but we will use per_ck. Here we
     // set per_ck to 4MHz.
     //
-    // The maximum adc_ker_ck_input frequency is 100MHz for revision V and 36MHz
-    // otherwise
+    // adc_ker_ck_input is then divided by the ADC prescaler to give f_adc. The
+    // maximum f_adc is 50MHz in VOS0 or 25MHz in VOS1
     let mut ccdr = rcc
         .sys_ck(100.MHz())
         .per_ck(4.MHz())

--- a/examples/adc12.rs
+++ b/examples/adc12.rs
@@ -44,6 +44,7 @@ fn main() -> ! {
     let (adc1, adc2) = adc::adc12(
         dp.ADC1,
         dp.ADC2,
+        4.MHz(),
         &mut delay,
         ccdr.peripheral.ADC12,
         &ccdr.clocks,

--- a/examples/adc12_parallel.rs
+++ b/examples/adc12_parallel.rs
@@ -35,15 +35,12 @@ fn main() -> ! {
     let rcc = dp.RCC.constrain();
 
     // We need to configure a clock for adc_ker_ck_input. The default
-    // adc_ker_ck_input is pll2_p_ck, but we will use per_ck. Here we
-    // set per_ck to 4MHz.
+    // adc_ker_ck_input is pll2_p_ck, but we will use per_ck. per_ck is sourced
+    // from the 64MHz HSI
     //
     // adc_ker_ck_input is then divided by the ADC prescaler to give f_adc. The
-    // maximum f_adc is 50MHz in VOS0 or 25MHz in VOS1
-    let mut ccdr = rcc
-        .sys_ck(100.MHz())
-        .per_ck(4.MHz())
-        .freeze(pwrcfg, &dp.SYSCFG);
+    // maximum f_adc is 50MHz
+    let mut ccdr = rcc.sys_ck(100.MHz()).freeze(pwrcfg, &dp.SYSCFG);
 
     // Switch adc_ker_ck_input multiplexer to per_ck
     ccdr.peripheral.kernel_adc_clk_mux(AdcClkSel::Per);

--- a/examples/adc12_parallel.rs
+++ b/examples/adc12_parallel.rs
@@ -38,8 +38,8 @@ fn main() -> ! {
     // adc_ker_ck_input is pll2_p_ck, but we will use per_ck. Here we
     // set per_ck to 4MHz.
     //
-    // The maximum adc_ker_ck_input frequency is 100MHz for revision V and 36MHz
-    // otherwise
+    // adc_ker_ck_input is then divided by the ADC prescaler to give f_adc. The
+    // maximum f_adc is 50MHz in VOS0 or 25MHz in VOS1
     let mut ccdr = rcc
         .sys_ck(100.MHz())
         .per_ck(4.MHz())

--- a/examples/adc12_parallel.rs
+++ b/examples/adc12_parallel.rs
@@ -58,6 +58,7 @@ fn main() -> ! {
     let (adc1, adc2) = adc::adc12(
         dp.ADC1,
         dp.ADC2,
+        4.MHz(),
         &mut delay,
         ccdr.peripheral.ADC12,
         &ccdr.clocks,

--- a/examples/dac_adc.rs
+++ b/examples/dac_adc.rs
@@ -1,0 +1,90 @@
+//! Example of using the DAC to generate a voltage and the ADC to read it
+//!
+//! Connect a jumper between pins PA4 and PC0
+
+#![no_main]
+#![no_std]
+
+use log::info;
+
+use cortex_m_rt::entry;
+
+use stm32h7xx_hal::{
+    adc, delay::Delay, pac, prelude::*, rcc::rec::AdcClkSel, traits::DacOut,
+};
+
+#[macro_use]
+mod utilities;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = example_power!(pwr).freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+
+    // We need to configure a clock for adc_ker_ck_input. The default
+    // adc_ker_ck_input is pll2_p_ck, but we will use per_ck. per_ck is sourced
+    // from the 64MHz HSI
+    //
+    // adc_ker_ck_input is then divided by the ADC prescaler to give f_adc. The
+    // maximum f_adc is 50MHz
+    let mut ccdr = rcc.sys_ck(50.MHz()).freeze(pwrcfg, &dp.SYSCFG);
+
+    // Switch adc_ker_ck_input multiplexer to per_ck
+    ccdr.peripheral.kernel_adc_clk_mux(AdcClkSel::Per);
+
+    info!("");
+    info!("stm32h7xx-hal example - DAC and ADC");
+    info!("");
+
+    let mut delay = Delay::new(cp.SYST, ccdr.clocks);
+
+    // Setup ADC
+    let mut adc1 = adc::Adc::adc1(
+        dp.ADC1,
+        16.MHz(),
+        &mut delay,
+        ccdr.peripheral.ADC12,
+        &ccdr.clocks,
+    )
+    .enable();
+    adc1.set_resolution(adc::Resolution::SixteenBit);
+
+    // We can't use ADC2 here because ccdr.peripheral.ADC12 has been
+    // consumed. See examples/adc12.rs
+
+    let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
+    let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
+
+    // Setup DAC
+    #[cfg(not(feature = "rm0455"))]
+    let dac = dp.DAC.dac(gpioa.pa4, ccdr.peripheral.DAC12);
+    #[cfg(feature = "rm0455")]
+    let dac = dp.DAC1.dac(gpioa.pa4, ccdr.peripheral.DAC1);
+
+    // Calibrate output buffer then enable DAC channel
+    let mut dac = dac.calibrate_buffer(&mut delay).enable();
+
+    let mut channel = gpioc.pc0.into_analog(); // ANALOG IN 10
+
+    dac.set_value(2048); // set to 50% of vdda
+
+    loop {
+        let reading: u32 = adc1.read(&mut channel).unwrap();
+        // voltage = reading * (vref/resolution)
+        let voltage = reading as f32 * (3.3 / adc1.slope() as f32);
+        info!("ADC reading: {}, voltage for nucleo: {}", reading, voltage);
+
+        // check voltage is really 50% of vdda
+        assert!(voltage - 1.65 < 8.25e-3); // 0.5% error
+    }
+}

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -49,13 +49,19 @@ fn main() -> ! {
 
     // Setup ADC
     #[cfg(not(feature = "rm0455"))]
-    let mut adc =
-        adc::Adc::adc3(dp.ADC3, &mut delay, ccdr.peripheral.ADC3, &ccdr.clocks);
+    let mut adc = adc::Adc::adc3(
+        dp.ADC3,
+        4.MHz(),
+        &mut delay,
+        ccdr.peripheral.ADC3,
+        &ccdr.clocks,
+    );
 
     // On RM0455 parts, the temperature sensor is on ADC2
     #[cfg(feature = "rm0455")]
     let mut adc = adc::Adc::adc2(
         dp.ADC2,
+        4.MHz(),
         &mut delay,
         ccdr.peripheral.ADC12,
         &ccdr.clocks,

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -580,14 +580,6 @@ macro_rules! adc_hal {
                     f_adc
                 }
 
-                /// The current ADC frequency. Defined as f_ADC in device datasheets
-                ///
-                /// The value returned by this method will always be equal or
-                /// lower than the `f_adc` passed to [`init`](#method.init)
-                pub fn frequency(&self) -> Hertz {
-                    self.frequency
-                }
-
                 /// Disables Deeppowerdown-mode and enables voltage regulator
                 ///
                 /// Note: After power-up, a [`calibration`](#method.calibrate) shall be run
@@ -866,6 +858,14 @@ macro_rules! adc_hal {
                     self.set_resolution(Resolution::SixteenBit);
                     self.set_lshift(AdcLshift::default());
                     cfg
+                }
+
+                /// The current ADC frequency. Defined as f_ADC in device datasheets
+                ///
+                /// The value returned by this method will always be equal or
+                /// lower than the `f_adc` passed to [`init`](#method.init)
+                pub fn frequency(&self) -> Hertz {
+                    self.frequency
                 }
 
                 /// Get ADC samping time

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -673,7 +673,17 @@ macro_rules! adc_hal {
                     #[cfg(not(feature = "revision_v"))]
                     self.rb.cr.modify(|_, w| w.boost().set_bit());
                     #[cfg(feature = "revision_v")]
-                    self.rb.cr.modify(|_, w| w.boost().lt50());
+                    self.rb.cr.modify(|_, w| {
+                        if self.frequency.raw() <= 6_250_000 {
+                            w.boost().lt6_25()
+                        } else if self.frequency.raw() <= 12_500_000 {
+                            w.boost().lt12_5()
+                        } else if self.frequency.raw() <= 25_000_000 {
+                            w.boost().lt25()
+                        } else {
+                            w.boost().lt50()
+                        }
+                    });
                 }
 
                 /// Enable ADC

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -572,12 +572,8 @@ macro_rules! adc_hal {
                     #[cfg(not(feature = "revision_v"))]
                     let f_adc = Hertz::from_raw(ker_ck.raw() / divider);
 
-                    // Minimum value for VOS0 VOS1 and VOS2. Consider removing
-                    // for VOS3
-                    assert!(f_adc.raw() >= 120_000);
-
-                    // Maximum value, for VOS0 only. Other voltage scale values
-                    // result in a lower maximum f_adc
+                    // Maximum ADC clock speed. With BOOST = 0 there is a no
+                    // minimum frequency given in part datasheets
                     assert!(f_adc.raw() <= 50_000_000);
 
                     self.frequency = f_adc;

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -72,7 +72,7 @@ pub struct Adc<ADC, ED> {
 ///
 /// Options for the sampling time, each is T + 0.5 ADC clock cycles.
 //
-// Refer to RM0433 Rev 6 - Chapter 24.4.13
+// Refer to RM0433 Rev 7 - Chapter 25.4.13
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[allow(non_camel_case_types)]
@@ -101,7 +101,7 @@ impl AdcSampleTime {
     }
 }
 
-// Refer to RM0433 Rev 6 - Chapter 24.4.13
+// Refer to RM0433 Rev 7 - Chapter 25.4.13
 impl From<AdcSampleTime> for u8 {
     fn from(val: AdcSampleTime) -> u8 {
         match val {
@@ -491,7 +491,7 @@ macro_rules! adc_hal {
                 ///
                 /// Note: After power-up, a [`calibration`](#method.calibrate) shall be run
                 pub fn power_up(&mut self, delay: &mut impl DelayUs<u8>) {
-                    // Refer to RM0433 Rev 6 - Chapter 24.4.6
+                    // Refer to RM0433 Rev 7 - Chapter 25.4.6
                     self.rb.cr.modify(|_, w|
                         w.deeppwd().clear_bit()
                             .advregen().set_bit()
@@ -503,7 +503,7 @@ macro_rules! adc_hal {
                 ///
                 /// Note: This resets the [`calibration`](#method.calibrate) of the ADC
                 pub fn power_down(&mut self) {
-                    // Refer to RM0433 Rev 6 - Chapter 24.4.6
+                    // Refer to RM0433 Rev 7 - Chapter 25.4.6
                     self.rb.cr.modify(|_, w|
                         w.deeppwd().set_bit()
                             .advregen().clear_bit()
@@ -514,7 +514,7 @@ macro_rules! adc_hal {
                 ///
                 /// Note: The ADC must be disabled
                 pub fn calibrate(&mut self) {
-                    // Refer to RM0433 Rev 6 - Chapter 24.4.8
+                    // Refer to RM0433 Rev 7 - Chapter 25.4.8
                     self.check_calibration_conditions();
 
                     // single channel (INNx equals to V_ref-)
@@ -555,7 +555,7 @@ macro_rules! adc_hal {
                 /// Configuration process immediately after enabling the ADC
                 fn configure(&mut self) {
                     // Single conversion mode, Software trigger
-                    // Refer to RM0433 Rev 6 - Chapters 24.4.15, 24.4.19
+                    // Refer to RM0433 Rev 7 - Chapters 25.4.15, 25.4.19
                     self.rb.cfgr.modify(|_, w|
                         w.cont().clear_bit()
                             .exten().disabled()
@@ -564,7 +564,7 @@ macro_rules! adc_hal {
 
                     // Enables boost mode for highest possible clock frequency
                     //
-                    // Refer to RM0433 Rev 6 - Chapter 24.4.3
+                    // Refer to RM0433 Rev 7 - Chapter 25.4.3
                     #[cfg(not(feature = "revision_v"))]
                     self.rb.cr.modify(|_, w| w.boost().set_bit());
                     #[cfg(feature = "revision_v")]
@@ -573,7 +573,7 @@ macro_rules! adc_hal {
 
                 /// Enable ADC
                 pub fn enable(mut self) -> Adc<$ADC, Enabled> {
-                    // Refer to RM0433 Rev 6 - Chapter 24.4.9
+                    // Refer to RM0433 Rev 7 - Chapter 25.4.9
                     self.rb.isr.modify(|_, w| w.adrdy().set_bit());
                     self.rb.cr.modify(|_, w| w.aden().set_bit());
                     while self.rb.isr.read().adrdy().bit_is_clear() {}
@@ -640,7 +640,7 @@ macro_rules! adc_hal {
                 ///
                 /// This method will start reading sequence on the given pin.
                 /// The value can be then read through the `read_sample` method.
-                // Refer to RM0433 Rev 6 - Chapter 24.4.16
+                // Refer to RM0433 Rev 7 - Chapter 25.4.16
                 pub fn start_conversion<PIN>(&mut self, _pin: &mut PIN)
                     where PIN: Channel<$ADC, ID = u8>,
                 {
@@ -655,7 +655,7 @@ macro_rules! adc_hal {
                     // Set LSHIFT[3:0]
                     self.rb.cfgr2.modify(|_, w| w.lshift().bits(self.get_lshift().value()));
 
-                    // Select channel (with preselection, refer to RM0433 Rev 6 - Chapter 24.4.12)
+                    // Select channel (with preselection, refer to RM0433 Rev 7 - Chapter 25.4.12)
                     self.rb.pcsel.modify(|r, w| unsafe { w.pcsel().bits(r.pcsel().bits() | (1 << chan)) });
                     self.set_chan_smp(chan);
                     self.rb.sqr1.modify(|_, w| unsafe {
@@ -672,7 +672,7 @@ macro_rules! adc_hal {
                 ///
                 /// `nb::Error::WouldBlock` in case the conversion is still
                 /// progressing.
-                // Refer to RM0433 Rev 6 - Chapter 24.4.16
+                // Refer to RM0433 Rev 7 - Chapter 25.4.16
                 pub fn read_sample(&mut self) -> nb::Result<u32, Infallible> {
                     let chan = self.current_channel.expect("No channel was selected, use start_conversion first");
 
@@ -681,7 +681,7 @@ macro_rules! adc_hal {
                         return Err(nb::Error::WouldBlock);
                     }
 
-                    // Disable preselection of this channel, refer to RM0433 Rev 6 - Chapter 24.4.12
+                    // Disable preselection of this channel, refer to RM0433 Rev 7 - Chapter 25.4.12
                     self.rb.pcsel.modify(|r, w| unsafe { w.pcsel().bits(r.pcsel().bits() & !(1 << chan)) });
                     self.current_channel = None;
 
@@ -711,7 +711,7 @@ macro_rules! adc_hal {
                 /// Disable ADC
                 pub fn disable(mut self) -> Adc<$ADC, Disabled> {
                     let cr = self.rb.cr.read();
-                    // Refer to RM0433 Rev 6 - Chapter 24.4.9
+                    // Refer to RM0433 Rev 7 - Chapter 25.4.9
                     if cr.adstart().bit_is_set() {
                         self.stop_regular_conversion();
                     }
@@ -824,7 +824,7 @@ macro_rules! adc_hal {
                 /// ...
                 /// LINCALRDYW6 -> result\[5\]
                 pub fn read_linear_calibration_values(&mut self) -> AdcCalLinear {
-                    // Refer to RM0433 Rev 6 - Chapter 24.4.8 (Page 920)
+                    // Refer to RM0433 Rev 7 - Chapter 25.4.8
                     self.check_linear_read_conditions();
 
                     // Read 1st block of linear correction

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -269,7 +269,18 @@ adc_pins!(ADC2,
     gpio::PA5<Analog> => 19,
 );
 
-#[cfg(not(feature = "rm0455"))]
+#[cfg(feature = "rm0455")]
+adc_internal!(
+    [ADC2, ADC12_COMMON];
+
+    Vbat => (14, vbaten),
+    Temperature => (18, vsenseen),
+    Vrefint => (19, vrefen)
+);
+
+// -------- ADC3 --------
+
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 adc_pins!(ADC3,
     // 0, 1 are Pxy_C pins
     gpio::PF9<Analog> => 2,
@@ -288,7 +299,7 @@ adc_pins!(ADC3,
     gpio::PH4<Analog> => 15,
     gpio::PH5<Analog> => 16,
 );
-#[cfg(not(feature = "rm0455"))]
+#[cfg(any(feature = "rm0433", feature = "rm0399"))]
 adc_internal!(
     [ADC3, ADC3_COMMON];
 
@@ -297,13 +308,35 @@ adc_internal!(
     Vrefint => (19, vrefen)
 );
 
-#[cfg(feature = "rm0455")]
-adc_internal!(
-    [ADC2, ADC12_COMMON];
+// ADC 3 not present on RM0455 parts
 
-    Vbat => (14, vbaten),
-    Temperature => (18, vsenseen),
-    Vrefint => (19, vrefen)
+#[cfg(feature = "rm0468")]
+adc_pins!(ADC3,
+    // 0, 1 are Pxy_C pins
+    gpio::PF9<Analog> => 2,
+    gpio::PF7<Analog> => 3,
+    gpio::PF5<Analog> => 4,
+    gpio::PF3<Analog> => 5,
+    gpio::PF10<Analog> => 6,
+    gpio::PF8<Analog> => 7,
+    gpio::PF6<Analog> => 8,
+    gpio::PF4<Analog> => 9,
+    gpio::PC0<Analog> => 10,
+    gpio::PC1<Analog> => 11,
+    gpio::PC2<Analog> => 12,
+    gpio::PH2<Analog> => 13,
+    gpio::PH3<Analog> => 14,
+    gpio::PH4<Analog> => 15,
+    // Although ADC3_INP16 appears in device datasheets (on PH5), RM0468 Rev 7
+    // Figure 231 does not show ADC3_INP16
+);
+#[cfg(feature = "rm0468")]
+adc_internal!(
+    [ADC3, ADC3_COMMON];
+
+    Vbat => (16, vbaten),
+    Temperature => (17, vsenseen),
+    Vrefint => (18, vrefen)
 );
 
 pub trait AdcExt<ADC>: Sized {

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -522,7 +522,9 @@ macro_rules! adc_hal {
                         33..=64 => (64, PRESC_A::Div64),
                         65..=128 => (128, PRESC_A::Div128),
                         129..=256 => (256, PRESC_A::Div256),
-                        _ => panic!(),
+                        _ => panic!("Selecting the ADC clock required a prescaler > 256, \
+                                     which is not possible in hardware. Either increase the ADC \
+                                     clock frequency or decrease the kernel clock frequency"),
                     };
                     unsafe { &*$ADC_COMMON::ptr() }.ccr.modify(|_, w| w.presc().variant(presc));
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -536,6 +536,10 @@ macro_rules! adc_hal {
                     #[cfg(not(feature = "revision_v"))]
                     let f_adc = Hertz::from_raw(ker_ck.raw() / divider);
 
+                    // Minimum value for VOS0 VOS1 and VOS2. Consider removing
+                    // for VOS3
+                    assert!(f_adc.raw() >= 120_000);
+
                     // Maximum value, for VOS0 only. Other voltage scale values
                     // result in a lower maximum f_adc
                     assert!(f_adc.raw() <= 50_000_000);


### PR DESCRIPTION
Use the prescaler to set the fastest ADC clock below or equal to this limit

Addresses #374 

TODO:
- [x] ~Don't use Boost mode below 20MHz~ Set `BOOST` based on f_adc
- [x] Helpful panic message if calculated prescaler > 256
- [x] Check the ~f_ADC~ kernel clock frequency based on the current voltage scale, not just VOS0
- [x] ~Check minimum f_ADC~ There is no minimum with `BOOST = 0`
- ~Support CKMODE[1:0]~
- [x] Changelog
- [ ] ~Also check that the relevant pll output divider is even. Though that may require more fields and code in `ccdr.clocks`.~