### PR TITLE
Moving embedded-hal 0.2 traits to separate package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 fugit = "0.3.5"
-embedded-hal = { version = "0.2.6", features = ["unproven"] }
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
+embedded-hal-1 = { package = "embedded-hal", version = "1" }
 embedded-dma = "0.2.0"
 cortex-m = { version = "^0.7.7", features = ["critical-section-single-core"] }
 defmt = { version = ">=0.2.0,<0.4", optional = true }

--- a/examples/dac.rs
+++ b/examples/dac.rs
@@ -4,7 +4,7 @@
 
 use cortex_m::asm;
 use cortex_m_rt::entry;
-use stm32h7xx_hal::hal::Direction;
+use stm32h7xx_hal::hal_02::Direction;
 #[macro_use]
 mod utilities;
 use stm32h7xx_hal::{pac, prelude::*};

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -11,8 +11,7 @@
 //! - [Using ADC1 and ADC2 in parallel](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/adc12_parallel.rs)
 //! - [Using ADC1 through DMA](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/adc_dma.rs)
 
-use crate::hal::adc::{Channel, OneShot};
-use crate::hal::blocking::delay::DelayUs;
+use embedded_hal_02::blocking::delay::DelayUs;
 
 use core::convert::Infallible;
 use core::marker::PhantomData;
