### PR TITLE
Remove references to `static mut`

### DIFF
--- a/examples/adc_dma.rs
+++ b/examples/adc_dma.rs
@@ -4,6 +4,7 @@
 //! For an example of using ADC1 and ADC2 together, see examples/adc12.rs
 //! For an example of using ADC1 and ADC2 in parallel, see examples/adc12_parallel.rs
 
+#![deny(warnings)]
 #![no_main]
 #![no_std]
 
@@ -33,8 +34,11 @@ fn main() -> ! {
 
     let adc_buffer: &'static mut [u16; 32_768] = {
         // Convert an uninitialised array into an array of uninitialised
-        let buf: &mut [MaybeUninit<u16>; 32_768] =
-            unsafe { mem::transmute(&mut BUFFER) };
+        let buf: &mut [MaybeUninit<u16>; 32_768] = unsafe {
+            &mut *(core::ptr::addr_of_mut!(BUFFER)
+                as *mut [MaybeUninit<_>; 32_768])
+        };
+
         // Initialise memory to valid values
         for slot in buf.iter_mut() {
             // Never create even a _temporary_ reference to uninitialised memory

--- a/examples/dma.rs
+++ b/examples/dma.rs
@@ -71,6 +71,9 @@ fn main() -> ! {
     // Save a copy on the stack so we can check it later
     let source_buffer_cloned = *source_buffer;
 
+    // NOTE(unsafe): TARGET_BUFFER must also be initialised to prevent undefined
+    // behaviour (taking a mutable reference to uninitialised memory)
+
     // Setup DMA
     //
     // We need to specify the transfer size with a type annotation

--- a/examples/ethernet-nucleo-h743zi2.rs
+++ b/examples/ethernet-nucleo-h743zi2.rs
@@ -13,6 +13,7 @@
 #![no_std]
 
 extern crate cortex_m_rt as rt;
+use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicU32, Ordering};
 use rt::{entry, exception};
 
@@ -51,7 +52,8 @@ const MAC_ADDRESS: [u8; 6] = [0x02, 0x00, 0x11, 0x22, 0x33, 0x44];
 
 /// Ethernet descriptor rings are a global singleton
 #[link_section = ".sram3.eth"]
-static mut DES_RING: ethernet::DesRing<4, 4> = ethernet::DesRing::new();
+static mut DES_RING: MaybeUninit<ethernet::DesRing<4, 4>> =
+    MaybeUninit::uninit();
 
 // the program entry point
 #[entry]
@@ -112,6 +114,8 @@ fn main() -> ! {
 
     let mac_addr = smoltcp::wire::EthernetAddress::from_bytes(&MAC_ADDRESS);
     let (_eth_dma, eth_mac) = unsafe {
+        DES_RING.write(ethernet::DesRing::new());
+
         ethernet::new(
             dp.ETHERNET_MAC,
             dp.ETHERNET_MTL,
@@ -127,7 +131,7 @@ fn main() -> ! {
                 rmii_txd0,
                 rmii_txd1,
             ),
-            &mut DES_RING,
+            DES_RING.assume_init_mut(),
             mac_addr,
             ccdr.peripheral.ETH1MAC,
             &ccdr.clocks,

--- a/examples/ethernet-rtic-stm32h735g-dk.rs
+++ b/examples/ethernet-rtic-stm32h735g-dk.rs
@@ -45,7 +45,8 @@ const MAC_ADDRESS: [u8; 6] = [0x02, 0x00, 0x11, 0x22, 0x33, 0x44];
 
 /// Ethernet descriptor rings are a global singleton
 #[link_section = ".axisram.eth"]
-static mut DES_RING: ethernet::DesRing<4, 4> = ethernet::DesRing::new();
+static mut DES_RING: MaybeUninit<ethernet::DesRing<4, 4>> =
+    MaybeUninit::uninit();
 
 // This data will be held by Net through a mutable reference
 pub struct NetStorageStatic<'a> {
@@ -157,6 +158,8 @@ mod app {
 
         let mac_addr = smoltcp::wire::EthernetAddress::from_bytes(&MAC_ADDRESS);
         let (eth_dma, eth_mac) = unsafe {
+            DES_RING.write(ethernet::DesRing::new());
+
             ethernet::new(
                 ctx.device.ETHERNET_MAC,
                 ctx.device.ETHERNET_MTL,
@@ -172,7 +175,7 @@ mod app {
                     rmii_txd0,
                     rmii_txd1,
                 ),
-                &mut DES_RING,
+                DES_RING.assume_init_mut(),
                 mac_addr,
                 ccdr.peripheral.ETH1MAC,
                 &ccdr.clocks,

--- a/examples/i2c4_bdma.rs
+++ b/examples/i2c4_bdma.rs
@@ -91,12 +91,20 @@ fn main() -> ! {
 
     let config = BdmaConfig::default().memory_increment(true);
 
+    // Initialise buffer
+    unsafe {
+        // Convert an uninitialised array into an array of uninitialised
+        let buf: &mut [core::mem::MaybeUninit<u8>; 10] =
+            &mut *(core::ptr::addr_of_mut!(BUFFER) as *mut _);
+        buf.iter_mut().for_each(|x| x.as_mut_ptr().write(0));
+    }
+
     // We need to specify the direction with a type annotation
     let mut transfer: Transfer<_, _, PeripheralToMemory, &mut [u8; 10], _> =
         Transfer::init(
             streams.0,
             i2c,
-            unsafe { BUFFER.assume_init_mut() }, // uninitialised memory
+            unsafe { BUFFER.assume_init_mut() },
             None,
             config,
         );

--- a/examples/mdma_bursts.rs
+++ b/examples/mdma_bursts.rs
@@ -61,7 +61,7 @@ fn main() -> ! {
     info!("");
 
     // Initialise the source buffer without taking any references to
-    // uninitialisated memory
+    // uninitialised memory
     let _source_buffer: &'static mut [u32; 200] = {
         let buf: &mut [MaybeUninit<u32>; 200] = unsafe {
             &mut *(core::ptr::addr_of_mut!(SOURCE_BUFFER)
@@ -75,6 +75,9 @@ fn main() -> ! {
         }
         unsafe { SOURCE_BUFFER.assume_init_mut() }
     };
+
+    // NOTE(unsafe): TARGET_BUFFER must also be initialised to prevent undefined
+    // behaviour (taking a mutable reference to uninitialised memory)
 
     // Setup DMA
     let streams = StreamsTuple::new(dp.MDMA, ccdr.peripheral.MDMA);

--- a/examples/mdma_bursts.rs
+++ b/examples/mdma_bursts.rs
@@ -5,12 +5,11 @@
 //! This example demonstrates a transfer with 1 beat/burst, and a 32
 //! beats/burst. The latter gives an approximately 25% speedup.
 
-#![allow(clippy::transmute_ptr_to_ptr)]
 #![deny(warnings)]
 #![no_main]
 #![no_std]
 
-use core::{mem, mem::MaybeUninit};
+use core::mem::MaybeUninit;
 
 use cortex_m_rt::entry;
 #[macro_use]
@@ -64,15 +63,17 @@ fn main() -> ! {
     // Initialise the source buffer without taking any references to
     // uninitialisated memory
     let _source_buffer: &'static mut [u32; 200] = {
-        let buf: &mut [MaybeUninit<u32>; 200] =
-            unsafe { mem::transmute(&mut SOURCE_BUFFER) };
+        let buf: &mut [MaybeUninit<u32>; 200] = unsafe {
+            &mut *(core::ptr::addr_of_mut!(SOURCE_BUFFER)
+                as *mut [MaybeUninit<u32>; 200])
+        };
 
         for value in buf.iter_mut() {
             unsafe {
                 value.as_mut_ptr().write(0x11223344u32);
             }
         }
-        unsafe { mem::transmute(buf) }
+        unsafe { SOURCE_BUFFER.assume_init_mut() }
     };
 
     // Setup DMA
@@ -89,9 +90,9 @@ fn main() -> ! {
             // unsafe: Both source and destination live at least as long as this
             // transfer
             let source: &'static mut [u32; 200] =
-                unsafe { mem::transmute(&mut SOURCE_BUFFER) };
+                unsafe { SOURCE_BUFFER.assume_init_mut() };
             let target: &'static mut [u32; 200] =
-                unsafe { mem::transmute(&mut TARGET_BUFFER) };
+                unsafe { TARGET_BUFFER.assume_init_mut() }; // uninitialised memory
 
             Transfer::init_master(
                 stream,
@@ -125,8 +126,7 @@ fn main() -> ! {
         }
 
         // Decompose the stream to get the buffers back
-        let (_stream0, _mem2mem, target_buffer, _source_buffer_opt) =
-            transfer.free();
+        let (_stream0, _mem2mem, target_buffer, _) = transfer.free();
 
         for a in target_buffer.iter() {
             assert_eq!(*a, 0x11223344);

--- a/examples/sdmmc.rs
+++ b/examples/sdmmc.rs
@@ -41,7 +41,7 @@ fn main() -> ! {
     let gpiod = dp.GPIOD.split(ccdr.peripheral.GPIOD);
 
     // STM32H747I-DISCO development board
-    #[cfg(any(feature = "rm0399"))]
+    #[cfg(feature = "rm0399")]
     let mut led = {
         let gpioi = dp.GPIOI.split(ccdr.peripheral.GPIOI);
 

--- a/examples/spi-dma-rtic.rs
+++ b/examples/spi-dma-rtic.rs
@@ -97,7 +97,7 @@ mod app {
         // Initialize our transmit buffer.
         let buffer: &'static mut [u8; BUFFER_SIZE] = {
             let buf: &mut [MaybeUninit<u8>; BUFFER_SIZE] = unsafe {
-                &mut *(&mut BUFFER as *mut MaybeUninit<[u8; BUFFER_SIZE]>
+                &mut *(core::ptr::addr_of_mut!(BUFFER)
                     as *mut [MaybeUninit<u8>; BUFFER_SIZE])
             };
 
@@ -107,10 +107,7 @@ mod app {
                 }
             }
 
-            unsafe {
-                &mut *(buf as *mut [MaybeUninit<u8>; BUFFER_SIZE]
-                    as *mut [u8; BUFFER_SIZE])
-            }
+            unsafe { BUFFER.assume_init_mut() }
         };
 
         let streams = hal::dma::dma::StreamsTuple::new(

--- a/examples/spi-dma.rs
+++ b/examples/spi-dma.rs
@@ -7,7 +7,6 @@
 //! into chunks and using the `next_transfer_with` method to start each part of
 //! the transfer.
 
-#![allow(clippy::transmute_ptr_to_ptr)]
 #![deny(warnings)]
 #![no_main]
 #![no_std]
@@ -85,26 +84,28 @@ fn main() -> ! {
     // uninitialisated memory
     let short_buffer: &'static mut [u8; 10] = {
         let buf: &mut [MaybeUninit<u8>; 10] =
-            unsafe { mem::transmute(&mut SHORT_BUFFER) };
+            unsafe { &mut *(core::ptr::addr_of_mut!(SHORT_BUFFER) as *mut _) };
 
         for (i, value) in buf.iter_mut().enumerate() {
             unsafe {
                 value.as_mut_ptr().write(i as u8 + 96); // 0x60, 0x61, 0x62...
             }
         }
-        unsafe { mem::transmute(buf) }
+        unsafe { SHORT_BUFFER.assume_init_mut() }
     };
     // view u32 buffer as u8. Endianess is undefined (little-endian on STM32H7)
     let long_buffer: &'static mut [u8; 0x2_0010] = {
         let buf: &mut [MaybeUninit<u32>; 0x8004] =
-            unsafe { mem::transmute(&mut LONG_BUFFER) };
+            unsafe { &mut *(core::ptr::addr_of_mut!(LONG_BUFFER) as *mut _) };
 
         for (i, value) in buf.iter_mut().enumerate() {
             unsafe {
                 value.as_mut_ptr().write(i as u32);
             }
         }
-        unsafe { mem::transmute(buf) }
+        unsafe {
+            &mut *(core::ptr::addr_of_mut!(LONG_BUFFER) as *mut [u8; 0x2_0010])
+        }
     };
 
     // Setup the DMA transfer on stream 0

--- a/examples/usb_passthrough.rs
+++ b/examples/usb_passthrough.rs
@@ -4,10 +4,13 @@
 //!
 //! This example uses both USB1 and USB2. This is only possible on devices that
 //! have the USB2 peripheral.
+#![deny(warnings)]
 #![no_std]
 #![no_main]
 
 use panic_itm as _;
+
+use core::mem::MaybeUninit;
 
 use cortex_m_rt::entry;
 
@@ -17,8 +20,8 @@ use stm32h7xx_hal::{prelude::*, stm32};
 
 use usb_device::prelude::*;
 
-static mut EP_MEMORY_1: [u32; 1024] = [0; 1024];
-static mut EP_MEMORY_2: [u32; 1024] = [0; 1024];
+static mut EP_MEMORY_1: MaybeUninit<[u32; 1024]> = MaybeUninit::uninit();
+static mut EP_MEMORY_2: MaybeUninit<[u32; 1024]> = MaybeUninit::uninit();
 
 #[entry]
 fn main() -> ! {
@@ -68,8 +71,25 @@ fn main() -> ! {
         &ccdr.clocks,
     );
 
+    // Initialise EP_MEMORY_1 to zero
+    unsafe {
+        let buf: &mut [MaybeUninit<u32>; 1024] =
+            &mut *(core::ptr::addr_of_mut!(EP_MEMORY_1) as *mut _);
+        for value in buf.iter_mut() {
+            value.as_mut_ptr().write(0);
+        }
+    }
+    // Initialise EP_MEMORY_2 to zero
+    unsafe {
+        let buf: &mut [MaybeUninit<u32>; 1024] =
+            &mut *(core::ptr::addr_of_mut!(EP_MEMORY_2) as *mut _);
+        for value in buf.iter_mut() {
+            value.as_mut_ptr().write(0);
+        }
+    }
+
     // Port 1
-    let usb1_bus = UsbBus::new(usb1, unsafe { &mut EP_MEMORY_1 });
+    let usb1_bus = UsbBus::new(usb1, unsafe { EP_MEMORY_1.assume_init_mut() });
     let mut serial1 = usbd_serial::SerialPort::new(&usb1_bus);
     let mut usb1_dev =
         UsbDeviceBuilder::new(&usb1_bus, UsbVidPid(0x16c0, 0x27dd))
@@ -82,7 +102,7 @@ fn main() -> ! {
             .build();
 
     // Port 2
-    let usb2_bus = UsbBus::new(usb2, unsafe { &mut EP_MEMORY_2 });
+    let usb2_bus = UsbBus::new(usb2, unsafe { EP_MEMORY_2.assume_init_mut() });
     let mut serial2 = usbd_serial::SerialPort::new(&usb2_bus);
     let mut usb2_dev =
         UsbDeviceBuilder::new(&usb2_bus, UsbVidPid(0x16c0, 0x27dd))

--- a/examples/usb_phy_serial_interrupt.rs
+++ b/examples/usb_phy_serial_interrupt.rs
@@ -3,6 +3,7 @@
 //! This example is for RM0433/RM0399 parts. It has been tested on the Arduino
 //! Portenta H7
 #![deny(warnings)]
+#![allow(clippy::type_complexity)]
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
[rust/#114447](https://github.com/rust-lang/rust/issues/114447) made `&mut MY_STATIC_MUT` a warning, with the intention of disallowing it entirely in the 2024 edition. We never used this in the crate itself, but it is used in many examples.

This commit removes these references from the examples. In general the new approach is to change `static mut` of type `X` to type `MaybeUninit<X>`. These can then cleanly be accessed with [`MY_STATIC_MUT.write()`](https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#method.write) followed by [`MY_STATIC_MUT.assume_init_mut()`](https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#method.assume_init_mut).

Where we need to cast a (reference to a)`MaybeUninit<[X; N]>` to a `[MaybeUninit<X>; N]` in order to initialise it element-by-element, the `&mut *ptr::addr_of_mut!(MY_STATIC_MUT)` construction is still used. After initialisation, we can then access it with `MY_STATIC_MUT.assume_init_mut()`.

In a few DMA Examples we were taking a reference `&mut TARGET_BUFFER` without initialising TARGET_BUFFER. This commit changes this to `TARGET_BUFFER.assume_init_mut()` *without* initialising `TARGET_BUFFER`. This was and remains UB.

* USB Examples: `static mut EP_MEMORY` now has type `MaybeUninit<[u32; 1024]>`
* Ethernet Examples: `static mut DES_RING` now has type `MaybeUninit<ethernet::DesRing<4, 4>>`