### PR TITLE
Draft: bump all deps except smoltcp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 fugit = "0.3.5"
 embedded-hal = { version = "0.2.6", features = ["unproven"] }
 embedded-dma = "0.2.0"
-cortex-m = "^0.7.4"
+cortex-m = { version = "^0.7.7", features = ["critical-section-single-core"] }
 defmt = { version = ">=0.2.0,<0.4", optional = true }
 stm32h7 = { version = "^0.15.1", default-features = false }
 void = { version = "1.0.2", default-features = false }
@@ -45,7 +45,7 @@ synopsys-usb-otg = { version = "^0.3.0", features = ["cortex-m"], optional = tru
 embedded-display-controller = { version = "^0.1.0", optional = true }
 log = { version = "0.4.14", optional = true} # see also the dev-dependencies section
 fdcan = { version = "0.1", optional = true }
-bitflags = { version = "1.3.2" }
+bitflags = { version = "2.0.0" }
 embedded-storage = "0.3"
 
 [dependencies.smoltcp]
@@ -71,10 +71,10 @@ log = "0.4.11"
 panic-halt = "0.2.0"
 panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }
 cfg-if = "1.0.0"
-rtt-target = { version = "0.3.1", features = ["cortex-m"] }
+rtt-target = "0.4.0"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
-cortex-m-log = { version = "~0.7.0", features = ["itm", "semihosting", "log-integration"] }
-cortex-m-semihosting = "0.3.5"
+cortex-m-log = { version = "0.8.0", features = ["itm", "semihosting", "log-integration"] }
+cortex-m-semihosting = "0.5.0"
 panic-itm = { version = "~0.4.1" }
 panic-semihosting = "0.6"
 usb-device = "0.2.5"


### PR DESCRIPTION
<details>
  <summary>cargo outdated</summary>

  ```terminal
Name     Project  Compat  Latest  Kind    Platform
----     -------  ------  ------  ----    --------
smoltcp  0.8.2    ---     0.9.1   Normal  ---
  ```
</details>

