### PR TITLE
Add support for using different modes for each phase of an xspi operation

### DIFF
--- a/src/xspi/octospi.rs
+++ b/src/xspi/octospi.rs
@@ -459,9 +459,9 @@ macro_rules! octospi_impl {
                 // Communications configuration register
                 regs.ccr.write(|w| unsafe {
                     w.dmode()
-                        .bits(config.mode.reg_value())
+                        .bits(config.modes.data.reg_value())
                         .admode()
-                        .bits(config.mode.reg_value())
+                        .bits(config.modes.address.reg_value())
                         .adsize()
                         .bits(0) // Eight-bit address
                         .imode()
@@ -498,7 +498,7 @@ macro_rules! octospi_impl {
 
                 Octospi {
                     rb: regs,
-                    mode: config.mode,
+                    modes: config.modes,
                 }
             }
 

--- a/src/xspi/qspi.rs
+++ b/src/xspi/qspi.rs
@@ -290,9 +290,9 @@ impl Qspi<stm32::QUADSPI> {
             w.fmode()
                 .bits(0) // indirect mode
                 .dmode()
-                .bits(config.mode.reg_value())
+                .bits(config.modes.data.reg_value())
                 .admode()
-                .bits(config.mode.reg_value())
+                .bits(config.modes.address.reg_value())
                 .adsize()
                 .bits(0) // Eight-bit address
                 .imode()
@@ -338,7 +338,7 @@ impl Qspi<stm32::QUADSPI> {
 
         Qspi {
             rb: regs,
-            mode: config.mode,
+            modes: config.modes,
         }
     }
 }


### PR DESCRIPTION
This adds `Config.modes` and `Xspi.configure_modes` methods but keeps the existing API (which sets the same mode for all phases).
