### PR TITLE
fix typo in sdmmc.rs

### DIFF
--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -1313,7 +1313,7 @@ macro_rules! sdmmc {
             }
 
             #[cfg(feature = "sdmmc-fatfs")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "sdmcc-fatfs")))]
+            #[cfg_attr(docsrs, doc(cfg(feature = "sdmmc-fatfs")))]
             impl embedded_sdmmc::BlockDevice for SdmmcBlockDevice<Sdmmc<$SDMMCX, SdCard>> {
                 type Error = Error;
 


### PR DESCRIPTION
I spotted this when looking at the recent changes to this file.