### PR TITLE
Bugfix for I2C transaction stop conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* i2c: Fix stop condition not awaited bug [#402]
+
 ## [v0.13.0] 2022-10-06
 
 * **Breaking** Require frequency when initialising adc, use this to set the prescaler [#379]

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -631,7 +631,8 @@ macro_rules! i2c {
                         *byte = self.i2c.rxdr.read().rxdata().bits();
                     }
 
-                    // automatic STOP
+                    // Wait until the read finishes
+                    busy_wait!(self.i2c, busy, is_not_busy);
 
                     Ok(())
                 }
@@ -657,7 +658,8 @@ macro_rules! i2c {
                         *byte = self.i2c.rxdr.read().rxdata().bits();
                     }
 
-                    // automatic STOP
+                    // Wait until the read finishes
+                    busy_wait!(self.i2c, busy, is_not_busy);
 
                     Ok(())
                 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -631,7 +631,7 @@ macro_rules! i2c {
                         *byte = self.i2c.rxdr.read().rxdata().bits();
                     }
 
-                    // Wait until the read finishes
+                    // Wait for automatic stop
                     busy_wait!(self.i2c, busy, is_not_busy);
 
                     Ok(())
@@ -658,7 +658,7 @@ macro_rules! i2c {
                         *byte = self.i2c.rxdr.read().rxdata().bits();
                     }
 
-                    // Wait until the read finishes
+                    // Wait for automatic stop
                     busy_wait!(self.i2c, busy, is_not_busy);
 
                     Ok(())

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -585,6 +585,9 @@ macro_rules! i2c {
                     // Stop
                     self.master_stop();
 
+                    // Wait for stop
+                    busy_wait!(self.i2c, busy, is_not_busy);
+
                     Ok(())
                 }
             }


### PR DESCRIPTION
Simply wait until the busy flag is released. Now the stop condition occurs (right before the next start condition in the case of successive writereads). 
Fixes #401 