### PR TITLE
feat(adc): spike for ADC reads using DMA w/ circular buffer

### DIFF
--- a/examples/adc_dma_circ.rs
+++ b/examples/adc_dma_circ.rs
@@ -1,0 +1,111 @@
+#![no_main]
+#![no_std]
+
+use core::{mem, mem::MaybeUninit};
+use log::info;
+
+use cortex_m_rt::entry;
+
+use embedded_hal::adc::Channel;
+use stm32h7xx_hal::{
+    adc,
+    delay::Delay,
+    dma::{
+        dma::{DmaConfig, StreamsTuple},
+        Transfer,
+    },
+    gpio, pac,
+    prelude::*,
+    stm32::ADC1,
+};
+
+#[macro_use]
+mod utilities;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // 1 slot because we are only using 1 channel
+    #[link_section = ".axisram"]
+    static mut BUFFER: MaybeUninit<[u16; 1]> = MaybeUninit::uninit();
+
+    let adc_buffer: &'static mut [u16; 1] = {
+        // Convert an uninitialised array into an array of uninitialised
+        let buf: &mut [MaybeUninit<u16>; 1] =
+            unsafe { mem::transmute(&mut BUFFER) };
+        // Initialise memory to valid values
+        for slot in buf.iter_mut() {
+            // Never create even a _temporary_ reference to uninitialised memory
+            unsafe {
+                slot.as_mut_ptr().write(0);
+            }
+        }
+        unsafe { mem::transmute(buf) }
+    };
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = example_power!(pwr).freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+
+    let ccdr = rcc
+        .sys_ck(400.MHz())
+        .pll2_p_ck(40.MHz())
+        .freeze(pwrcfg, &dp.SYSCFG);
+
+    info!("");
+    info!("stm32h7xx-hal example - ADC to Memory DMA Continuous using Circular Mode");
+    info!("");
+
+    let mut delay = Delay::new(cp.SYST, ccdr.clocks);
+
+    // Setup ADC
+    let mut adc1 = adc::Adc::adc1(
+        dp.ADC1,
+        2.MHz(),
+        &mut delay,
+        ccdr.peripheral.ADC12,
+        &ccdr.clocks,
+    )
+    .enable();
+    adc1.set_resolution(adc::Resolution::SixteenBit);
+    // We can't use ADC2 here because ccdr.peripheral.ADC12 has been
+    // consumed. See examples/adc12.rs
+
+    // Setup GPIOC
+    let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
+
+    // Configure pc4 as an analog input
+    let mut channel = gpioc.pc4.into_analog(); // ANALOG IN 4
+
+    let config = DmaConfig::default()
+        .circular_buffer(true)
+        .memory_increment(true);
+
+    // Setup the DMA transfer on stream 0
+    let streams = StreamsTuple::new(dp.DMA1, ccdr.peripheral.DMA1);
+    let mut transfer: Transfer<_, _, _, _, _> =
+        Transfer::init(streams.0, adc1, &mut adc_buffer[..], None, config);
+
+    // This closure runs right after enabling the stream
+    transfer.start(|adc| {
+        let channel = <gpio::PC4 as Channel<ADC1>>::channel();
+        adc.start_conversion_dma_circ(&[channel]); // more channels can be added to the list
+    });
+
+    loop {
+        info!("{}", unsafe {
+            core::ptr::read_volatile(0x2400_0000 as *const u16)
+            // if more channels are used, each address will be offset by 2
+        });
+
+        delay.delay_ms(10_u16); // slow down the loop a bit
+    }
+}


### PR DESCRIPTION
This implements continuous ADC reads of multiple channels using DMA and a circular buffer. Values should be able to be read directly from the buffer from any context, not just interrupts.

This is unsafe, but it's working and so gives a jumping off point for improvements. I'm not actually sure if the use-case is even possible in safe Rust.

Seeking ideas to improve:

* Needing to [pass in an array](https://github.com/dobrite/stm32h7xx-hal/pull/1/files#diff-43871c78ae970b705edf0c2c78115ac3ce5c692832a4e021a55095474622ec64R99-R100) of `u8`s instead of an array of pins.
* [Having to `read_volatile`](https://github.com/dobrite/stm32h7xx-hal/pull/1/files#diff-43871c78ae970b705edf0c2c78115ac3ce5c692832a4e021a55095474622ec64R105) because the transfer has `&mut` ownership over the buffer.  There would also need to be an API to access this buffer from outside an interrupt context, where we might not have access to the transfer.
* `DmaConfig` needs to be setup correctly (e.g. `circular_buffer(true)`), otherwise it won't work.
* Anything else! I'm relatively new to embedded, and I'm sure there are _tons_ of spots where this approach and code can be improved.