### PR TITLE
Update examples to RTIC v2 framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * flash: Add `access_banks` method [#489]
 * qspi/octospi: Support different modes for each phase of an xspi operation [#488]
 * timer: Fix off-by-one-tick in timer period calculation [#491]
+* **Breaking** Update `smoltcp` to `0.12.0` (from `0.11.0`)
+* Examples use RTIC v2
 
 ## [v0.16.0] 2024-03-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ optional = true
 
 [dev-dependencies]
 cortex-m-rt = ">=0.6.15,<0.8"
-cortex-m-rtic = "1.1"
+rtic = { version = "2.1", features = ["thumbv7-backend"] }
 log = "0.4.11"
 panic-halt = "0.2.0"
 panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }

--- a/examples/ethernet-rtic-nucleo-h723zg.rs
+++ b/examples/ethernet-rtic-nucleo-h723zg.rs
@@ -1,5 +1,5 @@
-//! Demo for Nucleo-H723ZG eval board using the Real Time for the Masses
-//! (RTIC) framework.
+//! Demo for Nucleo-H723ZG evaluation board using the Real-Time Interrupt-driven
+//! Concurrency (RTIC) framework.
 //!
 //! This demo responds to pings on 192.168.1.99 (IP address hardcoded below)
 //!
@@ -116,9 +116,7 @@ mod app {
     }
 
     #[init]
-    fn init(
-        mut ctx: init::Context,
-    ) -> (SharedResources, LocalResources, init::Monotonics) {
+    fn init(mut ctx: init::Context) -> (SharedResources, LocalResources) {
         utilities::logger::init();
         // Initialise power...
         let pwr = ctx.device.PWR.constrain();
@@ -227,7 +225,6 @@ mod app {
                 lan8742a,
                 link_led,
             },
-            init::Monotonics(),
         )
     }
 

--- a/examples/ethernet-rtic-stm32h735g-dk.rs
+++ b/examples/ethernet-rtic-stm32h735g-dk.rs
@@ -1,5 +1,5 @@
-//! Demo for STM32H735G-DK eval board using the Real Time for the Masses
-//! (RTIC) framework.
+//! Demo for STM32H735G-DK eval board using the Real-Time Interrupt-driven
+//! Concurrency (RTIC) framework.
 //!
 //! This demo responds to pings on 192.168.1.99 (IP address hardcoded below)
 //!
@@ -111,9 +111,8 @@ mod app {
     }
 
     #[init]
-    fn init(
-        mut ctx: init::Context,
-    ) -> (SharedResources, LocalResources, init::Monotonics) {
+
+    fn init(mut ctx: init::Context) -> (SharedResources, LocalResources) {
         utilities::logger::init();
         // Initialise power...
         let pwr = ctx.device.PWR.constrain();
@@ -221,7 +220,6 @@ mod app {
                 lan8742a,
                 link_led,
             },
-            init::Monotonics(),
         )
     }
 

--- a/examples/ethernet-rtic-stm32h747i-disco.rs
+++ b/examples/ethernet-rtic-stm32h747i-disco.rs
@@ -1,5 +1,5 @@
-//! Demo for STM32H747I-DISCO eval board using the Real Time for the Masses
-//! (RTIC) framework.
+//! Demo for STM32H747I-DISCO eval board using the Real-Time Interrupt-driven
+//! Concurrency (RTIC) framework.
 //!
 //! STM32H747I-DISCO: RMII TXD1 is on PG12
 //!
@@ -118,9 +118,7 @@ mod app {
     }
 
     #[init]
-    fn init(
-        mut ctx: init::Context,
-    ) -> (SharedResources, LocalResources, init::Monotonics) {
+    fn init(mut ctx: init::Context) -> (SharedResources, LocalResources) {
         utilities::logger::init();
         // Initialise power...
         let pwr = ctx.device.PWR.constrain();
@@ -231,7 +229,6 @@ mod app {
                 lan8742a,
                 link_led,
             },
-            init::Monotonics(),
         )
     }
 

--- a/examples/rtic.rs
+++ b/examples/rtic.rs
@@ -1,3 +1,5 @@
+//! Simple example of the Real-Time Interrupt-driven Concurrency (RTIC)
+//! framework. Originally tested on a STM32H735G-DK.
 #![deny(warnings)]
 #![deny(unsafe_code)]
 #![no_std]
@@ -24,9 +26,7 @@ mod app {
     }
 
     #[init]
-    fn init(
-        mut ctx: init::Context,
-    ) -> (SharedResources, LocalResources, init::Monotonics) {
+    fn init(mut ctx: init::Context) -> (SharedResources, LocalResources) {
         utilities::logger::init();
         let pwr = ctx.device.PWR.constrain();
         let pwrcfg = example_power!(pwr).freeze();
@@ -50,7 +50,6 @@ mod app {
                 button,
                 led: gpioc.pc3.into_push_pull_output(),
             },
-            init::Monotonics(),
         )
     }
 

--- a/examples/rtic_low_power.rs
+++ b/examples/rtic_low_power.rs
@@ -1,4 +1,5 @@
-//! Timers in RTIC with low power mode.
+//! Timers using the Real-Time Interrupt-driven Concurrency (RTIC) framework
+//! with low power mode.
 //!
 //! After the end of init the CPU transitions into CStop mode, and D1/D2
 //! (aka. CD) transition into DStop mode.
@@ -49,9 +50,7 @@ mod app {
     }
 
     #[init]
-    fn init(
-        ctx: init::Context,
-    ) -> (SharedResources, LocalResources, init::Monotonics) {
+    fn init(ctx: init::Context) -> (SharedResources, LocalResources) {
         utilities::logger::init();
         let mut syscfg = ctx.device.SYSCFG;
 
@@ -135,13 +134,12 @@ mod app {
                 timer2,
                 timer3,
             },
-            init::Monotonics(),
         )
     }
 
     // RTIC inserts a default idle loop that calls asm::wfi()
 
-    #[task(binds = EXTI15_10, local = [], priority = 1)]
+    #[task(binds = EXTI15_10, priority = 1)]
     fn exti15_10_interrupt(_: exti15_10_interrupt::Context) {
         // Once the wakeup is triggered, we loop here forever
     }

--- a/examples/rtic_timers.rs
+++ b/examples/rtic_timers.rs
@@ -1,4 +1,5 @@
-//! Timers in RTIC. Tests TIM1, TIM2, TIM12, TIM17
+//! Timers using the Real-Time Interrupt-driven Concurrency (RTIC)
+//! framework. Tests TIM1, TIM2, TIM12, TIM17
 #![deny(warnings)]
 #![deny(unsafe_code)]
 #![no_std]
@@ -33,9 +34,7 @@ mod app {
     }
 
     #[init]
-    fn init(
-        ctx: init::Context,
-    ) -> (SharedResources, LocalResources, init::Monotonics) {
+    fn init(ctx: init::Context) -> (SharedResources, LocalResources) {
         utilities::logger::init();
         let pwr = ctx.device.PWR.constrain();
         let pwrcfg = example_power!(pwr).freeze();
@@ -88,7 +87,6 @@ mod app {
                 led3: gpioi.pi14.into_push_pull_output(),
                 led4: gpioi.pi15.into_push_pull_output(),
             },
-            init::Monotonics(),
         )
     }
 

--- a/examples/sai-i2s-passthru.rs
+++ b/examples/sai-i2s-passthru.rs
@@ -42,9 +42,7 @@ mod app {
     struct LocalResources {}
 
     #[init]
-    fn init(
-        mut ctx: init::Context,
-    ) -> (SharedResources, LocalResources, init::Monotonics) {
+    fn init(mut ctx: init::Context) -> (SharedResources, LocalResources) {
         utilities::logger::init();
         let pwr = ctx.device.PWR.constrain();
         let vos = example_power!(pwr).freeze();
@@ -113,11 +111,7 @@ mod app {
         audio.try_send(0, 0).unwrap();
         info!("Startup complete!");
 
-        (
-            SharedResources { audio },
-            LocalResources {},
-            init::Monotonics(),
-        )
+        (SharedResources { audio }, LocalResources {})
     }
 
     #[task(binds = SAI1, shared = [audio] )]

--- a/examples/spi-dma-rtic.rs
+++ b/examples/spi-dma-rtic.rs
@@ -1,5 +1,5 @@
-//! Demo for STM32H747I-NUCLEO eval board using the Real Time Interrupt-driven Concurrency (RTIC)
-//! framework.
+//! Demo for STM32H747I-NUCLEO eval board using the Real-Time Interrupt-driven
+//! Concurrency (RTIC) framework.
 //!
 //! This example demonstrates using DMA to write data over a TX-only SPI interface.
 #![deny(warnings)]
@@ -45,9 +45,7 @@ mod app {
     #[local]
     struct LocalResources {}
     #[init]
-    fn init(
-        ctx: init::Context,
-    ) -> (SharedResources, LocalResources, init::Monotonics) {
+    fn init(ctx: init::Context) -> (SharedResources, LocalResources) {
         utilities::logger::init();
 
         // Initialise power...
@@ -132,11 +130,7 @@ mod app {
             _,
         > = hal::dma::Transfer::init(streams.1, spi, buffer, None, config);
 
-        (
-            SharedResources { cs, transfer },
-            LocalResources {},
-            init::Monotonics(),
-        )
+        (SharedResources { cs, transfer }, LocalResources {})
     }
 
     #[task(binds=DMA1_STR1, shared = [transfer, cs], priority=2)]

--- a/examples/usb_rtic.rs
+++ b/examples/usb_rtic.rs
@@ -38,9 +38,7 @@ mod app {
     }
 
     #[init]
-    fn init(
-        ctx: init::Context,
-    ) -> (SharedResources, LocalResources, init::Monotonics) {
+    fn init(ctx: init::Context) -> (SharedResources, LocalResources) {
         utilities::logger::init();
         let pwr = ctx.device.PWR.constrain();
         let pwrcfg = example_power!(pwr).freeze();
@@ -118,7 +116,6 @@ mod app {
                 usb,
                 led: led.into_push_pull_output(),
             },
-            init::Monotonics(),
         )
     }
 


### PR DESCRIPTION
We don't implement anything RTIC-specific in the HAL itself and the examples use only basic RTIC functions. Therefore these changes are quite limited.

~Intend to merge sometime after v0.17 release~