### PR TITLE
flash: fence ordering to ensure pg bit is set before write to flash memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* flash: Use Ordering fence to prevent inconsistency errors when writing to flash sector [#382]
 * flash: Rewrite `write_sector` to correctly write data in 256 bit chunks [#371]
 * iwdt: Added HAL implementation. Changed the name of the other implementation to `system_watchdog` [#376]
 * pac: Upgrade to stm32-rs v0.15.1 [#370]

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -164,8 +164,8 @@ impl Bank {
     /// The number of bytes within the bank
     pub fn size(&self) -> usize {
         match *self {
-            Bank::UserBank1 => (BANK1_ADDR_END - BANK1_ADDR_START),
-            Bank::UserBank2 => (BANK2_ADDR_END - BANK2_ADDR_START),
+            Bank::UserBank1 => BANK1_ADDR_END - BANK1_ADDR_START,
+            Bank::UserBank2 => BANK2_ADDR_END - BANK2_ADDR_START,
         }
     }
     /// The number of sectors within the bank, including sector zero
@@ -440,19 +440,19 @@ impl Flash {
         // Ensure no effective write, erase or option byte change operation is ongoing
         while regs.sr.read().bsy().bit_is_set() {}
 
-        // 1. Clear all the error flags due to previous programming/erase operation. Refer to Section 4.7: FLASH error management for details.
+        // Clear all the error flags due to previous programming/erase operation. Refer to Section 4.7: FLASH error management for details.
         clear_error_flags(regs);
 
-        // 2. Unlock the FLASH_CR1/2 register, as described in Section 4.5.1: FLASH configuration protection (only if register is not already unlocked).
+        // Unlock the FLASH_CR1/2 register, as described in Section 4.5.1: FLASH configuration protection (only if register is not already unlocked).
         self.unlock(bank)?;
 
-        // 3. Enable double-word parallelism.
-        unsafe { regs.cr.modify(|_, w| w.psize().bits(0b11)) }
-
-        // 4. Enable write operations by setting the PG1/2 bit in the FLASH_CR1/2 register.
+        // Enable write operations by setting the PG1/2 bit in the FLASH_CR1/2 register.
         regs.cr.modify(|_, w| w.pg().set_bit());
 
-        // 5. Check the protection of the targeted memory area.
+        // Enable double-word parallelism.
+        unsafe { regs.cr.modify(|_, w| w.psize().bits(0b11)) }
+
+        // Check the protection of the targeted memory area.
         // SKIP: In standard mode the entire UserBank1 and UserBank2 should have no write protections
 
         let mut addr = bank.sector_address(sector) as *mut u32;
@@ -460,7 +460,7 @@ impl Flash {
         // Offset it by the start position
         addr = unsafe { addr.add(start / 4) };
 
-        // 6. Write a double-word corresponding to 32-byte data starting at a 32-byte aligned address.
+        // Write a double-word corresponding to 32-byte data starting at a 32-byte aligned address.
         for chunk in data.chunks_exact(32) {
             if addr as usize > bank.end_address() {
                 // Unable to write outside of the bank end address
@@ -479,19 +479,18 @@ impl Flash {
                 }
             }
 
-            // 7. Wait until the write buffer is complete (WBNE1/WBNE2) and all operations have finished (QW1/QW2).
+            // Wait until the write buffer is complete (WBNE1/WBNE2) and all operations have finished (QW1/QW2).
             while {
                 let sr = regs.sr.read();
                 sr.wbne().bit_is_set() | sr.qw().bit_is_set()
             } {}
         }
 
-        // 8. Cleanup by clearing the PG bit
+        // Cleanup by clearing the PG bit and relocking the bank
         regs.cr.modify(|_, w| w.pg().clear_bit());
-
         self.lock(bank);
 
-        // 9. Check all the error flags due to previous programming/erase operation. Refer to Section 4.7: FLASH error management for details.
+        // Check all the error flags due to previous programming/erase operation. Refer to Section 4.7: FLASH error management for details.
         handle_illegal(self.bank_registers(bank))?;
 
         Ok(())
@@ -520,6 +519,8 @@ fn clear_error_flags(regs: &BANK) {
             .set_bit()
             .rdserr()
             .set_bit()
+            .incerr()
+            .set_bit()
     })
 }
 
@@ -529,10 +530,10 @@ fn clear_error_flags(regs: &BANK) {
     not(feature = "stm32h750v")
 ))]
 /// Handle illegal status flags
-/// TODO: Clear error flags
 fn handle_illegal(regs: &BANK) -> Result<(), Error> {
     let sr = regs.sr.read();
     let mut bank_err = BankError::empty();
+
     if sr.pgserr().bit_is_set() {
         bank_err |= BankError::PROGRAMMING_SEQUENCE;
     }


### PR DESCRIPTION
Following from issue: https://github.com/stm32-rs/stm32h7xx-hal/issues/382

The following code in certain circumstances yields a `BankError::PROGRAMMING_SEQUENCE`:

```rust
let mut buffer: [u8; 256] = [0xFF; 256];
// ... fill buffer with data
flash.erase_sector(Bank::UserBank2, 7).unwrap();
flash
    .write_sector(Bank::UserBank2, 7, 0, &buffer)
    .unwrap();
```

Reading the PM0433 reference manual; 4.7.3:

```
Programming sequence error (PGSERR):

More specifically, PGSERR1/2 flag is set if one of below conditions is met:
• A write operation is requested but the program enable bit (PG1/2) has not been set in FLASH_CR1/2 register prior to the request.
• The inconsistency error (INCERR1/2) has not been cleared to 0 before requesting a new write operation.
```

**_Solution:_**

I've found that enabling the Program Enable Bit _before_ enabling parallelism resolves this issue.

Additionally I have fixed some clippy related issues and clarified some comments


