### PR TITLE
Pwm channels cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * octospi: add support for octospi1 on rm0455 parts [#370]
 * serial: add support for uart9 and usart10 [#370]
 
+
+
+* pwm: Remove `POL` and `NPOL` generic type parameters from `Pwm` types [#381]
+
 ## [v0.12.2] 2022-05-06
 
 * gpio: Fix `with_<mode>` methods [#359]

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1019,8 +1019,12 @@ macro_rules! pwm_ext_hal {
 
 // Implement PWM configuration for timer
 macro_rules! tim_hal {
-    ($($TIMX:ident: ($timX:ident, $Rec:ident,
-                     $typ:ty, $bits:expr $(, DIR: $cms:ident)* $(, BDTR: $bdtr:ident, $moe_set:ident, $af1:ident, $bkinp_setting:ident $(, $bk2inp_setting:ident)*)*),)+) => {
+    ($($TIMX:ident: ($timX:ident, $Rec:ident, $typ:ty, $bits:expr
+        $(, DIR: $cms:ident)?
+        $(, BDTR: $bdtr:ident, $moe_set:ident, $af1:ident, $bkinp_setting:ident
+            $(, $bk2inp_setting:ident)?
+        )?
+    ),)+) => {
         $(
             pwm_ext_hal!($TIMX: $timX, $Rec);
 
@@ -1058,7 +1062,7 @@ macro_rules! tim_hal {
                     tim.$bdtr.write(|w|
                                    w.moe().$moe_set()
                     );
-                )*
+                )?
 
                 tim.cr1.write(|w|
                           w.cen().enabled()
@@ -1166,7 +1170,7 @@ macro_rules! tim_hal {
                                 //  BKINP should make input active high (BDTR BKP will set polarity), bit value varies timer to timer
                                 tim.af2.write(|w| w.bk2ine().set_bit().bk2inp().$bk2inp_setting());
                             }
-                        )*
+                        )?
                         else {
                             // Safety: the DTG field of BDTR allows any 8-bit deadtime value and the dtg variable is u8
                             unsafe {
@@ -1178,7 +1182,7 @@ macro_rules! tim_hal {
                         // Set CCxP = OCxREF / CCxNP = !OCxREF
                         // Refer to RM0433 Rev 6 - Table 324.
                         tim.$bdtr.modify(|_, w| w.moe().$moe_set());
-                    )*
+                    )?
 
 
                     $(
@@ -1187,7 +1191,7 @@ macro_rules! tim_hal {
                             Alignment::Right => { tim.cr1.modify(|_, w| w.dir().down()); },
                             Alignment::Center => { tim.cr1.modify(|_, w| w.$cms().center_aligned3()); }
                         }
-                    )*
+                    )?
 
                     tim.cr1.modify(|_, w| w.cen().enabled());
 
@@ -1248,7 +1252,7 @@ macro_rules! tim_hal {
 
                         self
                     }
-                )*
+                )?
 
                 #[must_use]
                 pub fn left_aligned(mut self) -> Self {
@@ -1276,7 +1280,7 @@ macro_rules! tim_hal {
 
                         self
                     }
-                )*
+                )?
             }
 
             // Timers with break/fault, dead time, and complimentary capabilities
@@ -1317,7 +1321,7 @@ macro_rules! tim_hal {
                         tim.$bdtr.modify(|_, w| w.moe().clear_bit());
                     }
                 }
-            )*
+            )?
         )+
     }
 }

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1239,10 +1239,10 @@ macro_rules! tim_hal {
                 $(
                     /// Set the deadtime for complementary PWM channels of this timer
                     #[must_use]
-                    pub fn with_deadtime<T: Into<NanoSeconds>>(mut self, deadtime: T) -> Self {
+                    pub fn with_deadtime(mut self, deadtime: NanoSeconds) -> Self {
                         // $bdtr is an Ident that only exists for timers with deadtime, so we can use it as a variable name to
                         // only implement this method for timers that support deadtime.
-                        let $bdtr = deadtime.into();
+                        let $bdtr = deadtime;
 
                         self.deadtime = $bdtr;
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1276,10 +1276,10 @@ macro_rules! tim_hal {
                 $(
                     /// Set the deadtime for complementary PWM channels of this timer
                     #[must_use]
-                    pub fn with_deadtime(mut self, deadtime: NanoSeconds) -> Self {
+                    pub fn with_deadtime<T: Into<NanoSeconds>>(mut self, deadtime: T) -> Self {
                         // $bdtr is an Ident that only exists for timers with deadtime, so we can use it as a variable name to
                         // only implement this method for timers that support deadtime.
-                        let $bdtr = deadtime;
+                        let $bdtr = deadtime.into();
 
                         self.deadtime = $bdtr;
 


### PR DESCRIPTION
I can't find any sense `Polarity` to be part of channel type because it doesn't affect on what traits and methods can be implemented on type. So I've removed `ActionLow` and `ActionHigh` from type and added `set_polarity` and `set_comp_polarity` runtime methods.
