### PR TITLE
make `Alternate` variants readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* Alternate pins are readable. [#409]
 
 ## [v0.13.1] 2022-11-06
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -152,7 +152,7 @@ impl From<AdcSampleTime> for u8 {
 /// ADC LSHIFT\[3:0\] of the converted value
 ///
 /// Only values in range of 0..=15 are allowed.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdcLshift(u8);
 
@@ -163,10 +163,6 @@ impl AdcLshift {
         }
 
         AdcLshift(lshift)
-    }
-
-    pub fn default() -> Self {
-        AdcLshift(0)
     }
 
     pub fn value(self) -> u8 {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -190,6 +190,7 @@ mod marker {
 impl<MODE> marker::Interruptable for Output<MODE> {}
 impl marker::Interruptable for Input {}
 impl marker::Readable for Input {}
+impl<const A: u8, MODE> marker::Readable for Alternate<A, MODE> {}
 impl marker::Readable for Output<OpenDrain> {}
 impl marker::Active for Input {}
 impl<Otype> marker::OutputSpeed for Output<Otype> {}

--- a/src/sai/i2s.rs
+++ b/src/sai/i2s.rs
@@ -668,7 +668,7 @@ fn i2s_config_channel(
     unsafe {
         audio_ch.cr1.modify(|_, w| {
             w.mode()
-                .bits(mode_bits as u8)
+                .bits(mode_bits)
                 .prtcfg()
                 .free()
                 .ds()


### PR DESCRIPTION
- allows us to read any alternate pin
- no longer have to read `Alternate` registers manually
- I am not super familiar with the ref manual, so if anyone has any other thoughts/criticism I would love to hear.