<details>
  <summary>cargo duplicates</summary>

  ```terminal
Package        Versions
-------        --------
bare-metal     1.0.0   0.2.5
bitflags       2.0.0   1.3.2
nb             1.1.0   0.1.3
rtt-target     0.4.0   0.3.1
rustc_version  0.4.0   0.2.3
semver         1.0.17  0.9.0
spin           0.9.6   0.5.2

bare-metal 1.0.0:
- Because of stm32h7xx-hal 0.13.1 => cortex-m-rtic 1.1.4 => bare-metal 1.0.0
- Because of stm32h7xx-hal 0.13.1 => stm32h7 0.15.1 => bare-metal 1.0.0
- Because of stm32h7xx-hal 0.13.1 => bare-metal 1.0.0
bare-metal 0.2.5:
- Because of stm32h7xx-hal 0.13.1 => cortex-m-log 0.8.0 => cortex-m 0.7.7 => bare-metal 0.2.5
- Because of stm32h7xx-hal 0.13.1 => cortex-m-rtic 1.1.4 => cortex-m 0.7.7 => bare-metal 0.2.5
- Because of stm32h7xx-hal 0.13.1 => cortex-m-log 0.8.0 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => bare-metal 0.2.5
- Because of stm32h7xx-hal 0.13.1 => panic-semihosting 0.6.0 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => bare-metal 0.2.5
- Because of stm32h7xx-hal 0.13.1 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => bare-metal 0.2.5
- Because of stm32h7xx-hal 0.13.1 => panic-itm 0.4.2 => cortex-m 0.7.7 => bare-metal 0.2.5
- Because of stm32h7xx-hal 0.13.1 => panic-rtt-target 0.1.2 => cortex-m 0.7.7 => bare-metal 0.2.5
- Because of stm32h7xx-hal 0.13.1 => panic-semihosting 0.6.0 => cortex-m 0.7.7 => bare-metal 0.2.5
- Because of stm32h7xx-hal 0.13.1 => stm32h7 0.15.1 => cortex-m 0.7.7 => bare-metal 0.2.5
- Because of stm32h7xx-hal 0.13.1 => cortex-m 0.7.7 => bare-metal 0.2.5
- Because of stm32h7xx-hal 0.13.1 => synopsys-usb-otg 0.3.2 => cortex-m 0.7.7 => bare-metal 0.2.5

bitflags 2.0.0:
- Because of stm32h7xx-hal 0.13.1 => bitflags 2.0.0
bitflags 1.3.2:
- Because of stm32h7xx-hal 0.13.1 => defmt 0.3.2 => bitflags 1.3.2
- Because of stm32h7xx-hal 0.13.1 => fdcan 0.1.2 => bitflags 1.3.2
- Because of stm32h7xx-hal 0.13.1 => smoltcp 0.8.2 => bitflags 1.3.2

nb 1.1.0:
- Because of stm32h7xx-hal 0.13.1 => fdcan 0.1.2 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => cortex-m-log 0.8.0 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => cortex-m-rtic 1.1.4 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => cortex-m-log 0.8.0 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => panic-semihosting 0.6.0 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => panic-itm 0.4.2 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => panic-rtt-target 0.1.2 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => panic-semihosting 0.6.0 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => stm32h7 0.15.1 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => synopsys-usb-otg 0.3.2 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => embedded-sdmmc 0.4.0 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => stm32-fmc 0.3.0 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => synopsys-usb-otg 0.3.2 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => usbd-serial 0.1.1 => embedded-hal 0.2.7 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => usbd-serial 0.1.1 => nb 0.1.3 => nb 1.1.0
- Because of stm32h7xx-hal 0.13.1 => nb 1.1.0
nb 0.1.3:
- Because of stm32h7xx-hal 0.13.1 => cortex-m-log 0.8.0 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => cortex-m-rtic 1.1.4 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => cortex-m-log 0.8.0 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => panic-semihosting 0.6.0 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => panic-itm 0.4.2 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => panic-rtt-target 0.1.2 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => panic-semihosting 0.6.0 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => stm32h7 0.15.1 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => synopsys-usb-otg 0.3.2 => cortex-m 0.7.7 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => embedded-sdmmc 0.4.0 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => stm32-fmc 0.3.0 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => synopsys-usb-otg 0.3.2 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => usbd-serial 0.1.1 => embedded-hal 0.2.7 => nb 0.1.3
- Because of stm32h7xx-hal 0.13.1 => usbd-serial 0.1.1 => nb 0.1.3

rtt-target 0.4.0:
- Because of stm32h7xx-hal 0.13.1 => rtt-target 0.4.0
rtt-target 0.3.1:
- Because of stm32h7xx-hal 0.13.1 => panic-rtt-target 0.1.2 => rtt-target 0.3.1

rustc_version 0.4.0:
- Because of stm32h7xx-hal 0.13.1 => cortex-m-rtic 1.1.4 => heapless 0.7.16 => rustc_version 0.4.0
rustc_version 0.2.3:
- Because of stm32h7xx-hal 0.13.1 => cortex-m-log 0.8.0 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3
- Because of stm32h7xx-hal 0.13.1 => cortex-m-rtic 1.1.4 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3
- Because of stm32h7xx-hal 0.13.1 => cortex-m-log 0.8.0 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3
- Because of stm32h7xx-hal 0.13.1 => panic-semihosting 0.6.0 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3
- Because of stm32h7xx-hal 0.13.1 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3
- Because of stm32h7xx-hal 0.13.1 => panic-itm 0.4.2 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3
- Because of stm32h7xx-hal 0.13.1 => panic-rtt-target 0.1.2 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3
- Because of stm32h7xx-hal 0.13.1 => panic-semihosting 0.6.0 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3
- Because of stm32h7xx-hal 0.13.1 => stm32h7 0.15.1 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3
- Because of stm32h7xx-hal 0.13.1 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3
- Because of stm32h7xx-hal 0.13.1 => synopsys-usb-otg 0.3.2 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3

semver 1.0.17:
- Because of stm32h7xx-hal 0.13.1 => cortex-m-rtic 1.1.4 => heapless 0.7.16 => rustc_version 0.4.0 => semver 1.0.17
semver 0.9.0:
- Because of stm32h7xx-hal 0.13.1 => cortex-m-log 0.8.0 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3 => semver 0.9.0
- Because of stm32h7xx-hal 0.13.1 => cortex-m-rtic 1.1.4 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3 => semver 0.9.0
- Because of stm32h7xx-hal 0.13.1 => cortex-m-log 0.8.0 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3 => semver 0.9.0
- Because of stm32h7xx-hal 0.13.1 => panic-semihosting 0.6.0 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3 => semver 0.9.0
- Because of stm32h7xx-hal 0.13.1 => cortex-m-semihosting 0.5.0 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3 => semver 0.9.0
- Because of stm32h7xx-hal 0.13.1 => panic-itm 0.4.2 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3 => semver 0.9.0
- Because of stm32h7xx-hal 0.13.1 => panic-rtt-target 0.1.2 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3 => semver 0.9.0
- Because of stm32h7xx-hal 0.13.1 => panic-semihosting 0.6.0 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3 => semver 0.9.0
- Because of stm32h7xx-hal 0.13.1 => stm32h7 0.15.1 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3 => semver 0.9.0
- Because of stm32h7xx-hal 0.13.1 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3 => semver 0.9.0
- Because of stm32h7xx-hal 0.13.1 => synopsys-usb-otg 0.3.2 => cortex-m 0.7.7 => bare-metal 0.2.5 => rustc_version 0.2.3 => semver 0.9.0

spin 0.9.6:
- Because of stm32h7xx-hal 0.13.1 => cortex-m-rtic 1.1.4 => heapless 0.7.16 => spin 0.9.6
spin 0.5.2:
- Because of stm32h7xx-hal 0.13.1 => lazy_static 1.4.0 => spin 0.5.2
  ```
</details>