### PR TITLE
In examples, disable the static-mut-refs lint

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.74.0
+          toolchain: 1.80.0
           target: thumbv7em-none-eabihf
           components: clippy
       - uses: clechasseur/rs-clippy-check@v3

--- a/examples/dma.rs
+++ b/examples/dma.rs
@@ -1,6 +1,7 @@
 //! Example of Memory to Memory Transfer with the DMA
 
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_main]
 #![no_std]
 

--- a/examples/ethernet-nucleo-h743zi2.rs
+++ b/examples/ethernet-nucleo-h743zi2.rs
@@ -9,6 +9,7 @@
 //! This demo does not use smoltcp - see the ethernet-rtic-stm32h747i-disco demo
 //! for an example of smoltcp
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_main]
 #![no_std]
 

--- a/examples/ethernet-rtic-nucleo-h723zg.rs
+++ b/examples/ethernet-rtic-nucleo-h723zg.rs
@@ -12,6 +12,7 @@
 //!
 //! `cargo flash --example ethernet-rtic-nucleo-h723zg --features=ethernet,stm32h735 --chip=STM32H723ZGTx`
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_main]
 #![no_std]
 

--- a/examples/ethernet-rtic-stm32h735g-dk.rs
+++ b/examples/ethernet-rtic-stm32h735g-dk.rs
@@ -8,6 +8,7 @@
 //! The ethernet ring buffers are placed in AXI SRAM, where they can be
 //! accessed by both the core and the Ethernet DMA.
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_main]
 #![no_std]
 

--- a/examples/ethernet-rtic-stm32h747i-disco.rs
+++ b/examples/ethernet-rtic-stm32h747i-disco.rs
@@ -15,6 +15,7 @@
 //! The ethernet ring buffers are placed in SRAM3, where they can be
 //! accessed by both the core and the Ethernet DMA.
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_main]
 #![no_std]
 

--- a/examples/ethernet-stm32h747i-disco.rs
+++ b/examples/ethernet-stm32h747i-disco.rs
@@ -8,6 +8,7 @@
 //! This demo does not use smoltcp - see the ethernet-rtic-stm32h747i-disco demo
 //! for an example of smoltcp
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_main]
 #![no_std]
 

--- a/examples/i2c4_bdma.rs
+++ b/examples/i2c4_bdma.rs
@@ -3,6 +3,7 @@
 //!
 
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_std]
 #![no_main]
 

--- a/examples/mdma.rs
+++ b/examples/mdma.rs
@@ -1,6 +1,7 @@
 //! Example of Memory to Memory Transfer with the Master DMA (MDMA)
 
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_main]
 #![no_std]
 

--- a/examples/mdma_bursts.rs
+++ b/examples/mdma_bursts.rs
@@ -6,6 +6,7 @@
 //! beats/burst. The latter gives an approximately 25% speedup.
 
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_main]
 #![no_std]
 

--- a/examples/sai_dma_passthru.rs
+++ b/examples/sai_dma_passthru.rs
@@ -3,6 +3,7 @@
 
 #![allow(unused_macros)]
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_main]
 #![no_std]
 

--- a/examples/serial-dma.rs
+++ b/examples/serial-dma.rs
@@ -8,6 +8,7 @@
 //! the transfer.
 
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_main]
 #![no_std]
 

--- a/examples/spi-dma-rtic.rs
+++ b/examples/spi-dma-rtic.rs
@@ -3,6 +3,7 @@
 //!
 //! This example demonstrates using DMA to write data over a TX-only SPI interface.
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![allow(clippy::type_complexity)]
 #![no_main]
 #![no_std]

--- a/examples/spi-dma.rs
+++ b/examples/spi-dma.rs
@@ -8,6 +8,7 @@
 //! the transfer.
 
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_main]
 #![no_std]
 

--- a/examples/usb_passthrough.rs
+++ b/examples/usb_passthrough.rs
@@ -5,6 +5,7 @@
 //! This example uses both USB1 and USB2. This is only possible on devices that
 //! have the USB2 peripheral.
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_std]
 #![no_main]
 

--- a/examples/usb_phy_serial_interrupt.rs
+++ b/examples/usb_phy_serial_interrupt.rs
@@ -3,6 +3,7 @@
 //! This example is for RM0433/RM0399 parts. It has been tested on the Arduino
 //! Portenta H7
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![allow(clippy::type_complexity)]
 #![no_std]
 #![no_main]

--- a/examples/usb_rtic.rs
+++ b/examples/usb_rtic.rs
@@ -7,6 +7,7 @@
 //! NUCLEO-H743ZI2 board.
 //!
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_std]
 #![no_main]
 

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -9,6 +9,7 @@
 //! NUCLEO-H743ZI2 board.
 //!
 #![deny(warnings)]
+#![allow(static_mut_refs)]
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
[static-mut-refs](https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html#static-mut-refs)

For the future, need to investigate:
* How to implement DMA without requiring the lifetime of the buffer to be `'static`
* How to specific the link_section of non-static buffers

Suggest merging to fix CI on stable and nightly. (clippy and MSRV versions will still need a bump as well)