@@ -189,7 +188,7 @@ impl AdcCalLinear {
 macro_rules! adc_pins {
     ($ADC:ident, $($input:ty => $chan:expr),+ $(,)*) => {
         $(
-            impl Channel<$ADC> for $input {
+            impl embedded_hal_02::adc::Channel<$ADC> for $input {
                 type ID = u8;
 
                 fn channel() -> u8 {
@@ -823,7 +822,7 @@ macro_rules! adc_hal {
                 /// The value can be then read through the `read_sample` method.
                 // Refer to RM0433 Rev 7 - Chapter 25.4.16
                 pub fn start_conversion<PIN>(&mut self, _pin: &mut PIN)
-                    where PIN: Channel<$ADC, ID = u8>,
+                    where PIN: embedded_hal_02::adc::Channel<$ADC, ID = u8>,
                 {
                     let chan = PIN::channel();
                     assert!(chan <= 19);
@@ -841,7 +840,7 @@ macro_rules! adc_hal {
                 /// This method starts a conversion sequence with DMA
                 /// enabled. The DMA mode selected depends on the [`AdcDmaMode`] specified.
                 pub fn start_conversion_dma<PIN>(&mut self, _pin: &mut PIN, mode: AdcDmaMode)
-                    where PIN: Channel<$ADC, ID = u8>,
+                    where PIN: embedded_hal_02::adc::Channel<$ADC, ID = u8>,
                 {
                     let chan = PIN::channel();
                     assert!(chan <= 19);
@@ -1112,10 +1111,10 @@ macro_rules! adc_hal {
                 }
             }
 
-            impl<WORD, PIN> OneShot<$ADC, WORD, PIN> for Adc<$ADC, Enabled>
+            impl<WORD, PIN> embedded_hal_02::adc::OneShot<$ADC, WORD, PIN> for Adc<$ADC, Enabled>
             where
                 WORD: From<u32>,
-                PIN: Channel<$ADC, ID = u8>,
+                PIN: embedded_hal_02::adc::Channel<$ADC, ID = u8>,
             {
                 type Error = ();
 

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -9,7 +9,7 @@ use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 
 use crate::gpio::{self, Analog};
-use crate::hal::blocking::delay::DelayUs;
+use crate::hal_02::blocking::delay::DelayUs;
 use crate::rcc::{rec, ResetEnable};
 #[cfg(not(feature = "rm0455"))]
 use crate::stm32::DAC as DAC1;

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -40,10 +40,6 @@
 use cast::u32;
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::SYST;
-use embedded_hal::{
-    blocking::delay::{DelayMs, DelayUs},
-    timer::CountDown,
-};
 use void::Void;
 
 use crate::nb::block;
@@ -110,7 +106,7 @@ impl<'a> Countdown<'a> {
     }
 }
 
-impl<'a> CountDown for Countdown<'a> {
+impl<'a> embedded_hal_02::timer::CountDown for Countdown<'a> {
     type Time = fugit::MicrosDurationU32;
 
     fn start<T>(&mut self, count: T)
@@ -163,25 +159,26 @@ impl Delay {
     }
 }
 
-impl DelayMs<u32> for Delay {
+impl embedded_hal_02::blocking::delay::DelayMs<u32> for Delay {
     fn delay_ms(&mut self, ms: u32) {
+        use embedded_hal_02::blocking::delay::DelayUs;
         self.delay_us(ms * 1_000);
     }
 }
 
-impl DelayMs<u16> for Delay {
+impl embedded_hal_02::blocking::delay::DelayMs<u16> for Delay {
     fn delay_ms(&mut self, ms: u16) {
         self.delay_ms(u32(ms));
     }
 }
 
-impl DelayMs<u8> for Delay {
+impl embedded_hal_02::blocking::delay::DelayMs<u8> for Delay {
     fn delay_ms(&mut self, ms: u8) {
         self.delay_ms(u32(ms));
     }
 }
 
-impl DelayUs<u32> for Delay {
+impl embedded_hal_02::blocking::delay::DelayUs<u32> for Delay {
     fn delay_us(&mut self, us: u32) {
         // The SysTick Reload Value register supports values between 1 and 0x00FFFFFF.
         const MAX_RVR: u32 = 0x00FF_FFFF;
@@ -220,13 +217,13 @@ impl DelayUs<u32> for Delay {
     }
 }
 
-impl DelayUs<u16> for Delay {
+impl embedded_hal_02::blocking::delay::DelayUs<u16> for Delay {
     fn delay_us(&mut self, us: u16) {
         self.delay_us(u32(us))
     }
 }
 
-impl DelayUs<u8> for Delay {
+impl embedded_hal_02::blocking::delay::DelayUs<u8> for Delay {
     fn delay_us(&mut self, us: u8) {
         self.delay_us(u32(us))
     }
@@ -251,9 +248,9 @@ macro_rules! impl_delay_from_count_down_timer  {
     ($(($Delay:ident, $delay:ident, $num:expr)),+) => {
         $(
 
-            impl<T> $Delay<u32> for DelayFromCountDownTimer<T>
+            impl<T> embedded_hal_02::blocking::delay::$Delay<u32> for DelayFromCountDownTimer<T>
             where
-                T: CountDown<Time = Hertz>,
+                T: embedded_hal_02::timer::CountDown<Time = Hertz>,
             {
                 fn $delay(&mut self, t: u32) {
                     let mut time_left = t;
@@ -280,18 +277,18 @@ macro_rules! impl_delay_from_count_down_timer  {
                 }
             }
 
-            impl<T> $Delay<u16> for DelayFromCountDownTimer<T>
+            impl<T> embedded_hal_02::blocking::delay::$Delay<u16> for DelayFromCountDownTimer<T>
             where
-                T: CountDown<Time = Hertz>,
+                T: embedded_hal_02::timer::CountDown<Time = Hertz>,
             {
                 fn $delay(&mut self, t: u16) {
                     self.$delay(t as u32);
                 }
             }
 
-            impl<T> $Delay<u8> for DelayFromCountDownTimer<T>
+            impl<T> embedded_hal_02::blocking::delay::$Delay<u8> for DelayFromCountDownTimer<T>
             where
-                T: CountDown<Time = Hertz>,
+                T: embedded_hal_02::timer::CountDown<Time = Hertz>,
             {
                 fn $delay(&mut self, t: u8) {
                     self.$delay(t as u32);

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -992,9 +992,9 @@ where
     /// MDMA block. The length is referred to the source size
     ///
     /// * `s_len`: The number of input words of s_size available. `None` if the
-    /// source is a peripheral
+    ///   source is a peripheral
     /// * `d_len`: The number of input words of d_size available. `None` if the
-    /// destination is a peripheral
+    ///   destination is a peripheral
     ///
     /// `s_len` and `d_len` cannot both be peripherals (None)
     fn m_number_of_bytes(
@@ -1052,24 +1052,24 @@ where
     /// # Panics
     ///
     /// * When a memory-memory transfer is specified but the `second_buf`
-    /// argument is `None`.
+    ///   argument is `None`.
     ///
     /// * When the length is greater than 65536 bytes.
     ///
     /// * When `config` specifies a `source_increment` that is smaller than the
-    /// source size.
+    ///   source size.
     ///
     /// * When `config` specifies a `destination_increment` that is smaller than
-    /// the destination size.
+    ///   the destination size.
     ///
     /// * When `config` specifies a `transfer_length` that is not a multiple of
-    /// both the source and destination sizes.
+    ///   both the source and destination sizes.
     ///
     /// * When `config` specifies a `packing_alignment` that extends the source,
-    /// but the source size is larger than the destination size.
+    ///   but the source size is larger than the destination size.
     ///
     /// * When `config` specifies a `packing_alignment` that truncates the
-    /// source, but the source size is smaller than the destination size.
+    ///   source, but the source size is smaller than the destination size.
     pub fn init_master(
         mut stream: STREAM,
         peripheral: PERIPHERAL,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -27,14 +27,14 @@
 //! - **Dynamic**: Pin mode is selected at runtime. See changing configurations for more details
 //! - Input
 //!     - **PullUp**: Input connected to high with a weak pull up resistor. Will be high when nothing
-//!     is connected
+//!       is connected
 //!     - **PullDown**: Input connected to high with a weak pull up resistor. Will be low when nothing
-//!     is connected
+//!       is connected
 //!     - **Floating**: Input not pulled to high or low. Will be undefined when nothing is connected
 //! - Output
 //!     - **PushPull**: Output which either drives the pin high or low
 //!     - **OpenDrain**: Output which leaves the gate floating, or pulls it do ground in drain
-//!     mode. Can be used as an input in the `open` configuration
+//!       mode. Can be used as an input in the `open` configuration
 //!
 //! ## Changing modes
 //! The simplest way to change the pin mode is to use the `into_<mode>` functions. These return a

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -77,7 +77,7 @@ mod dynamic;
 pub use dynamic::{Dynamic, DynamicPin};
 mod hal_02;
 
-pub use embedded_hal::digital::v2::PinState;
+pub use embedded_hal_02::digital::v2::PinState;
 
 use core::fmt;
 

--- a/src/gpio/hal_02.rs
+++ b/src/gpio/hal_02.rs
@@ -5,13 +5,11 @@ use super::{
     Output, PartiallyErasedPin, Pin, PinMode, PinState,
 };
 
-use embedded_hal::digital::v2::{
-    InputPin, IoPin, OutputPin, StatefulOutputPin, ToggleableOutputPin,
-};
-
 // Implementations for `Pin`
 
-impl<const P: char, const N: u8, MODE> OutputPin for Pin<P, N, Output<MODE>> {
+impl<const P: char, const N: u8, MODE> embedded_hal_02::digital::v2::OutputPin
+    for Pin<P, N, Output<MODE>>
+{
     type Error = Infallible;
 
     #[inline(always)]
@@ -27,7 +25,8 @@ impl<const P: char, const N: u8, MODE> OutputPin for Pin<P, N, Output<MODE>> {
     }
 }
 
-impl<const P: char, const N: u8, MODE> StatefulOutputPin
+impl<const P: char, const N: u8, MODE>
+    embedded_hal_02::digital::v2::StatefulOutputPin
     for Pin<P, N, Output<MODE>>
 {
     #[inline(always)]
@@ -41,7 +40,8 @@ impl<const P: char, const N: u8, MODE> StatefulOutputPin
     }
 }
 
-impl<const P: char, const N: u8, MODE> ToggleableOutputPin
+impl<const P: char, const N: u8, MODE>
+    embedded_hal_02::digital::v2::ToggleableOutputPin
     for Pin<P, N, Output<MODE>>
 {
     type Error = Infallible;
@@ -53,7 +53,8 @@ impl<const P: char, const N: u8, MODE> ToggleableOutputPin
     }
 }
 
-impl<const P: char, const N: u8, MODE> InputPin for Pin<P, N, MODE>
+impl<const P: char, const N: u8, MODE> embedded_hal_02::digital::v2::InputPin
+    for Pin<P, N, MODE>
 where
     MODE: marker::Readable,
 {
@@ -70,7 +71,7 @@ where
     }
 }
 
-impl<const P: char, const N: u8> IoPin<Self, Self>
+impl<const P: char, const N: u8> embedded_hal_02::digital::v2::IoPin<Self, Self>
     for Pin<P, N, Output<OpenDrain>>
 {
     type Error = Infallible;
@@ -83,7 +84,8 @@ impl<const P: char, const N: u8> IoPin<Self, Self>
     }
 }
 
-impl<const P: char, const N: u8, Otype> IoPin<Pin<P, N, Input>, Self>
+impl<const P: char, const N: u8, Otype>
+    embedded_hal_02::digital::v2::IoPin<Pin<P, N, Input>, Self>
     for Pin<P, N, Output<Otype>>
 where
     Output<Otype>: PinMode,
@@ -98,7 +100,8 @@ where
     }
 }
 
-impl<const P: char, const N: u8, Otype> IoPin<Self, Pin<P, N, Output<Otype>>>
+impl<const P: char, const N: u8, Otype>
+    embedded_hal_02::digital::v2::IoPin<Self, Pin<P, N, Output<Otype>>>
     for Pin<P, N, Input>
 where
     Output<Otype>: PinMode,
@@ -118,7 +121,7 @@ where
 
 // Implementations for `ErasedPin`
 
-impl<MODE> OutputPin for ErasedPin<Output<MODE>> {
+impl<MODE> embedded_hal_02::digital::v2::OutputPin for ErasedPin<Output<MODE>> {
     type Error = core::convert::Infallible;
 
     #[inline(always)]
@@ -134,7 +137,9 @@ impl<MODE> OutputPin for ErasedPin<Output<MODE>> {
     }
 }
 
-impl<MODE> StatefulOutputPin for ErasedPin<Output<MODE>> {
+impl<MODE> embedded_hal_02::digital::v2::StatefulOutputPin
+    for ErasedPin<Output<MODE>>
+{
     #[inline(always)]
     fn is_set_high(&self) -> Result<bool, Self::Error> {
         Ok(self.is_set_high())
@@ -146,7 +151,9 @@ impl<MODE> StatefulOutputPin for ErasedPin<Output<MODE>> {
     }
 }
 
-impl<MODE> ToggleableOutputPin for ErasedPin<Output<MODE>> {
+impl<MODE> embedded_hal_02::digital::v2::ToggleableOutputPin
+    for ErasedPin<Output<MODE>>
+{
     type Error = Infallible;
 
     #[inline(always)]
@@ -156,7 +163,7 @@ impl<MODE> ToggleableOutputPin for ErasedPin<Output<MODE>> {
     }
 }
 
-impl<MODE> InputPin for ErasedPin<MODE>
+impl<MODE> embedded_hal_02::digital::v2::InputPin for ErasedPin<MODE>
 where
     MODE: marker::Readable,
 {
@@ -175,7 +182,9 @@ where
 
 // Implementations for `PartiallyErasedPin`
 
-impl<const P: char, MODE> OutputPin for PartiallyErasedPin<P, Output<MODE>> {
+impl<const P: char, MODE> embedded_hal_02::digital::v2::OutputPin
+    for PartiallyErasedPin<P, Output<MODE>>
+{
     type Error = Infallible;
 
     #[inline(always)]
@@ -191,7 +200,7 @@ impl<const P: char, MODE> OutputPin for PartiallyErasedPin<P, Output<MODE>> {
     }
 }
 
-impl<const P: char, MODE> StatefulOutputPin
+impl<const P: char, MODE> embedded_hal_02::digital::v2::StatefulOutputPin
     for PartiallyErasedPin<P, Output<MODE>>
 {
     #[inline(always)]
@@ -205,7 +214,7 @@ impl<const P: char, MODE> StatefulOutputPin
     }
 }
 
-impl<const P: char, MODE> ToggleableOutputPin
+impl<const P: char, MODE> embedded_hal_02::digital::v2::ToggleableOutputPin
     for PartiallyErasedPin<P, Output<MODE>>
 {
     type Error = Infallible;
@@ -217,7 +226,8 @@ impl<const P: char, MODE> ToggleableOutputPin
     }
 }
 
-impl<const P: char, MODE> InputPin for PartiallyErasedPin<P, MODE>
+impl<const P: char, MODE> embedded_hal_02::digital::v2::InputPin
+    for PartiallyErasedPin<P, MODE>
 where
     MODE: marker::Readable,
 {
@@ -236,7 +246,9 @@ where
 
 // Implementations for `DynamicPin`
 
-impl<const P: char, const N: u8> OutputPin for DynamicPin<P, N> {
+impl<const P: char, const N: u8> embedded_hal_02::digital::v2::OutputPin
+    for DynamicPin<P, N>
+{
     type Error = PinModeError;
     fn set_high(&mut self) -> Result<(), Self::Error> {
         self.set_high()
@@ -246,7 +258,9 @@ impl<const P: char, const N: u8> OutputPin for DynamicPin<P, N> {
     }
 }
 
-impl<const P: char, const N: u8> InputPin for DynamicPin<P, N> {
+impl<const P: char, const N: u8> embedded_hal_02::digital::v2::InputPin
+    for DynamicPin<P, N>
+{
     type Error = PinModeError;
     fn is_high(&self) -> Result<bool, Self::Error> {
         self.is_high()

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -9,7 +9,6 @@ use core::cmp;
 use core::marker::PhantomData;
 
 use crate::gpio::{self, Alternate, OpenDrain};
-use crate::hal::blocking::i2c::{Read, Write, WriteRead};
 use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::stm32::{I2C1, I2C2, I2C3, I2C4};
 use crate::time::Hertz;
@@ -557,7 +556,7 @@ macro_rules! i2c {
                 }
             }
 
-            impl Write for I2c<$I2CX> {
+            impl embedded_hal_02::blocking::i2c::Write for I2c<$I2CX> {
                 type Error = Error;
 
                 fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
@@ -592,7 +591,7 @@ macro_rules! i2c {
                 }
             }
 
-            impl WriteRead for I2c<$I2CX> {
+            impl embedded_hal_02::blocking::i2c::WriteRead for I2c<$I2CX> {
                 type Error = Error;
 
                 fn write_read(
@@ -641,7 +640,7 @@ macro_rules! i2c {
                 }
             }
 
-            impl Read for I2c<$I2CX> {
+            impl embedded_hal_02::blocking::i2c::Read for I2c<$I2CX> {
                 type Error = Error;
 
                 fn read(

--- a/src/independent_watchdog.rs
+++ b/src/independent_watchdog.rs
@@ -1,9 +1,5 @@
 //! Independent Watchdog
 //!
-//! This module implements the embedded-hal
-//! [Watchdog](https://docs.rs/embedded-hal/latest/embedded_hal/watchdog/trait.Watchdog.html)
-//! trait for the Independent Watchdog peripheral.
-//!
 //! The Independent Watchdog peripheral triggers a system reset when its internal counter expires.
 //!
 //! # Peripheral Naming

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ compile_error!(
 "
 );
 
-pub use embedded_hal as hal;
+pub use embedded_hal_02 as hal_02;
 pub mod traits;
 
 pub use nb;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
 //! Prelude
-pub use embedded_hal::prelude::*;
+pub use embedded_hal_02::prelude::*;
 
 pub use crate::adc::AdcExt as _stm32h7xx_hal_adc_AdcExt;
 #[cfg(feature = "can")]

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -172,7 +172,6 @@
 
 use core::marker::PhantomData;
 
-use crate::hal;
 use crate::pac;
 
 use crate::rcc::{rec, CoreClocks, ResetEnable};
@@ -1447,7 +1446,7 @@ macro_rules! tim_pin_hal {
        ($CH:ident, $ccmrx_output:ident, $ocxpe:ident, $ocxm:ident),)+
     ) => {
         $(
-            impl<COMP> hal::PwmPin for Pwm<$TIMX, $CH, COMP>
+            impl<COMP> embedded_hal_02::PwmPin for Pwm<$TIMX, $CH, COMP>
                 where Pwm<$TIMX, $CH, COMP>: PwmPinEnable {
                 type Duty = $typ;
 
@@ -1760,7 +1759,7 @@ macro_rules! lptim_hal {
                 PINS::split()
             }
 
-            impl hal::PwmPin for Pwm<$TIMX, C1, ComplementaryImpossible> {
+            impl embedded_hal_02::PwmPin for Pwm<$TIMX, C1, ComplementaryImpossible> {
                 type Duty = u16;
 
                 // You may not access self in the following methods!

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -1,5 +1,4 @@
 //! # Quadrature Encoder Interface
-use crate::hal::{self, Direction};
 use crate::rcc::{rec, ResetEnable};
 
 use crate::gpio::{self, Alternate};
@@ -210,18 +209,18 @@ macro_rules! tim_hal {
                 }
             }
 
-            impl hal::Qei for Qei<$TIM> {
+            impl crate::hal_02::Qei for Qei<$TIM> {
                 type Count = $bits;
 
                 fn count(&self) -> $bits {
                     self.tim.cnt.read().bits() as $bits
                 }
 
-                fn direction(&self) -> Direction {
+                fn direction(&self) -> crate::hal_02::Direction {
                     if self.tim.cr1.read().dir().bit_is_clear() {
-                        hal::Direction::Upcounting
+                        crate::hal_02::Direction::Upcounting
                     } else {
-                        hal::Direction::Downcounting
+                        crate::hal_02::Direction::Downcounting
                     }
                 }
             }

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -185,7 +185,7 @@ macro_rules! tim_hal {
                     tim.smcr.write(|w| { w.sms().bits(3) });
 
                     #[allow(unused_unsafe)] // method is safe for some timers
-                    tim.arr.write(|w| unsafe { w.bits(core::u32::MAX) });
+                    tim.arr.write(|w| unsafe { w.bits(u32::MAX) });
                     tim.cr1.write(|w| w.cen().set_bit());
 
                     Qei { tim }

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -35,10 +35,10 @@
 //! * `use_hse(a)` implies `sys_ck(a)`
 //!
 //! * `sys_ck(b)` implies `pll1_p_ck(b)` unless `b` equals HSI or
-//! `use_hse(b)` was specified
+//!   `use_hse(b)` was specified
 //!
 //! * `pll1_p_ck(c)` implies `pll1_r_ck(c/2)`, including when
-//! `pll1_p_ck` was implied by `sys_ck(c)` or `mco2_from_pll1_p_ck(c)`.
+//!   `pll1_p_ck` was implied by `sys_ck(c)` or `mco2_from_pll1_p_ck(c)`.
 //!
 //! Implied clock specifications can always be overridden by explicitly
 //! specifying that clock. If this results in a configuration that cannot

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -7,7 +7,6 @@
 use core::cmp;
 use core::mem;
 
-use crate::hal::blocking::rng;
 use crate::rcc::{rec, rec::RngClkSel};
 use crate::rcc::{CoreClocks, ResetEnable};
 use crate::stm32::RNG;
@@ -116,7 +115,7 @@ impl core::iter::Iterator for Rng {
     }
 }
 
-impl rng::Read for Rng {
+impl embedded_hal_02::blocking::rng::Read for Rng {
     type Error = ErrorKind;
 
     fn read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {

--- a/src/sai/i2s.rs
+++ b/src/sai/i2s.rs
@@ -29,7 +29,6 @@ type CH = stm32::sai4::CH;
 use crate::gpio::{self, Alternate};
 
 use crate::traits::i2s::FullDuplex;
-// use embedded_hal::i2s::FullDuplex;
 
 const NUM_SLOTS: u8 = 16;
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -12,9 +12,7 @@ use core::fmt;
 use core::marker::PhantomData;
 use core::ptr;
 
-use embedded_hal::blocking::serial as serial_block;
-use embedded_hal::prelude::*;
-use embedded_hal::serial;
+use embedded_hal_02::prelude::*;
 use nb::block;
 
 use stm32::usart1::cr2::{
@@ -964,7 +962,7 @@ macro_rules! usart {
                 }
             }
 
-            impl serial::Read<u8> for Serial<$USARTX> {
+            impl embedded_hal_02::serial::Read<u8> for Serial<$USARTX> {
                 type Error = Error;
 
                 fn read(&mut self) -> nb::Result<u8, Error> {
@@ -976,7 +974,7 @@ macro_rules! usart {
                 }
             }
 
-            impl serial::Read<u8> for Rx<$USARTX> {
+            impl embedded_hal_02::serial::Read<u8> for Rx<$USARTX> {
                 type Error = Error;
 
                 fn read(&mut self) -> nb::Result<u8, Error> {
@@ -1064,7 +1062,7 @@ macro_rules! usart {
                 }
             }
 
-            impl serial::Write<u8> for Serial<$USARTX> {
+            impl embedded_hal_02::serial::Write<u8> for Serial<$USARTX> {
                 type Error = core::convert::Infallible;
 
                 fn flush(&mut self) -> nb::Result<(), Self::Error> {
@@ -1082,11 +1080,11 @@ macro_rules! usart {
                 }
             }
 
-            impl serial_block::write::Default<u8> for Serial<$USARTX> {
+            impl embedded_hal_02::blocking::serial::write::Default<u8> for Serial<$USARTX> {
                 //implement marker trait to opt-in to default blocking write implementation
             }
 
-            impl serial::Write<u8> for Tx<$USARTX> {
+            impl embedded_hal_02::serial::Write<u8> for Tx<$USARTX> {
                 // NOTE(Void) See section "29.7 USART interrupts"; the
                 // only possible errors during transmission are: clear
                 // to send (which is disabled in this case) errors and
@@ -1297,7 +1295,7 @@ usart_sel! {
 
 impl<USART> fmt::Write for Tx<USART>
 where
-    Tx<USART>: serial::Write<u8>,
+    Tx<USART>: embedded_hal_02::serial::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let _ = s.as_bytes().iter().map(|c| block!(self.write(*c))).last();
@@ -1307,7 +1305,7 @@ where
 
 impl<USART> fmt::Write for Serial<USART>
 where
-    Serial<USART>: serial::Write<u8>,
+    Serial<USART>: embedded_hal_02::serial::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let _ = s.as_bytes().iter().map(|c| block!(self.write(*c))).last();

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -199,7 +199,7 @@ impl Config {
     ///
     /// Note:
     /// * This function updates the HAL peripheral to treat the pin provided in the MISO parameter
-    /// as the MOSI pin and the pin provided in the MOSI parameter as the MISO pin.
+    ///   as the MOSI pin and the pin provided in the MOSI parameter as the MISO pin.
     #[must_use]
     pub fn swap_mosi_miso(mut self) -> Self {
         self.swap_miso_mosi = true;
@@ -249,7 +249,7 @@ pub struct HardwareCS {
     ///
     /// Note:
     /// * This value introduces a delay on SCK from the initiation of the transaction. The delay
-    /// is specified as a number of SCK cycles, so the actual delay may vary.
+    ///   is specified as a number of SCK cycles, so the actual delay may vary.
     pub assertion_delay: f32,
     /// The polarity of the CS pin.
     pub polarity: Polarity,
@@ -272,8 +272,8 @@ pub enum HardwareCSMode {
     ///
     /// Note:
     /// * This mode does require some maintenance. Before sending, you must setup
-    /// the frame with [Spi::setup_transaction]. After everything has been sent,
-    /// you must also clean it up with [Spi::end_transaction].
+    ///   the frame with [Spi::setup_transaction]. After everything has been sent,
+    ///   you must also clean it up with [Spi::end_transaction].
     FrameTransaction,
 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -67,11 +67,6 @@ use core::marker::PhantomData;
 use core::ptr;
 
 use crate::gpio::{self, Alternate};
-use crate::hal;
-use crate::hal::spi::FullDuplex;
-pub use crate::hal::spi::{
-    Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3,
-};
 use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::stm32;
 #[cfg(feature = "rm0455")]
@@ -83,6 +78,9 @@ use crate::stm32::spi1::{
 };
 use crate::stm32::{SPI1, SPI2, SPI3, SPI4, SPI5, SPI6};
 use crate::time::Hertz;
+pub use embedded_hal_02::spi::{
+    Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3,
+};
 
 /// SPI error
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -557,7 +555,7 @@ pub trait SpiExt<SPI, WORD>: Sized {
 }
 
 pub trait HalEnabledSpi:
-    HalSpi + FullDuplex<Self::Word, Error = Error>
+    HalSpi + embedded_hal_02::spi::FullDuplex<Self::Word, Error = Error>
 {
     type Disabled: HalDisabledSpi<
         Spi = Self::Spi,
@@ -1058,7 +1056,7 @@ macro_rules! spi {
 	                }
 	            }
 
-                impl hal::spi::FullDuplex<$TY> for Spi<$SPIX, Enabled, $TY> {
+                impl embedded_hal_02::spi::FullDuplex<$TY> for Spi<$SPIX, Enabled, $TY> {
                     type Error = Error;
 
                     fn read(&mut self) -> nb::Result<$TY, Error> {
@@ -1173,7 +1171,7 @@ macro_rules! spi {
 
                     /// Internal implementation for blocking::spi::Write
                     fn transfer_internal_w(&mut self, write_words: &[$TY]) -> Result<(), Error> {
-                        use hal::spi::FullDuplex;
+                        use embedded_hal_02::spi::FullDuplex;
 
                         // both buffers are the same length
                         if write_words.is_empty() {
@@ -1231,7 +1229,7 @@ macro_rules! spi {
 
                     /// Internal implementation for blocking::spi::Transfer
                     fn transfer_internal_rw(&mut self, words : &mut [$TY]) -> Result<(), Error> {
-                        use hal::spi::FullDuplex;
+                        use embedded_hal_02::spi::FullDuplex;
 
                         if words.is_empty() {
                             return Ok(());
@@ -1288,7 +1286,7 @@ macro_rules! spi {
                     }
                 }
 
-                impl hal::blocking::spi::Transfer<$TY> for Spi<$SPIX, Enabled, $TY> {
+                impl embedded_hal_02::blocking::spi::Transfer<$TY> for Spi<$SPIX, Enabled, $TY> {
                     type Error = Error;
 
                     fn transfer<'w>(&mut self, words: &'w mut [$TY]) -> Result<&'w [$TY], Self::Error> {
@@ -1298,7 +1296,7 @@ macro_rules! spi {
                         Ok(words)
                     }
                 }
-                impl hal::blocking::spi::Write<$TY> for Spi<$SPIX, Enabled, $TY> {
+                impl embedded_hal_02::blocking::spi::Write<$TY> for Spi<$SPIX, Enabled, $TY> {
                     type Error = Error;
 
                     fn write(&mut self, words: &[$TY]) -> Result<(), Self::Error> {

--- a/src/system_watchdog.rs
+++ b/src/system_watchdog.rs
@@ -18,7 +18,6 @@
 //!
 //! - [Example application](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/watchdog.rs)
 
-use crate::hal::watchdog::{Watchdog, WatchdogEnable};
 use crate::rcc::Ccdr;
 use crate::time::{Hertz, MilliSeconds};
 use cast::u8;
@@ -115,7 +114,7 @@ impl SystemWindowWatchdog {
     }
 }
 
-impl Watchdog for SystemWindowWatchdog {
+impl embedded_hal_02::watchdog::Watchdog for SystemWindowWatchdog {
     /// Feeds the watchdog in order to avoid a reset, only executes properly if the watchdog
     /// has already been started aka. the down_counter is not 0 anymore
     fn feed(&mut self) {
@@ -125,7 +124,7 @@ impl Watchdog for SystemWindowWatchdog {
     }
 }
 
-impl WatchdogEnable for SystemWindowWatchdog {
+impl embedded_hal_02::watchdog::WatchdogEnable for SystemWindowWatchdog {
     type Time = MilliSeconds;
     /// Starts the watchdog with a given timeout period, if this period is out of bounds the function
     /// is going to panic

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -418,7 +418,7 @@ macro_rules! hal {
                         clk * timeout.as_secs() +
                         clk * u64::from(timeout.subsec_nanos()) / NANOS_PER_SECOND,
                     )
-                    .unwrap_or(u32::max_value());
+                    .unwrap_or(u32::MAX);
 
                     self.set_timeout_ticks(ticks.max(1));
                 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -10,8 +10,6 @@
 
 use core::marker::PhantomData;
 
-use crate::hal::timer::{CountDown, Periodic};
-
 use crate::stm32::{lptim1, lptim3};
 use crate::stm32::{LPTIM1, LPTIM2, LPTIM3};
 #[cfg(not(feature = "rm0455"))]
@@ -285,9 +283,9 @@ pub enum Event {
 macro_rules! hal {
     ($($TIMX:ident: ($timX:ident, $Rec:ident, $cntType:ty),)+) => {
         $(
-            impl Periodic for Timer<$TIMX> {}
+            impl embedded_hal_02::timer::Periodic for Timer<$TIMX> {}
 
-            impl CountDown for Timer<$TIMX> {
+            impl embedded_hal_02::timer::CountDown for Timer<$TIMX> {
                 type Time = Hertz;
 
                 fn start<T>(&mut self, timeout: T)
@@ -331,6 +329,8 @@ macro_rules! hal {
                 fn timer(self, timeout: Hertz,
                             prec: Self::Rec, clocks: &CoreClocks
                 ) -> Timer<$TIMX> {
+                    use embedded_hal_02::timer::CountDown;
+
                     let mut timer = Timer::$timX(self, prec, clocks);
                     timer.start(timeout);
                     timer
@@ -607,9 +607,9 @@ hal! {
 macro_rules! lptim_hal {
     ($($TIMX:ident: ($timx:ident, $Rec:ident, $timXpac:ident),)+) => {
         $(
-            impl Periodic for LpTimer<$TIMX, Enabled> {}
+            impl embedded_hal_02::timer::Periodic for LpTimer<$TIMX, Enabled> {}
 
-            impl CountDown for LpTimer<$TIMX, Enabled> {
+            impl embedded_hal_02::timer::CountDown for LpTimer<$TIMX, Enabled> {
                 type Time = Hertz;
 
                 fn start<T>(&mut self, timeout: T)
@@ -692,10 +692,13 @@ macro_rules! lptim_hal {
             }
 
             impl LpTimer<$TIMX, Enabled> {
+
                 /// Configures a LPTIM peripheral as a periodic count down timer
                 pub fn $timx(tim: $TIMX, timeout: Hertz,
                                 prec: rec::$Rec, clocks: &CoreClocks
                 ) -> Self {
+                    use embedded_hal_02::timer::CountDown;
+
                     // enable and reset peripheral to a clean state
                     let _ = prec.enable().reset(); // drop, can be recreated by free method
 


### PR DESCRIPTION
This PR migrates the existing embedded-hal traits into the `hal_02` specifier so that we can continue with freely adding in new e-h 1.0 implementations as they are desired.