### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ stm32-fmc = { version = "0.3", optional = true }
 synopsys-usb-otg = { version = "^0.3.0", features = ["cortex-m"], optional = true }
 embedded-display-controller = { version = "^0.1.0", optional = true }
 log = { version = "0.4.14", optional = true} # see also the dev-dependencies section
-fdcan = { version = "0.1", optional = true }
+fdcan = { version = "0.2", optional = true }
 bitflags = { version = "2.0.0" }
 embedded-storage = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,25 +148,9 @@ debug = true # symbols are nice and they don't increase the size in flash
 lto = true # better optimizations
 opt-level = "s" # optimize for binary size
 
-[[example]]
-name = "rtic"
-required-features = ["rt"]
-
-[[example]]
-name = "rtic_timers"
-required-features = ["rt", "rm0433"]
-
-[[example]]
-name = "vos0"
-required-features = ["revision_v"]
-
-[[example]]
-name = "fmc"
-required-features = ["fmc", "rm0399"]
-
-[[example]]
-name = "fmc_nand_flash"
-required-features = ["fmc"]
+# The following examples do not build for all feature flag combinations. The
+# `required-features` field specifies the hal features and/or the hardware
+# configuration required by the example.
 
 [[example]]
 name = "can-echo"
@@ -177,32 +161,8 @@ name = "can-fd"
 required-features = ["can"]
 
 [[example]]
-name = "qspi"
-required-features = ["xspi", "rm0433"]
-
-[[example]]
-name = "qspi_mdma"
-required-features = ["xspi", "rm0433"]
-
-[[example]]
-name = "qspi_flash_memory"
-required-features = ["xspi", "rm0433"]
-
-[[example]]
-name = "octospi"
-required-features = ["xspi", "rm0468"]
-
-[[example]]
-name = "octospi_hyperram"
-required-features = ["xspi", "rm0468"]
-
-[[example]]
-name = "sdmmc"
-required-features = ["sdmmc"]
-
-[[example]]
-name = "sdmmc_fat"
-required-features = ["sdmmc", "sdmmc-fatfs"]
+name = "crc"
+required-features = ["crc"]
 
 [[example]]
 name = "embedded-graphics"
@@ -225,6 +185,58 @@ name = "ethernet-nucleo-h743zi2"
 required-features = ["rt", "revision_v", "stm32h743v", "ethernet"]
 
 [[example]]
+name = "fmc"
+required-features = ["fmc", "rm0399"]
+
+[[example]]
+name = "fmc_nand_flash"
+required-features = ["fmc"]
+
+[[example]]
+name = "octospi"
+required-features = ["xspi", "rm0468"]
+
+[[example]]
+name = "octospi_hyperram"
+required-features = ["xspi", "rm0468"]
+
+[[example]]
+name = "qspi"
+required-features = ["xspi", "rm0433"]
+
+[[example]]
+name = "qspi_mdma"
+required-features = ["xspi", "rm0433"]
+
+[[example]]
+name = "qspi_flash_memory"
+required-features = ["xspi", "rm0433"]
+
+[[example]]
+name = "rtc"
+required-features = ["rt", "rtc"]
+
+[[example]]
+name = "rtic"
+required-features = ["rt"]
+
+[[example]]
+name = "rtic_timers"
+required-features = ["rt", "rm0433"]
+
+[[example]]
+name = "sdmmc"
+required-features = ["sdmmc"]
+
+[[example]]
+name = "sdmmc_fat"
+required-features = ["sdmmc", "sdmmc-fatfs"]
+
+[[example]]
+name = "spi-dma-rtic"
+required-features = ["rt"]
+
+[[example]]
 name = "tick_timer"
 required-features = ["rt"]
 
@@ -245,17 +257,5 @@ name = "usb_phy_serial_interrupt"
 required-features = ["rt", "usb_hs", "rm0433"]
 
 [[example]]
-name = "rtc"
-required-features = ["rt", "rtc"]
-
-[[example]]
-name = "sai_dma_passthru"
-required-features = ["rm0433"]
-
-[[example]]
-name = "spi-dma-rtic"
-required-features = ["rm0433","rt"]
-
-[[example]]
-name = "crc"
-required-features = ["crc", "rt"]
+name = "vos0"
+required-features = ["revision_v"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ nb = "1.0.0"
 paste = "1.0.1"
 bare-metal = "1.0.0"
 sdio-host = { version = "0.9", optional = true }
-embedded-sdmmc = { version = "0.4", optional = true }
+embedded-sdmmc = { version = "0.5", optional = true }
 stm32-fmc = { version = "0.3", optional = true }
 synopsys-usb-otg = { version = "^0.3.0", features = ["cortex-m"], optional = true }
 embedded-display-controller = { version = "^0.1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,8 @@ panic-semihosting = "0.6"
 usb-device = "0.2.5"
 usbd-serial = "0.1.0"
 numtoa = "0.2.3"
-tinybmp = "0.4"
-embedded-graphics = "0.7"
+tinybmp = "0.5"
+embedded-graphics = "0.8"
 
 [dev-dependencies.smoltcp]
 version = "0.10.0"

--- a/examples/sai_dma_passthru.rs
+++ b/examples/sai_dma_passthru.rs
@@ -1,9 +1,8 @@
-//! This example was tested on the original Electro Smith Daisy Seed board with
+//! This example was tested on the original Electro Smith Daisy Seed board (STM32H750) with
 //! AK4556 codec https://www.electro-smith.com/daisy
 
 #![allow(unused_macros)]
 #![deny(warnings)]
-// #![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 


### PR DESCRIPTION
* Bump embedded-sdmmc from 0.4 to 0.5
* Bump fdcan from 0.1 to 0.2
* Bump embedded-graphics from 0.7 to 0.8
* Update [[example]] targets