### PR TITLE
pwr: remove unused parameter

### DIFF
--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -396,7 +396,7 @@ impl Pwr {
         any(feature = "rm0433", feature = "rm0399", feature = "rm0468")
     ))]
     #[must_use]
-    pub fn vos0(mut self, _: &SYSCFG) -> Self {
+    pub fn vos0(mut self) -> Self {
         self.target_vos = VoltageScale::Scale0;
         self
     }


### PR DESCRIPTION
`Pwr::vos0` is the only function in Pwr that takes an unused reference to `SYSCFG`. I suppose it remained undetected because of the `_` as it's name.

This removes the parameter and makes it the same as `Pwr::vos{1,2,3}`.