### PR TITLE
Improve documentation rendering of feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ exclude = [".gitignore"]
 [package.metadata.docs.rs]
 features = ["stm32h743v", "rt", "xspi", "sdmmc", "fmc", "usb_hs", "rtc", "ethernet", "ltdc", "crc", "rand", "can", "defmt", "log", "fugit/defmt"]
 targets = ["thumbv7em-none-eabihf"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 fugit = "0.3.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 //! * [`defmt`](https://defmt.ferrous-systems.com/) formatting for some types can be enabled with the feature `defmt`.
 
 #![cfg_attr(not(test), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(non_camel_case_types)]
 
 extern crate paste;
@@ -140,13 +141,16 @@ pub use crate::stm32 as device;
 
 // Enable use of interrupt macro
 #[cfg(feature = "rt")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
 pub use crate::stm32::interrupt;
 
 #[cfg(feature = "device-selected")]
 pub mod adc;
 #[cfg(all(feature = "device-selected", feature = "can"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "can")))]
 pub mod can;
 #[cfg(all(feature = "device-selected", feature = "crc"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "crc")))]
 pub mod crc;
 #[cfg(feature = "device-selected")]
 pub mod dac;
@@ -159,12 +163,14 @@ pub mod dma;
     feature = "ethernet",
     not(feature = "rm0455")
 ))]
+#[cfg_attr(docsrs, doc(cfg(feature = "ethernet")))]
 pub mod ethernet;
 #[cfg(feature = "device-selected")]
 pub mod exti;
 #[cfg(feature = "device-selected")]
 pub mod flash;
 #[cfg(all(feature = "device-selected", feature = "fmc"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "fmc")))]
 pub mod fmc;
 #[cfg(feature = "device-selected")]
 pub mod gpio;
@@ -173,6 +179,7 @@ pub mod i2c;
 #[cfg(feature = "device-selected")]
 pub mod independent_watchdog;
 #[cfg(all(feature = "device-selected", feature = "ltdc"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "ltdc")))]
 pub mod ltdc;
 #[cfg(feature = "device-selected")]
 pub mod prelude;
@@ -187,10 +194,12 @@ pub mod rcc;
 #[cfg(feature = "device-selected")]
 pub mod rng;
 #[cfg(all(feature = "device-selected", feature = "rtc"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "rtc")))]
 pub mod rtc;
 #[cfg(feature = "device-selected")]
 pub mod sai;
 #[cfg(all(feature = "device-selected", feature = "sdmmc"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "sdmmc")))]
 pub mod sdmmc;
 #[cfg(feature = "device-selected")]
 pub mod serial;
@@ -205,8 +214,10 @@ pub mod time;
 #[cfg(feature = "device-selected")]
 pub mod timer;
 #[cfg(all(feature = "device-selected", feature = "usb_hs"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "usb_hs")))]
 pub mod usb_hs;
 #[cfg(all(feature = "device-selected", feature = "xspi"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "xspi")))]
 pub mod xspi;
 
 #[cfg(feature = "device-selected")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,14 +3,17 @@ pub use embedded_hal::prelude::*;
 
 pub use crate::adc::AdcExt as _stm32h7xx_hal_adc_AdcExt;
 #[cfg(feature = "can")]
+#[cfg_attr(docsrs, doc(cfg(feature = "can")))]
 pub use crate::can::CanExt as _stm32h7xx_hal_can_CanExt;
 #[cfg(feature = "crc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crc")))]
 pub use crate::crc::CrcExt as _stm32h7xx_hal_crc_CrcExt;
 pub use crate::dac::DacExt as _stm32h7xx_hal_dac_DacExt;
 pub use crate::delay::DelayExt as _stm32h7xx_hal_delay_DelayExt;
 pub use crate::exti::ExtiExt as _stm32h7xx_hal_delay_ExtiExt;
 pub use crate::flash::FlashExt as _stm32h7xx_hal_flash_FlashExt;
 #[cfg(feature = "fmc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fmc")))]
 pub use crate::fmc::FmcExt as _stm32h7xx_hal_fmc_FmcExt;
 pub use crate::gpio::GpioExt as _stm32h7xx_hal_gpio_GpioExt;
 pub use crate::i2c::I2cExt as _stm32h7xx_hal_i2c_I2cExt;
