### PR TITLE
Tidy redundant imports

### DIFF
--- a/examples/usb_phy_serial_interrupt.rs
+++ b/examples/usb_phy_serial_interrupt.rs
@@ -18,8 +18,10 @@ use {
         stm32,
         usb_hs::{UsbBus, USB1_ULPI},
     },
-    usb_device::prelude::*,
-    usb_device::{bus::UsbBusAllocator, device::UsbDevice},
+    usb_device::{
+        bus::UsbBusAllocator,
+        device::{UsbDevice, UsbDeviceBuilder, UsbVidPid},
+    },
     usbd_serial::{DefaultBufferStore, SerialPort},
 };
 

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -4,7 +4,6 @@
 //!
 //! - [CRC example](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/crc.rs)
 
-use core::convert::TryInto;
 use core::fmt;
 
 use crate::rcc::{rec, ResetEnable};

--- a/src/ethernet/eth.rs
+++ b/src/ethernet/eth.rs
@@ -28,7 +28,6 @@ use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::stm32;
 
 use smoltcp::{
-    self,
     phy::{self, DeviceCapabilities},
     time::Instant,
     wire::EthernetAddress,

--- a/src/sai/i2s.rs
+++ b/src/sai/i2s.rs
@@ -2,7 +2,6 @@
 //!
 //! Inter-IC Sound.
 //!
-use core::convert::TryInto;
 
 use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::sai::{GetClkSAI, Sai, SaiChannel, CLEAR_ALL_FLAGS_BITS, INTERFACE};

--- a/src/sai/pdm.rs
+++ b/src/sai/pdm.rs
@@ -15,8 +15,6 @@
 //! let _ = block!(sai.read_data()).unwrap();
 //! ```
 
-use core::convert::TryInto;
-
 use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::sai::{GetClkSAI, Sai, SaiChannel, INTERFACE};
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -63,7 +63,6 @@
 //! [embedded_hal]: https://docs.rs/embedded-hal/0.2.3/embedded_hal/spi/index.html
 
 use core::cell::UnsafeCell;
-use core::convert::From;
 use core::marker::PhantomData;
 use core::ptr;
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -8,7 +8,6 @@
 // TODO: on the h7x3 at least, only TIM2, TIM3, TIM4, TIM5 can support 32 bits.
 // TIM1 is 16 bit.
 
-use core::convert::TryFrom;
 use core::marker::PhantomData;
 
 use crate::hal::timer::{CountDown, Periodic};


### PR DESCRIPTION
`TryFrom` and `TryInto` are part of the Rust prelude [since the 2021 edition](https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html). https://github.com/stm32-rs/stm32h7xx-hal/pull/236