### PR TITLE
Revert "Move ethernet DMA reset slightly earlier to eliminate freeze on h723"

### DIFF
--- a/src/ethernet/eth.rs
+++ b/src/ethernet/eth.rs
@@ -455,12 +455,6 @@ pub unsafe fn new_unchecked<const TD: usize, const RD: usize>(
         // Ensure syscfg is enabled (for PMCR)
         rcc.apb4enr.modify(|_, w| w.syscfgen().set_bit());
 
-        // Reset ETH_DMA - write 1 and wait for 0.
-        // On the H723, we have to do this before prec.enable()
-        // or the DMA will never come out of reset
-        eth_dma.dmamr.modify(|_, w| w.swr().set_bit());
-        while eth_dma.dmamr.read().swr().bit_is_set() {}
-
         // AHB1 ETH1MACEN
         prec.enable();
 
@@ -478,6 +472,10 @@ pub unsafe fn new_unchecked<const TD: usize, const RD: usize>(
     //rcc.ahb1rstr.modify(|_, w| w.eth1macrst().clear_bit());
 
     cortex_m::interrupt::free(|_cs| {
+        // reset ETH_DMA - write 1 and wait for 0
+        eth_dma.dmamr.modify(|_, w| w.swr().set_bit());
+        while eth_dma.dmamr.read().swr().bit_is_set() {}
+
         // 200 MHz
         eth_mac
             .mac1ustcr


### PR DESCRIPTION
Revert the changes to `eth.rs` from #445 

Fixes #448 