### PR TITLE
Replace casts of &T to &mut T with UnsafeCell

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -7,6 +7,7 @@
 //! - [Advanced USART Functions](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/serial-advanced.rs)
 //! - [Inverted Signal Levels](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/serial-inverted-loopback.rs)
 
+use core::cell::UnsafeCell;
 use core::fmt;
 use core::marker::PhantomData;
 use core::ptr;
@@ -1114,8 +1115,9 @@ macro_rules! usart {
                         // NOTE(write_volatile) 8-bit write that's not
                         // possible through the svd2rust API
                         unsafe {
-                            ptr::write_volatile(
-                                &(*$USARTX::ptr()).tdr as *const _ as *mut _, byte)
+                            let tdr = &(*$USARTX::ptr()).tdr as *const _ as *const UnsafeCell<u8>;
+
+                            ptr::write_volatile(UnsafeCell::raw_get(tdr), byte)
                         }
                         Ok(())
                     } else {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -62,6 +62,7 @@
 //!
 //! [embedded_hal]: https://docs.rs/embedded-hal/0.2.3/embedded_hal/spi/index.html
 
+use core::cell::UnsafeCell;
 use core::convert::From;
 use core::marker::PhantomData;
 use core::ptr;
@@ -1083,8 +1084,9 @@ macro_rules! spi {
                             {
                                 // NOTE(write_volatile) see note above
                                 unsafe {
+                                    let txdr = &self.spi.txdr as *const _ as *const UnsafeCell<$TY>;
                                     ptr::write_volatile(
-                                        &self.spi.txdr as *const _ as *mut $TY,
+                                        UnsafeCell::raw_get(txdr),
                                         word,
                                     )
                                 }
@@ -1112,8 +1114,9 @@ macro_rules! spi {
                             {
                                 // NOTE(write_volatile/read_volatile) write/read only 1 word
                                 unsafe {
+                                    let txdr = &self.spi.txdr as *const _ as *const UnsafeCell<$TY>;
                                     ptr::write_volatile(
-                                        &self.spi.txdr as *const _ as *mut $TY,
+                                        UnsafeCell::raw_get(txdr),
                                         word,
                                     );
                                     return Ok(ptr::read_volatile(

--- a/src/xspi/mod.rs
+++ b/src/xspi/mod.rs
@@ -143,6 +143,7 @@ mod common {
         stm32,
         time::Hertz,
     };
+    use core::cell::UnsafeCell;
     use core::{marker::PhantomData, ptr};
 
     /// Represents operation modes of the XSPI interface.
@@ -641,7 +642,9 @@ mod common {
                 // Write data to the FIFO in a byte-wise manner.
                 unsafe {
                     for byte in data {
-                        ptr::write_volatile(&self.rb.dr as *const _ as *mut u8, *byte);
+                        let dr = &self.rb.dr as *const _ as *const UnsafeCell<u8>;
+
+                        ptr::write_volatile(UnsafeCell::raw_get(dr), *byte);
                     }
                 }
 
@@ -723,7 +726,9 @@ mod common {
                 // Transaction starts here
                 unsafe {
                     for byte in data {
-                        ptr::write_volatile(&self.rb.dr as *const _ as *mut u8, *byte);
+                        let dr = &self.rb.dr as *const _ as *const UnsafeCell<u8>;
+
+                        ptr::write_volatile(UnsafeCell::raw_get(dr), *byte);
                     }
                 }
 


### PR DESCRIPTION
Specifically we cast `*const T` to `*const UnsafeCell<T>` then use the [`UnsafeCell::raw_get`](https://doc.rust-lang.org/stable/std/cell/struct.UnsafeCell.html#method.raw_get) method.