### PR TITLE
Add embedded-hal 1.0 traits to stm32h7xx-hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 fugit = "0.3.5"
-embedded-hal = { version = "0.2.6", features = ["unproven"] }
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"] }
+embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-dma = "0.2.0"
 cortex-m = { version = "^0.7.7", features = ["critical-section-single-core"] }
 defmt = { version = ">=0.2.0,<0.4", optional = true }


### PR DESCRIPTION
I've added both the embedded-hal 0.2.7 and embedded-hal 1.0 declarations in Cargo.toml.

I've also added the embedded-hal 1.0 trait definitions, but we need to correct the naming of the embedded-hal 1.0 traits because there are now duplicate definitions between 0.2.7 trait and 1.0 traits.

Please help me understand how to properly name the 1.0 traits.

Thank you!