### PR TITLE
bump minor version: hopefully help crates.io update the registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stm32h7xx-hal"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Andrew Straw <strawman@astraw.com>",
            "Richard Meadows <richard@richard.fish>",
            "Henrik Böving <hargonix@gmail.com>",


### PR DESCRIPTION
Per my comment here, crates.io is not properly updating the dependency tree of stm32h7xx_hal, probably because the minor version of the crate is static: https://github.com/stm32-rs/stm32h7xx-hal/pull/440#issuecomment-1736732152

https://doc.rust-lang.org/cargo/reference/resolver.html may help figure out why this is the case.

As of stm32h7xx_hal = 0.14.0, the registry reads:
`{"name":"stm32h7xx-hal","vers":"0.14.0","deps":[{"name":"bare-metal","req":"^1.0.0","features":[],"optional":false,"default_features":true,"target":null,"kind":"normal"},{"name":"bitflags","req":"^2.0.0","features":[],"optional":false,"default_features":true,"target":null,"kind":"normal"},{"name":"cast","req":"^0.3.0","features":[],"optional":false,"default_features":false,"target":null,"kind":"normal"},{"name":"cfg-if","req":"^1.0.0","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"chrono","req":"^0.4","features":[],"optional":true,"default_features":false,"target":null,"kind":"normal"},{"name":"cortex-m","req":"^0.7.7","features":["critical-section-single-core"],"optional":false,"default_features":true,"target":null,"kind":"normal"},{"name":"cortex-m-log","req":"^0.8.0","features":["itm","semihosting","log-integration"],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"cortex-m-rt","req":">=0.6.15, <0.8","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"cortex-m-rtic","req":"^1.1","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"cortex-m-semihosting","req":"^0.5.0","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"defmt","req":">=0.2.0, <0.4","features":[],"optional":true,"default_features":true,"target":null,"kind":"normal"},{"name":"embedded-display-controller","req":"^0.1.0","features":[],"optional":true,"default_features":true,"target":null,"kind":"normal"},{"name":"embedded-dma","req":"^0.2.0","features":[],"optional":false,"default_features":true,"target":null,"kind":"normal"},{"name":"embedded-graphics","req":"^0.7","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"embedded-hal","req":"^0.2.6","features":["unproven"],"optional":false,"default_features":true,"target":null,"kind":"normal"},{"name":"embedded-sdmmc","req":"^0.4","features":[],"optional":true,"default_features":true,"target":null,"kind":"normal"},{"name":"embedded-storage","req":"^0.3","features":[],"optional":false,"default_features":true,"target":null,"kind":"normal"},{"name":"fdcan","req":"^0.1","features":[],"optional":true,"default_features":true,"target":null,"kind":"normal"},{"name":"fugit","req":"^0.3.5","features":[],"optional":false,"default_features":true,"target":null,"kind":"normal"},{"name":"lazy_static","req":"^1.4.0","features":["spin_no_std"],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"log","req":"^0.4.14","features":[],"optional":true,"default_features":true,"target":null,"kind":"normal"},{"name":"log","req":"^0.4.11","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"nb","req":"^1.0.0","features":[],"optional":false,"default_features":true,"target":null,"kind":"normal"},{"name":"numtoa","req":"^0.2.3","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"panic-halt","req":"^0.2.0","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"panic-itm","req":"~0.4.1","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"panic-rtt-target","req":"^0.1.0","features":["cortex-m"],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"panic-semihosting","req":"^0.6","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"paste","req":"^1.0.1","features":[],"optional":false,"default_features":true,"target":null,"kind":"normal"},{"name":"rand_core","req":"^0.6","features":[],"optional":true,"default_features":false,"target":null,"kind":"normal"},{"name":"rtt-target","req":"^0.4.0","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"sdio-host","req":"^0.9","features":[],"optional":true,"default_features":true,"target":null,"kind":"normal"},{"name":"smoltcp","req":"^0.8.0","features":["medium-ethernet","proto-ipv4","socket-raw"],"optional":true,"default_features":false,"target":null,"kind":"normal"},{"name":"smoltcp","req":"^0.8.0","features":["medium-ethernet","proto-ipv4","proto-ipv6","socket-raw"],"optional":false,"default_features":false,"target":null,"kind":"dev"},{"name":"stm32-fmc","req":"^0.3","features":[],"optional":true,"default_features":true,"target":null,"kind":"normal"},{"name":"stm32h7","req":"^0.15.1","features":[],"optional":false,"default_features":false,"target":null,"kind":"normal"},{"name":"synopsys-usb-otg","req":"^0.3.0","features":["cortex-m"],"optional":true,"default_features":true,"target":null,"kind":"normal"},{"name":"tinybmp","req":"^0.4","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"usb-device","req":"^0.2.5","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"usbd-serial","req":"^0.1.0","features":[],"optional":false,"default_features":true,"target":null,"kind":"dev"},{"name":"void","req":"^1.0.2","features":[],"optional":false,"default_features":false,"target":null,"kind":"normal"}],"cksum":"5fe4a709ccbccd9994d2363e27104933561ef170f892c950ffe939546c2ece1d","features":{"can":["fdcan/fdcan_h7"],"cm4":[],"cm7":[],"crc":[],"default":["rt"],"device-selected":[],"dsi":[],"ethernet":["smoltcp"],"example-ldo":[],"example-smps":[],"fmc":["stm32-fmc"],"log-itm":[],"log-rtt":[],"log-semihost":[],"ltdc":["embedded-display-controller"],"rand":["rand_core"],"revision_v":[],"rm0399":[],"rm0433":[],"rm0455":[],"rm0468":[],"rt":["stm32h7/rt"],"rtc":["chrono"],"sdmmc":["sdio-host"],"sdmmc-fatfs":["embedded-sdmmc","sdmmc"],"smps":[],"stm32h735":["stm32h7/stm32h735","device-selected","revision_v","rm0468","smps"],"stm32h742":["stm32h7/stm32h743","device-selected","rm0433"],"stm32h742v":["stm32h7/stm32h743v","device-selected","revision_v","rm0433"],"stm32h743":["stm32h7/stm32h743","device-selected","rm0433"],"stm32h743v":["stm32h7/stm32h743v","device-selected","revision_v","rm0433"],"stm32h747cm7":["stm32h7/stm32h747cm7","device-selected","revision_v","rm0399","cm7","dsi","smps"],"stm32h750":["stm32h7/stm32h743","device-selected","rm0433"],"stm32h750v":["stm32h7/stm32h743v","device-selected","revision_v","rm0433"],"stm32h753":["stm32h7/stm32h753","device-selected","rm0433"],"stm32h753v":["stm32h7/stm32h753v","device-selected","revision_v","rm0433"],"stm32h7a3":["stm32h7/stm32h7b3","device-selected","revision_v","rm0455","smps"],"stm32h7b0":["stm32h7/stm32h7b3","device-selected","revision_v","rm0455","smps"],"stm32h7b3":["stm32h7/stm32h7b3","device-selected","revision_v","rm0455","smps"],"usb_hs":["synopsys-usb-otg","synopsys-usb-otg/hs"],"xspi":[]},"yanked":false,"rust_version":"1.59"}`

This kind of thing wouldn't be observable for someone using the crate as a local package. 