### PR TITLE
Fix invalid read test logic in sdmmc example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update `smoltcp` dependency to `0.9.0`
 * MSRV increased to 1.65.0
 * add `IntoAf` trait to restrict `into_alternate` [#346]
+* sdmmc: Fix read speed test.
 
 ## [v0.14.0] 2023-03-22
 

--- a/examples/sdmmc.rs
+++ b/examples/sdmmc.rs
@@ -145,15 +145,13 @@ fn main() -> ! {
     info!("");
 
     // Read test
-    let mut buffer = [0u8; 5120];
+    let mut buffer = [0u8; 512 * 10];
 
     cp.DWT.enable_cycle_counter();
     let start = pac::DWT::cycle_count();
 
-    for i in 0..10 {
-        // Read 10 blocks
-        sdmmc.read_blocks(10 * i, &mut buffer).unwrap();
-    }
+    // Read 10 blocks
+    sdmmc.read_blocks(0, &mut buffer).unwrap();
 
     let end = pac::DWT::cycle_count();
     let duration = (end - start) as f32 / ccdr.clocks.c_ck().raw() as f32;


### PR DESCRIPTION
The read check is processing a buffer 10 blocks long. The check then reads data from the SD card 10 times to then report the speed of "Read 10 blocks at X bytes/second". The problem is that it actually reads 10*10 blocks.

With this patch, `read_blocks` is used correctly to populate a continuous buffer.