### PR TITLE
Upgrade smoltcp to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ fdcan = { version = "0.2", optional = true }
 embedded-storage = "0.3"
 
 [dependencies.smoltcp]
-version = "0.10.0"
+version = "0.11.0"
 default-features = false
 features = ["medium-ethernet", "proto-ipv4", "socket-raw"]
 optional = true
@@ -83,11 +83,6 @@ tinybmp = "0.5"
 embedded-graphics = "0.8"
 otm8009a = "0.1"
 eg-seven-segment = "0.2.0"
-
-[dev-dependencies.smoltcp]
-version = "0.10.0"
-default-features = false
-features = ["medium-ethernet", "proto-ipv4", "proto-ipv6", "socket-raw"]
 
 [features]
 default = ["rt"]


### PR DESCRIPTION
Also remove extra "proto-ipv6" feature that is not needed by examples