@@ -24,6 +27,7 @@ pub use crate::sai::SaiDmaExt as _stm32h7xx_hal_spi_SaiDmaExt;
 pub use crate::sai::SaiI2sExt as _stm32h7xx_hal_spi_SaiI2sExt;
 pub use crate::sai::SaiPdmExt as _stm32h7xx_hal_spi_SaiPdmExt;
 #[cfg(feature = "sdmmc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sdmmc")))]
 pub use crate::sdmmc::SdmmcExt as _stm32h7xx_hal_sdmmc_SdmmcExt;
 pub use crate::serial::SerialExt as _stm32h7xx_hal_serial_SerialExt;
 pub use crate::spi::HalDisabledSpi as _stm32h7xx_hal_spi_HalDisabledSpi;
@@ -33,5 +37,6 @@ pub use crate::spi::SpiExt as _stm32h7xx_hal_spi_SpiExt;
 pub use crate::time::U32Ext as _stm32h7xx_hal_time_U32Ext;
 pub use crate::timer::TimerExt as _stm32h7xx_hal_timer_TimerExt;
 #[cfg(all(feature = "xspi"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "xspi")))]
 pub use crate::xspi::XspiExt as _stm32h7xx_hal_xspi_XspiExt;
 pub use fugit::{ExtU32 as _, RateExtU32 as _};

--- a/src/rcc/backup.rs
+++ b/src/rcc/backup.rs
@@ -26,6 +26,7 @@
 #[non_exhaustive]
 pub struct BackupREC {
     #[cfg(feature = "rtc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rtc")))]
     pub RTC: Rtc,
     backup_regulator: bool,
 }
@@ -54,9 +55,11 @@ impl BackupREC {
 }
 
 #[cfg(feature = "rtc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rtc")))]
 pub use rtc::{Rtc, RtcClkSel};
 
 #[cfg(feature = "rtc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rtc")))]
 mod rtc {
     use crate::rcc::rec::ResetEnable;
     use crate::stm32::RCC;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -228,6 +228,7 @@ rng_core_large!(usize);
 
 // rand_core
 #[cfg(feature = "rand")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 impl rand_core::RngCore for Rng {
     /// Generate a random u32
     /// Panics if RNG fails.
@@ -264,4 +265,5 @@ impl rand_core::RngCore for Rng {
 }
 
 #[cfg(feature = "rand")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 impl rand_core::CryptoRng for Rng {}

--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -1228,6 +1228,7 @@ macro_rules! sdmmc {
                 }
 
                 #[cfg(feature = "sdmmc-fatfs")]
+                #[cfg_attr(docsrs, doc(cfg(feature = "sdmmc-fatfs")))]
                 pub fn sdmmc_block_device(self) -> SdmmcBlockDevice<Sdmmc<$SDMMCX, SdCard>> {
                     SdmmcBlockDevice {
                         sdmmc: core::cell::RefCell::new(self)
@@ -1236,6 +1237,7 @@ macro_rules! sdmmc {
             }
 
             #[cfg(feature = "sdmmc-fatfs")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "sdmcc-fatfs")))]
             impl embedded_sdmmc::BlockDevice for SdmmcBlockDevice<Sdmmc<$SDMMCX, SdCard>> {
                 type Error = Error;
 

--- a/src/usb_hs.rs
+++ b/src/usb_hs.rs
@@ -1,7 +1,5 @@
 //! USB OTG peripherals
 //!
-//! Requires the `usb_hs` feature.
-//!
 //! ## ULPI Transciever Delay
 //!
 //! Some ULPI PHYs like the Microchip USB334x series require a delay between the


### PR DESCRIPTION
Uses docrs attributes to highlight items behind a feature flag. There's more info [here](https://users.rust-lang.org/t/how-to-document-optional-features-in-api-docs/64577)