### PR TITLE
Expose QSPI control register to switch used bank

### DIFF
--- a/src/xspi/mod.rs
+++ b/src/xspi/mod.rs
@@ -248,7 +248,7 @@ mod common {
         Error,
     }
 
-    /// Indicates a specific QUADSPI bank to use
+    /// Indicates a specific QUADSPI bank to use.
     #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[cfg(any(feature = "rm0433", feature = "rm0399"))]
@@ -259,6 +259,45 @@ mod common {
     }
     // Banks are not supported by the Octospi peripheral (there's two Octospi
     // peripherals instead)
+
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
+    pub enum BankError {
+        DualModeNotSupported,
+    }
+
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
+    impl TryFrom<Bank> for BankSelect {
+        type Error = BankError;
+
+        fn try_from(value: Bank) -> Result<Self, Self::Error> {
+            match value {
+                Bank::One => Ok(BankSelect::One),
+                Bank::Two => Ok(BankSelect::Two),
+                Bank::Dual => Err(BankError::DualModeNotSupported),
+            }
+        }
+    }
+
+    /// Indicates one of the two existing QUADSPI bank.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
+    pub enum BankSelect {
+        One,
+        Two,
+    }
+
+    #[cfg(any(feature = "rm0433", feature = "rm0399"))]
+    impl From<BankSelect> for Bank {
+        fn from(val: BankSelect) -> Self {
+            match val {
+                BankSelect::One => Bank::One,
+                BankSelect::Two => Bank::Two,
+            }
+        }
+    }
 
     /// A structure for specifying the XSPI configuration.
     ///

--- a/src/xspi/mod.rs
+++ b/src/xspi/mod.rs
@@ -116,8 +116,8 @@
 mod qspi;
 #[cfg(any(feature = "rm0433", feature = "rm0399"))]
 pub use common::{
-    Bank, Xspi as Qspi, XspiError as QspiError, XspiMode as QspiMode,
-    XspiWord as QspiWord,
+    Bank, BankError, BankSelect, Xspi as Qspi, XspiError as QspiError,
+    XspiMode as QspiMode, XspiWord as QspiWord,
 };
 #[cfg(any(feature = "rm0433", feature = "rm0399"))]
 pub use qspi::QspiExt as XspiExt;

--- a/src/xspi/qspi.rs
+++ b/src/xspi/qspi.rs
@@ -229,6 +229,8 @@ pub trait QspiExt {
 }
 
 impl Qspi<stm32::QUADSPI> {
+    /// Switches between single-bank mode on Bank 1 and single-bank mode on Bank 2.
+    /// Note that it has no effect in dual-flash mode.
     pub fn change_bank_unchecked(
         &mut self,
         bank: BankSelect,
@@ -342,6 +344,10 @@ impl Qspi<stm32::QUADSPI> {
 }
 
 impl QspiExt for stm32::QUADSPI {
+    /// Create and initialize a new QUADSPI peripheral that will use the single-bank mode on the Bank 1 of the flash memory.
+    ///
+    /// A list of pins `(sck, io0, io1, io2, io3)` for this QSPI peripheral should be passed as pins.
+    /// Even if the pins are not used, the function will consume them to avoid accessing to them manually.
     fn bank1<CONFIG, PINS>(
         self,
         _pins: PINS,
@@ -356,6 +362,10 @@ impl QspiExt for stm32::QUADSPI {
         Qspi::qspi_unchecked(self, config, Bank::One, clocks, prec)
     }
 
+    /// Create and initialize a new QUADSPI peripheral that will use the single-bank mode on the Bank 2 of the flash memory.
+    ///
+    /// A list of pins `(sck, io0, io1, io2, io3)` for this QSPI peripheral should be passed as pins.
+    /// Even if the pins are not used, the function will consume them to avoid accessing to them manually.
     fn bank2<CONFIG, PINS>(
         self,
         _pins: PINS,
@@ -370,6 +380,13 @@ impl QspiExt for stm32::QUADSPI {
         Qspi::qspi_unchecked(self, config, Bank::Two, clocks, prec)
     }
 
+    /// Create and initialize a new QUADSPI peripheral that can switch between both banks of the flash memory.
+    ///
+    /// The Bank to use at initialization is given by the `initial_bank` parameter.
+    /// A list of pins `(sck, bank1_io0, bank1_io1, bank1_io2, bank1_io3, bank2_io0, bank2_io1, bank2_io2, bank2_io3)` for this QSPI peripheral should be passed as pins.
+    /// Even if the pins are not used, the function will consume them to avoid accessing to them manually.
+    ///
+    /// Note that the peripheral will still be initialized in single-bank mode and the used bank have to be changed using the [`change_bank_unchecked`](../xspi/struct.Qspi.html#method.change_bank_unchecked) method.
     fn bank_switch<CONFIG, PINS>(
         self,
         _pins: PINS,
@@ -385,6 +402,9 @@ impl QspiExt for stm32::QUADSPI {
         Qspi::qspi_unchecked(self, config, initial_bank.into(), clocks, prec)
     }
 
+    /// Create and initialize a new QUADSPI peripheral without consuming any pins.
+    ///
+    /// The given `bank` allow to chose between communication to just one of the two banks (single-bank mode) or to both at the same time (dual-flash mode).
     fn qspi_unchecked<CONFIG>(
         self,
         config: CONFIG,

--- a/src/xspi/qspi.rs
+++ b/src/xspi/qspi.rs
@@ -179,6 +179,14 @@ pub trait QspiExt {
 }
 
 impl Qspi<stm32::QUADSPI> {
+    pub fn change_bank(&mut self, bank: Bank) {
+        match bank {
+            Bank::One => self.rb.cr.modify(|_, w| w.fsel().clear_bit()),
+            Bank::Two => self.rb.cr.modify(|_, w| w.fsel().set_bit()),
+            Bank::Dual => self.rb.cr.modify(|_, w| w.dfm().set_bit()),
+        }
+    }
+
     pub fn qspi_unchecked<CONFIG>(
         regs: stm32::QUADSPI,
         config: CONFIG,


### PR DESCRIPTION
Hi, I'm using this library with a STM32 H7 series microcontroller which is connected to a NOR Flash with 2 chips.

Since this NOR Flash support QuadSPI, I wanted to use it but I also want to access to both memory chips.    
Since Both of my flash chips are used separatly, one for image backup and one for temporary storage, I want to access to only one of them at a time.    
My problem is that, when I looked at the Dual-Flash mode, it seems that I have to read and write to both chips at the same time as from the `Quad-SPI interface on STM32 microcontrollers and microprocessors` STM documentation, I can read:
> Note that all bytes at even addresses are stored in Flash 1 while all bytes at odd addresses are stored in Flash 2.
> As described in the figure above, in Dual-Flash mode the same command, address and alternate are sent to both Flash 1 and Flash 2.

This is really not ideal for me because I don't want to risk corrupting the backups when doing any operation on the other chip.

On top of that, I only have one `clock` and one `reset` GPIO line available for both since the chips have been mounted to use the Dual-Flash mode. This means that I can't create two QSPI peripherals using `QUADSPI.bank1()` and `QUADSPI.bank2()` since these functions consume the given pins and thus, the common clock.

This pull request is here to propose a solution for this case and for that I created a new `QSPI.bank_switch()` method that accept a `PinsBank1And2` list of pins to consume and a default bank.   
To change the addressed bank, I exposed the QUADSPI control register trhough a `change_bank()` method.

Also please note that I'm far from being an expert in Flash memories so if you know a solution to my problem that does not require any change in the STM32 hal I will gladly take it.