### PR TITLE
Add halfduplex to serial::config::Config and example

### DIFF
--- a/examples/serial-halfduplex.rs
+++ b/examples/serial-halfduplex.rs
@@ -71,14 +71,14 @@ fn main() -> ! {
     loop {
         // Tx from usart3
         for c in "Hello, world!".chars() {
-            let _res = block!(usart3.write(c as u8)).unwrap();
+            block!(usart3.write(c as u8)).unwrap();
             let received = block!(usart6.read()).unwrap();
             info!("usart6 rx {}", received as char);
         }
 
         // Tx from usart6
         for c in "Hello, world!".chars() {
-            let _res = block!(usart6.write(c as u8)).unwrap();
+            block!(usart6.write(c as u8)).unwrap();
             let received = block!(usart3.read()).unwrap();
             info!("usart3 rx {}", received as char);
         }

--- a/examples/serial-halfduplex.rs
+++ b/examples/serial-halfduplex.rs
@@ -1,0 +1,86 @@
+//! Example of half-duplex USART communication between two USART's.
+//!
+//! Connect the USART3_TX (PC10) and USART6_TX (PC6) and an external pullup resistor together.
+//! i.e., connect one end of a resistor to a 3.3V pin and connect both PC10 and PC6 pins to the other end
+//! of the resistor. 330 ohm resistor worked but exact value is not critical.
+//!
+//! It will print "Hello, world!" over and over again one character at a time.
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::entry;
+#[macro_use]
+mod utilities;
+use log::info;
+
+use stm32h7xx_hal::{pac, prelude::*, serial};
+
+use nb::block;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = example_power!(pwr).freeze();
+
+    // Constrain and Freeze clock
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(160.MHz()).freeze(pwrcfg, &dp.SYSCFG);
+
+    // Acquire the GPIOC peripheral. This also enables the clock for
+    // GPIOC in the RCC register.
+    let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
+
+    let usart3txpin = gpioc.pc10.into_alternate::<7>();
+    let usart3rxpin = gpioc.pc11.into_alternate::<7>();
+    let usart6txpin = gpioc.pc6.into_alternate::<7>();
+    let usart6rxpin = gpioc.pc7.into_alternate::<7>();
+
+    info!("stm32h7xx-hal example - USART half-duplex");
+
+    // Configure the serial peripheral.
+    let config = serial::config::Config::new(9600.bps())
+        .parity_none()
+        .halfduplex(true)
+        .stopbits(serial::config::StopBits::Stop1);
+
+    let mut usart3 = dp
+        .USART3
+        .serial(
+            (usart3txpin, usart3rxpin),
+            config,
+            ccdr.peripheral.USART3,
+            &ccdr.clocks,
+        )
+        .unwrap();
+
+    let mut usart6 = dp
+        .USART6
+        .serial(
+            (usart6txpin, usart6rxpin),
+            config,
+            ccdr.peripheral.USART6,
+            &ccdr.clocks,
+        )
+        .unwrap();
+
+    loop {
+        // Tx from usart3
+        for c in "Hello, world!".chars() {
+            let _res = block!(usart3.write(c as u8)).unwrap();
+            let received = block!(usart6.read()).unwrap();
+            info!("usart6 rx {}", received as char);
+        }
+
+        // Tx from usart6
+        for c in "Hello, world!".chars() {
+            let _res = block!(usart6.write(c as u8)).unwrap();
+            let received = block!(usart3.read()).unwrap();
+            info!("usart3 rx {}", received as char);
+        }
+    }
+}

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -19,6 +19,7 @@ use nb::block;
 use stm32::usart1::cr2::{
     CLKEN_A, CPHA_A, CPOL_A, LBCL_A, MSBFIRST_A, RXINV_A, TXINV_A,
 };
+use stm32::usart1::cr3::HDSEL_A;
 
 use crate::gpio::{self, Alternate};
 use crate::rcc::{rec, CoreClocks, ResetEnable};
@@ -144,6 +145,7 @@ pub mod config {
         pub inverttx: bool,
         pub rxfifothreshold: FifoThreshold,
         pub txfifothreshold: FifoThreshold,
+        pub halfduplex: bool,
     }
 
     impl Config {
@@ -165,6 +167,7 @@ pub mod config {
                 inverttx: false,
                 rxfifothreshold: FifoThreshold::Eighth,
                 txfifothreshold: FifoThreshold::Eighth,
+                halfduplex: false,
             }
         }
 
@@ -254,6 +257,12 @@ pub mod config {
             txfifothreshold: FifoThreshold,
         ) -> Self {
             self.txfifothreshold = txfifothreshold;
+            self
+        }
+
+        /// If `true`, sets to half-duplex mode
+        pub fn halfduplex(mut self, halfduplex: bool) -> Self {
+            self.halfduplex = halfduplex;
             self
         }
     }
@@ -649,6 +658,15 @@ macro_rules! usart {
                     unsafe {
                         self.usart.cr3.modify(|_, w| w.txftcfg().bits(fifo_threshold_bits));
                     }
+
+                    // Configure half-duplex mode
+                    self.usart.cr3.modify(|_, w| {
+                        w.hdsel().variant(if config.halfduplex {
+                            HDSEL_A::Selected
+                        } else {
+                            HDSEL_A::NotSelected
+                        })
+                    });
 
                     // Configure serial mode
                     self.usart.cr2.write(|w| {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -605,6 +605,14 @@ macro_rules! usart {
                     let mut serial = Serial { usart, ker_ck };
                     let config = config.into();
                     serial.usart.cr1.reset();
+
+                    // If synchronous mode is supported, check that it is not
+                    // enabled alongside half duplex mode
+                    $(
+                        if config.halfduplex & $synchronous {
+                            return Err(config::InvalidConfig);
+                        }
+                    )?
                     serial.configure(&config $(, $synchronous )?);
 
                     Ok(serial)


### PR DESCRIPTION
This allows the USART's to be used with serial devices that operate in a half-duplex mode (transmit and receive on one wire). An example was also added (serial-halfduplex) and has been tested with a NUCLEO-H723ZG board. It has also been tested with a Frysky RX4R RC receiver Smart Port interface.