### PR TITLE
add VSC settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ Cargo.lock
 *.bin
 .gdb_history
 Embed.toml
-**/*.vscode
+.vscode/*
+!.vscode/settings.json
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "rust-analyzer.cargo.features": [
+        "rt",
+        "stm32h743v",
+    ],
+    "rust-analyzer.checkOnSave.features": [
+        "rt",
+        "stm32h743v",
+    ],
+    "rust-analyzer.checkOnSave.allTargets": false,
+    "rust-analyzer.checkOnSave.target": "thumbv7em-none-eabihf",
+    "rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
+}


### PR DESCRIPTION
- add VSC settings
- helps contributers be able to work out of the box
- currently `clippy` and `rust-analyzer` do not work out of the box