### PR TITLE
usb: On rm0455/rm0468 parts, pins PA11/PA12 do not have an alternate function for USB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* Bugfix, usb: On RM0455 and RM0468 parts, PA11/PA12 do not have an alternate function
+  (AF) for USB. Use `into_analog()` when passing pins to `USB1/2::new` on these parts [#464]
+
 ## [v0.15.0] 2023-10-09
 
 * Remove unused `bitflags` dependency
@@ -385,3 +388,4 @@
 [#451]: https://github.com/stm32-rs/stm32h7xx-hal/pull/451
 [#453]: https://github.com/stm32-rs/stm32h7xx-hal/pull/453
 [#456]: https://github.com/stm32-rs/stm32h7xx-hal/pull/456
+[#464]: https://github.com/stm32-rs/stm32h7xx-hal/pull/464

--- a/examples/usb_rtic.rs
+++ b/examples/usb_rtic.rs
@@ -70,7 +70,7 @@ mod app {
         #[cfg(any(feature = "rm0455", feature = "rm0468"))]
         let (pin_dm, pin_dp) = {
             let gpioa = ctx.device.GPIOA.split(ccdr.peripheral.GPIOA);
-            (gpioa.pa11.into_alternate(), gpioa.pa12.into_alternate())
+            (gpioa.pa11, gpioa.pa12)
         };
 
         let led = ctx.device.GPIOE.split(ccdr.peripheral.GPIOE).pe1;

--- a/src/usb_hs.rs
+++ b/src/usb_hs.rs
@@ -18,7 +18,7 @@
 use crate::rcc;
 use crate::stm32;
 
-use crate::gpio::{self, Alternate, Speed};
+use crate::gpio::{self, Alternate, Analog, Speed};
 
 use crate::time::Hertz;
 
@@ -50,8 +50,8 @@ impl USB1 {
         usb_global: stm32::OTG1_HS_GLOBAL,
         usb_device: stm32::OTG1_HS_DEVICE,
         usb_pwrclk: stm32::OTG1_HS_PWRCLK,
-        _pin_dm: gpio::PA11<Alternate<10>>,
-        _pin_dp: gpio::PA12<Alternate<10>>,
+        _pin_dm: gpio::PA11<Analog>,
+        _pin_dp: gpio::PA12<Analog>,
         prec: rcc::rec::Usb1Otg,
         clocks: &rcc::CoreClocks,
     ) -> Self {


### PR DESCRIPTION
See pinouts in part datasheets. To use these pins for USB, it's not necessary to switch them to an alternate function: the USB D-/D+ pins are functional when the GPIO state is Analog. Tested on a STM32H7A3ZIT6

The ability to allocate PA11/PA12 to AF10 was correctly removed in https://github.com/stm32-rs/stm32h7xx-hal/pull/346 , but this exposed the bug.