### PR TITLE
Add additional possibility for WWDG1RSTF to WindowWatchdogReset arm.

### DIFF
--- a/src/rcc/reset_reason.rs
+++ b/src/rcc/reset_reason.rs
@@ -40,7 +40,7 @@ pub fn get_reset_reason(rcc: &mut crate::stm32::RCC) -> ResetReason {
         (false, false, false, false, false, false, false, false, false, true) => {
             ResetReason::CpuReset
         }
-        (false, true, false, false, false, true, false, false, false, true) => {
+        (false, true, false, false, false, false, false, false, false, false) | (false, true, false, false, false, true, false, false, false, true) => {
             ResetReason::WindowWatchdogReset
         }
         (false, false, true, false, false, true, false, false, false, true) => {


### PR DESCRIPTION
STM32H743ZI2 is confirmed to occasionally raise only the WWGD1RSTF flag after encountering a window watchdog reset.

This fix adds an additional option for the WindowWatchdogReset arm.

re: https://github.com/stm32-rs/stm32h7xx-hal/issues/433

Not tested on any hardware yet.