### PR TITLE
Add access_banks flash accessor

### DIFF
--- a/src/flash/mod.rs
+++ b/src/flash/mod.rs
@@ -130,7 +130,7 @@ pub trait FlashExt {
         &mut self,
         f: impl FnOnce(&mut LockedFlashBank, Option<&mut LockedFlashBank>) -> T,
     ) -> T;
-    ///
+    /// Access to memory bank 1.
     fn access_bank1<F, T>(&mut self, f: F) -> T
     where
         F: FnOnce(&mut LockedFlashBank) -> T;


### PR DESCRIPTION
This adds a `access_banks` helper to the `FlashExt`, which is a middle ground between `access_bank1` and `split`.

## Problem
Right now the only way to access bank 2 is using the `split` method, which consumes the `FLASH` instance. In my usecase I want to access both flash banks but I also need to flip the banks at some point, so I need to have access to the option control register via [`FLASH::optcr(&self)`](https://docs.rs/stm32h7/0.15.1/stm32h7/stm32h743v/flash/struct.RegisterBlock.html#method.optcr), which needs the `FLASH` instance.

## Solution
Using the new `access_banks` helper I can keep the `FLASH` instance around and get access to both banks as well as the option control register when I need it.