### PR TITLE
Minor fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 exclude = [".gitignore"]
 
 [package.metadata.docs.rs]
-features = ["stm32h743v", "rt", "xspi", "sdmmc", "fmc", "usb_hs", "rtc", "ethernet", "ltdc", "crc", "rand", "can", "defmt", "log", "fugit/defmt"]
+features = ["stm32h743v", "rt", "xspi", "sdmmc", "sdmmc-fatfs", "fmc", "usb_hs", "rtc", "ethernet", "ltdc", "crc", "rand", "can", "defmt", "log", "fugit/defmt"]
 targets = ["thumbv7em-none-eabihf"]
 
 [dependencies]

--- a/src/xspi/octospi.rs
+++ b/src/xspi/octospi.rs
@@ -75,7 +75,7 @@ impl HyperbusConfig {
     pub fn device_size_bytes(mut self, size_order: u8) -> Self {
         debug_assert!(size_order > 4, "Memory size must be at least 32 bytes");
         debug_assert!(
-            size_order <= 26,
+            size_order <= 28,
             "Maximum memory size that can be mapped is 256 MBytes"
         );
 


### PR DESCRIPTION
- [x] Add sdmmc-fatfs flag to docs.rs documentation render
- [x] Maximum Hyperbus memory size is 256MB
- [x] ~Update depreciated methods in chrono~