### PR TITLE
Introduce SDMMC `write_blocks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update `smoltcp` dependency to `0.9.0`
 * MSRV increased to 1.65.0
 * add `IntoAf` trait to restrict `into_alternate` [#346]
+* sdmmc: Fix read speed test.
 
 ## [v0.14.0] 2023-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Update `smoltcp` dependency to `0.9.0`
 * MSRV increased to 1.65.0
 * add `IntoAf` trait to restrict `into_alternate` [#346]
-* sdmmc: Fix read speed test.
+* sdmmc: Introduce `write_blocks` [#453]
 
 ## [v0.14.0] 2023-03-22
 

--- a/examples/sdmmc.rs
+++ b/examples/sdmmc.rs
@@ -145,15 +145,13 @@ fn main() -> ! {
     info!("");
 
     // Read test
-    let mut buffer = [0u8; 5120];
+    let mut buffer = [0u8; 512 * 10];
 
     cp.DWT.enable_cycle_counter();
     let start = pac::DWT::cycle_count();
 
-    for i in 0..10 {
-        // Read 10 blocks
-        sdmmc.read_blocks(10 * i, &mut buffer).unwrap();
-    }
+    // Read 10 blocks
+    sdmmc.read_blocks(0, &mut buffer).unwrap();
 
     let end = pac::DWT::cycle_count();
     let duration = (end - start) as f32 / ccdr.clocks.c_ck().raw() as f32;

--- a/examples/sdmmc.rs
+++ b/examples/sdmmc.rs
@@ -144,55 +144,45 @@ fn main() -> ! {
     info!("----------------------");
     info!("");
 
-    // Read test
-    let mut buffer = [0u8; 512 * 10];
-
     cp.DWT.enable_cycle_counter();
-    let start = pac::DWT::cycle_count();
 
-    // Read 10 blocks
-    sdmmc.read_blocks(0, &mut buffer).unwrap();
-
-    let end = pac::DWT::cycle_count();
-    let duration = (end - start) as f32 / ccdr.clocks.c_ck().raw() as f32;
-
-    info!("Read 10 blocks at {} bytes/s", 5120. / duration);
-    info!("");
-
+    // Write single block test
     let write_buffer = [0x34; 512];
     let start = pac::DWT::cycle_count();
-
-    for i in 0..10 {
-        if let Err(err) = sdmmc.write_block(i, &write_buffer) {
-            info!("Failed to write block {}: {:?}", i, err);
-        }
-    }
-
+    sdmmc.write_block(0, &write_buffer).unwrap();
     let end = pac::DWT::cycle_count();
     let duration = (end - start) as f32 / ccdr.clocks.c_ck().raw() as f32;
+    info!("Wrote single block at {} bytes/s", 512.0 / duration);
 
-    info!("Wrote 10 blocks at {} bytes/s", 5120. / duration);
-    info!("");
+    // Write multiple blocks test
+    let write_buffer = [0x34; 512 * 16];
+    let start = pac::DWT::cycle_count();
+    sdmmc.write_blocks(0, &write_buffer).unwrap();
+    let end = pac::DWT::cycle_count();
+    let duration = (end - start) as f32 / ccdr.clocks.c_ck().raw() as f32;
+    info!("Wrote 16 blocks at {} bytes/s", (512.0 * 16.0) / duration);
+
+    // Read single block test
+    let mut buffer = [0u8; 512];
+    let start = pac::DWT::cycle_count();
+    sdmmc.read_block(0, &mut buffer).unwrap();
+    let end = pac::DWT::cycle_count();
+    let duration = (end - start) as f32 / ccdr.clocks.c_ck().raw() as f32;
+    info!("Read single block at {} bytes/s", 512.0 / duration);
+
+    // Read multiple blocks test
+    let mut buffer = [0u8; 512 * 16];
+    let start = pac::DWT::cycle_count();
+    sdmmc.read_blocks(0, &mut buffer).unwrap();
+    let end = pac::DWT::cycle_count();
+    let duration = (end - start) as f32 / ccdr.clocks.c_ck().raw() as f32;
+    info!("Read 16 blocks at {} bytes/s", (512.0 * 16.0) / duration);
 
     info!("Verification test...");
-    // Write 10 blocks
-    for i in 0..10 {
-        if let Err(err) = sdmmc.write_block(i, &write_buffer) {
-            info!("Failed to write block {}: {:?}", i, err);
-        } else {
-            info!("Wrote block {}", i);
-        }
-
-        // Read back
-        sdmmc.read_blocks(0, &mut buffer).unwrap();
-    }
-
-    // Check the read
     for byte in buffer.iter() {
         assert_eq!(*byte, 0x34);
     }
-    info!("Verified 10 blocks");
-    info!("");
+    info!("Verified all blocks");
 
     info!("Done!");
 

--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -295,6 +295,7 @@ pub enum Error {
     Crc,
     DataCrcFail,
     RxOverFlow,
+    TxUnderFlow,
     NoCard,
     BadClock,
     InvalidConfiguration,
@@ -342,6 +343,8 @@ macro_rules! err_from_datapath_sm {
             return Err(Error::DataCrcFail);
         } else if $status.rxoverr().bit() {
             return Err(Error::RxOverFlow);
+        } else if $status.txunderr().bit() {
+            return Err(Error::TxUnderFlow);
         } else if $status.dtimeout().bit() {
             return Err(Error::Timeout);
         }
@@ -777,6 +780,77 @@ macro_rules! sdmmc {
                             break;
                         }
                     }
+
+                    err_from_datapath_sm!(status);
+                    self.clear_static_interrupt_flags();
+
+                    let mut timeout: u32 = 0xFFFF_FFFF;
+
+                    // Try to read card status (CMD13)
+                    while timeout > 0 {
+                        if self.card_ready()? {
+                            return Ok(());
+                        }
+                        timeout -= 1;
+                    }
+                    Err(Error::SoftwareTimeout)
+                }
+
+                /// Write multiple blocks to card. The length of the buffer
+                /// must be multiple of 512.
+                ///
+                /// `address` is the block address.
+                pub fn write_blocks(
+                    &mut self,
+                    address: u32,
+                    buffer: &[u8]
+                ) -> Result<(), Error> {
+                    let _card = self.card()?;
+
+                    assert!(buffer.len() % 512 == 0,
+                            "Buffer length must be a multiple of 512");
+                    let n_blocks = buffer.len() / 512;
+
+                    if !self.cmd16_illegal {
+                        self.cmd(common_cmd::set_block_length(512))?; // CMD16
+                    }
+
+                    // Setup write command
+                    self.start_datapath_transfer(512 * n_blocks as u32, 9, Dir::HostToCard);
+                    self.cmd(common_cmd::write_multiple_blocks(address))?; // CMD25
+
+                    let mut i = 0;
+                    let mut status;
+                    while {
+                        status = self.sdmmc.star.read();
+                        !(status.txunderr().bit()
+                          || status.dcrcfail().bit()
+                          || status.dtimeout().bit()
+                          || status.dataend().bit())
+                    } {
+                        if status.txfifohe().bit() {
+                            for _ in 0..8 {
+                                let mut wb = [0u8; 4];
+                                wb.copy_from_slice(&buffer[i..i + 4]);
+                                let word = u32::from_le_bytes(wb);
+                                self.sdmmc.fifor.write(|w| unsafe { w.bits(word) });
+                                i += 4;
+                            }
+                        }
+
+                        if i >= buffer.len() {
+                            break
+                        }
+                    }
+
+                    while {
+                        status = self.sdmmc.star.read();
+                        !(status.txunderr().bit()
+                          || status.dcrcfail().bit()
+                          || status.dtimeout().bit()
+                          || status.dataend().bit())
+                    } {}
+                    self.cmd(common_cmd::stop_transmission())?; // CMD12
 
                     err_from_datapath_sm!(status);
                     self.clear_static_interrupt_flags();


### PR DESCRIPTION
`write_block` needs to be called for every 512 bytes long block that is to be written to the SD card. Each of these calls requires the overhead of negotiating the write command and if I understand it correctly it also requires to erase the whole SD segment and copying it back. 

### Speed

With this patch, `write_blocks` is introduced, mirroring the behavior of `read_block` and `read_blocks`. This new method by itself helped me to improve write speed from the original example of 9.2 kB/s to 65 kB/s.

Write performance with 480 MHz system clock, 50 MHz bus speed, and enabled caches:

| Buffer size | Total size written | Speed |
| -- | -- | -- |
| 64 kB | 64 kB | 513 kB/s |
| 64 kB | 32 MB | 4.9 MB/s |
|128 kB | 32 MB | 5.2 MB/s |

### Erase before writing

Using ACMD23 to erase block data before writing in my case did not improve the result. Either my card does not benefit from it or I used it wrong.

### Possible improvements

Although the results look good Class 10 SD cards should be much faster. Even with half the bus speed, it should achieve at least 10 MB/s. If anybody has an idea what may be the bottleneck, please share.

### Follow ups

- Utilize block write/read in FAT bindings: #456